### PR TITLE
Initialize Dentix Laravel project skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+APP_NAME="Dentix"
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=dentix
+DB_USERNAME=root
+DB_PASSWORD=
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Dentix
+
+Projeto Laravel 11 com Breeze.
+
+## Instalação (Laragon)
+
+```bash
+composer install
+cp .env.example .env
+php artisan key:generate
+php artisan migrate
+npm install && npm run dev
+php artisan serve
+```

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule)
+    {
+        //
+    }
+
+    protected function commands()
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    protected $dontReport = [];
+
+    protected $dontFlash = [
+        'password',
+        'password_confirmation',
+    ];
+
+    public function register()
+    {
+        $this->reportable(function (Throwable $e) {
+            //
+        });
+    }
+}

--- a/app/Http/Controllers/Admin/CadeiraController.php
+++ b/app/Http/Controllers/Admin/CadeiraController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Cadeira;
+use Illuminate\Http\Request;
+
+class CadeiraController extends Controller
+{
+    public function index()
+    {
+        $cadeiras = Cadeira::all();
+        return view('admin.cadeiras.index', compact('cadeiras'));
+    }
+
+    public function create()
+    {
+        return view('admin.cadeiras.create');
+    }
+}

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Clinic;
+use Illuminate\Http\Request;
+
+class ClinicController extends Controller
+{
+    public function index()
+    {
+        $clinics = Clinic::all();
+        return view('admin.clinics.index', compact('clinics'));
+    }
+
+    public function create()
+    {
+        return view('admin.clinics.create');
+    }
+}

--- a/app/Http/Controllers/Admin/UnidadeController.php
+++ b/app/Http/Controllers/Admin/UnidadeController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Unidade;
+use Illuminate\Http\Request;
+
+class UnidadeController extends Controller
+{
+    public function index()
+    {
+        $unidades = Unidade::all();
+        return view('admin.unidades.index', compact('unidades'));
+    }
+
+    public function create()
+    {
+        return view('admin.unidades.create');
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
+{
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
+    ];
+
+    protected $middlewareGroups = [
+        'web' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\SetClinicContext::class,
+        ],
+        'api' => [
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+
+    protected $routeMiddleware = [
+        'auth' => \App\Http\Middleware\Authenticate::class,
+        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+    ];
+}

--- a/app/Http/Middleware/SetClinicContext.php
+++ b/app/Http/Middleware/SetClinicContext.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class SetClinicContext
+{
+    public function handle($request, Closure $next)
+    {
+        if ($user = Auth::user()) {
+            app()->instance('clinic_id', $user->clinic_id);
+        }
+        return $next($request);
+    }
+}

--- a/app/Models/Cadeira.php
+++ b/app/Models/Cadeira.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\BelongsToClinic;
+
+class Cadeira extends Model
+{
+    use BelongsToClinic;
+
+    protected $fillable = [
+        'unidade_id', 'nome', 'especialidade', 'status', 'horarios_disponiveis'
+    ];
+
+    public function unidade()
+    {
+        return $this->belongsTo(Unidade::class);
+    }
+}

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\BelongsToClinic;
+
+class Clinic extends Model
+{
+    use BelongsToClinic;
+
+    protected $fillable = [
+        'nome', 'cnpj', 'responsavel', 'plano', 'idioma_preferido'
+    ];
+}

--- a/app/Models/Unidade.php
+++ b/app/Models/Unidade.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\BelongsToClinic;
+
+class Unidade extends Model
+{
+    use BelongsToClinic;
+
+    protected $fillable = [
+        'clinic_id', 'nome', 'endereco', 'cidade', 'estado', 'contato', 'horarios_funcionamento'
+    ];
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use App\Traits\BelongsToClinic;
+
+class User extends Authenticatable
+{
+    use HasFactory, Notifiable, BelongsToClinic;
+
+    protected $fillable = [
+        'name', 'email', 'password', 'clinic_id'
+    ];
+
+    protected $hidden = [
+        'password', 'remember_token',
+    ];
+
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class);
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    public const HOME = '/home';
+
+    public function boot()
+    {
+        parent::boot();
+
+        Route::middleware('web')
+            ->group(base_path('routes/web.php'));
+
+        Route::prefix('admin')
+            ->middleware(['web', 'auth'])
+            ->group(base_path('routes/admin.php'));
+    }
+}

--- a/app/Traits/BelongsToClinic.php
+++ b/app/Traits/BelongsToClinic.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait BelongsToClinic
+{
+    protected static function bootBelongsToClinic()
+    {
+        if (auth()->check()) {
+            static::addGlobalScope('clinic', function (Builder $builder) {
+                $builder->where('clinic_id', auth()->id() ? auth()->user()->clinic_id : null);
+            });
+        }
+    }
+
+    public function initializeBelongsToClinic()
+    {
+        $this->fillable[] = 'clinic_id';
+    }
+}

--- a/artisan
+++ b/artisan
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__.'/vendor/autoload.php';
+
+$app = require_once __DIR__.'/bootstrap/app.php';
+
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+
+$status = $kernel->handle(
+    $input = new Symfony\Component\Console\Input\ArgvInput(),
+    new Symfony\Component\Console\Output\ConsoleOutput
+);
+
+$kernel->terminate($input, $status);
+exit($status);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Foundation\Application;
+
+$app = new Application(
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    App\Http\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    App\Console\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    App\Exceptions\Handler::class
+);
+
+return $app;

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "dentix/dentix",
+    "type": "project",
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^11.0",
+        "laravel/breeze": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        },
+        "classmap": [
+            "database/seeders",
+            "database/factories"
+        ]
+    },
+    "scripts": {
+        "post-autoload-dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan package:discover --ansi"
+        ],
+        "post-root-package-install": [
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+        ],
+        "post-create-project-cmd": [
+            "@php artisan key:generate --ansi"
+        ]
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": []
+        }
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    'name' => env('APP_NAME', 'Dentix'),
+
+    'env' => env('APP_ENV', 'production'),
+
+    'debug' => (bool) env('APP_DEBUG', false),
+
+    'url' => env('APP_URL', 'http://localhost'),
+
+    'timezone' => 'UTC',
+
+    'locale' => 'en',
+
+    'fallback_locale' => 'en',
+
+    'providers' => [
+        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
+        Illuminate\Auth\AuthServiceProvider::class,
+        Illuminate\Database\DatabaseServiceProvider::class,
+        Illuminate\View\ViewServiceProvider::class,
+        Laravel\Breeze\BreezeServiceProvider::class,
+        App\Providers\RouteServiceProvider::class,
+    ],
+
+    'aliases' => [
+        'App' => Illuminate\Support\Facades\App::class,
+        'DB' => Illuminate\Support\Facades\DB::class,
+        'Route' => Illuminate\Support\Facades\Route::class,
+    ],
+];

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'default' => env('DB_CONNECTION', 'mysql'),
+
+    'connections' => [
+        'mysql' => [
+            'driver' => 'mysql',
+            'url' => env('DATABASE_URL'),
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => env('DB_DATABASE', 'dentix'),
+            'username' => env('DB_USERNAME', 'root'),
+            'password' => env('DB_PASSWORD', ''),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'strict' => true,
+        ],
+    ],
+
+    'migrations' => 'migrations',
+];

