### PR TITLE
Fix missing console command registration

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -19,6 +19,8 @@ return [
         Illuminate\Foundation\Providers\FoundationServiceProvider::class,
         Illuminate\Auth\AuthServiceProvider::class,
         Illuminate\Database\DatabaseServiceProvider::class,
+        Illuminate\Filesystem\FilesystemServiceProvider::class,
+        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
         Laravel\Breeze\BreezeServiceProvider::class,
         App\Providers\RouteServiceProvider::class,


### PR DESCRIPTION
## Summary
- add `Illuminate\Foundation\Providers\ConsoleSupportServiceProvider` to the provider list so package commands like `package:discover` work

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba40afb04832a8d41371f15e96684