### PR TITLE
Fix npm dependency conflict with Vite 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "vite": "^5.0.0",
-    "laravel-vite-plugin": "^0.8.0"
+    "laravel-vite-plugin": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- update `laravel-vite-plugin` to a version compatible with Vite 5

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686baf2f46c0832ab034c40cd267d1f9