--- a/config/view.php
+++ b/config/view.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'paths' => [resource_path('views')],
+    'compiled' => storage_path('framework/views'),
+];

--- a/database/migrations/2024_01_01_000000_create_clinics_table.php
+++ b/database/migrations/2024_01_01_000000_create_clinics_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('clinics', function (Blueprint $table) {
+            $table->id();
+            $table->string('nome');
+            $table->string('cnpj');
+            $table->string('responsavel');
+            $table->string('plano');
+            $table->string('idioma_preferido');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clinics');
+    }
+};

--- a/database/migrations/2024_01_01_000001_create_unidades_table.php
+++ b/database/migrations/2024_01_01_000001_create_unidades_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('unidades', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinic_id')->constrained('clinics');
+            $table->string('nome');
+            $table->string('endereco');
+            $table->string('cidade');
+            $table->string('estado');
+            $table->string('contato');
+            $table->string('horarios_funcionamento');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('unidades');
+    }
+};

--- a/database/migrations/2024_01_01_000002_create_cadeiras_table.php
+++ b/database/migrations/2024_01_01_000002_create_cadeiras_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cadeiras', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('unidade_id')->constrained('unidades');
+            $table->string('nome');
+            $table->string('especialidade');
+            $table->string('status');
+            $table->string('horarios_disponiveis');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cadeiras');
+    }
+};

--- a/database/migrations/2024_01_01_000003_add_clinic_id_to_users_table.php
+++ b/database/migrations/2024_01_01_000003_add_clinic_id_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('clinic_id')->nullable()->constrained('clinics');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['clinic_id']);
+            $table->dropColumn('clinic_id');
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "laravel-vite-plugin": "^0.8.0"
+  }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,15 @@
+<?php
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+$kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
+
+$response = $kernel->handle(
+    $request = Illuminate\Http\Request::capture()
+)->send();
+
+$kernel->terminate($request, $response);

