### PR TITLE
Fix property definition in TrimStrings

### DIFF
--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -11,7 +11,7 @@ class TrimStrings extends Middleware
      *
      * @var array<int, string>
      */
-    protected array $except = [
+    protected $except = [
         'password',
         'password_confirmation',
     ];


### PR DESCRIPTION
## Summary
- remove the typed property declaration in `TrimStrings` middleware

## Testing
- `composer --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc1b8ba08832ab4b1b8d9c5f031f4