### PR TITLE
Fix proxy header constant for Symfony

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -15,9 +15,15 @@ class TrustProxies extends Middleware
     protected $proxies;
 
     /**
-     * The headers that should be used to detect proxies.
+     * The headers that should be used to detect proxies. The deprecated
+     * `HEADER_X_FORWARDED_ALL` constant was removed in newer Symfony
+     * versions, so the individual flags are combined here instead.
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+    protected $headers =
+        Request::HEADER_X_FORWARDED_FOR |
+        Request::HEADER_X_FORWARDED_HOST |
+        Request::HEADER_X_FORWARDED_PORT |
+        Request::HEADER_X_FORWARDED_PROTO;
 }


### PR DESCRIPTION
## Summary
- combine individual proxy header constants instead of using removed `HEADER_X_FORWARDED_ALL`

## Testing
- `npm --version`
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc0d8421c832ab670870cf8080b63