--- a/resources/views/admin/cadeiras/create.blade.php
+++ b/resources/views/admin/cadeiras/create.blade.php
@@ -1,0 +1,4 @@
+@extends('layouts.app')
+@section('content')
+<h1>Criar Cadeira</h1>
+@endsection

--- a/resources/views/admin/cadeiras/index.blade.php
+++ b/resources/views/admin/cadeiras/index.blade.php
@@ -1,0 +1,4 @@
+@extends('layouts.app')
+@section('content')
+<h1>Cadeiras</h1>
+@endsection

--- a/resources/views/admin/clinics/create.blade.php
+++ b/resources/views/admin/clinics/create.blade.php
@@ -1,0 +1,4 @@
+@extends('layouts.app')
+@section('content')
+<h1>Criar Clínica</h1>
+@endsection

--- a/resources/views/admin/clinics/index.blade.php
+++ b/resources/views/admin/clinics/index.blade.php
@@ -1,0 +1,4 @@
+@extends('layouts.app')
+@section('content')
+<h1>Clínicas</h1>
+@endsection

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Administração</h1>
+<p>Gerencie clínicas, unidades e cadeiras de atendimento</p>
+<div class="grid">
+    <div class="card">
+        <h3>Clínicas</h3>
+        <p>Gerencie as informações das clínicas cadastradas</p>
+        <small>Dados da empresa • Planos de assinatura • Responsáveis legais</small><br>
+        <a class="btn" href="{{ route('clinicas.index') }}">Gerenciar Clínicas</a>
+    </div>
+    <div class="card">
+        <h3>Unidades</h3>
+        <p>Gerencie as unidades de atendimento</p>
+        <small>Endereços e contatos • Horários • Vinculação com clínicas</small><br>
+        <a class="btn" href="{{ route('unidades.index') }}">Gerenciar Unidades</a>
+    </div>
+    <div class="card">
+        <h3>Cadeiras</h3>
+        <p>Gerencie as cadeiras de atendimento</p>
+        <small>Identificação • Status de funcionamento • Horários disponíveis</small><br>
+        <a class="btn" href="{{ route('cadeiras.index') }}">Gerenciar Cadeiras</a>
+    </div>
+</div>
+<hr>
+<p>Ações Rápidas:</p>
+<ul>
+    <li><a href="{{ route('clinicas.create') }}">+ Nova Clínica</a></li>
+    <li><a href="{{ route('unidades.create') }}">+ Nova Unidade</a></li>
+    <li><a href="{{ route('cadeiras.create') }}">+ Nova Cadeira</a></li>
+</ul>
+@endsection

--- a/resources/views/admin/unidades/create.blade.php
+++ b/resources/views/admin/unidades/create.blade.php
@@ -1,0 +1,4 @@
+@extends('layouts.app')
+@section('content')
+<h1>Criar Unidade</h1>
+@endsection

--- a/resources/views/admin/unidades/index.blade.php
+++ b/resources/views/admin/unidades/index.blade.php
@@ -1,0 +1,4 @@
+@extends('layouts.app')
+@section('content')
+<h1>Unidades</h1>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name') }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+        header { background: #0d6efd; color: #fff; padding: 1rem; }
+        nav a { color: #fff; margin-right: 1rem; }
+        .container { padding: 1rem; }
+        .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1rem; }
+        .card { border: 1px solid #ccc; padding: 1rem; border-radius: 5px; }
+        .btn { display: inline-block; padding: 0.5rem 1rem; background: #0d6efd; color: #fff; text-decoration: none; border-radius: 3px; }
+    </style>
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/">Home</a>
+        <a href="/admin">Admin</a>
+    </nav>
+</header>
+<div class="container">
+    @yield('content')
+</div>
+</body>
+</html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Bem-vindo ao Dentix</h1>
+<a href="/admin">Ir para Administração</a>
+@endsection

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\ClinicController;
+use App\Http\Controllers\Admin\UnidadeController;
+use App\Http\Controllers\Admin\CadeiraController;
+
+Route::get('/', function () {
+    return view('admin.index');
+})->name('admin.index');
+
+Route::resource('clinicas', ClinicController::class);
+Route::resource('unidades', UnidadeController::class);
+Route::resource('cadeiras', CadeiraController::class);

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
+
+// Placeholder for auth routes (Breeze would generate real routes)
+Route::get('/login', [AuthenticatedSessionController::class, 'create'])
+        ->name('login');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    return view('welcome');
+});
+
+require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add composer and npm configs
- scaffold a lightweight Laravel-style directory structure
- implement multi-tenant models, migrations and middleware
- add admin controllers and views
- document setup steps in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ba0105960832aa4ad524796df577b