### PR TITLE
Fix missing hash service provider

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -29,6 +29,7 @@ return [
         Illuminate\Cookie\CookieServiceProvider::class,
         Illuminate\Session\SessionServiceProvider::class,
         Illuminate\Encryption\EncryptionServiceProvider::class,
+        Illuminate\Hashing\HashServiceProvider::class,
         Laravel\Breeze\BreezeServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
     ],
@@ -37,5 +38,6 @@ return [
         'App' => Illuminate\Support\Facades\App::class,
         'DB' => Illuminate\Support\Facades\DB::class,
         'Route' => Illuminate\Support\Facades\Route::class,
+        'Hash' => Illuminate\Support\Facades\Hash::class,
     ],
 ];

--- a/config/hashing.php
+++ b/config/hashing.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+    'driver' => 'bcrypt',
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+    ],
+
+    'argon' => [
+        'memory' => 65536,
+        'threads' => 1,
+        'time' => 4,
+    ],
+
+    'argon2id' => [
+        'memory' => 65536,
+        'threads' => 1,
+        'time' => 4,
+    ],
+];


### PR DESCRIPTION
## Summary
- register `Illuminate\Hashing\HashServiceProvider`
- expose `Hash` facade alias
- add default hashing configuration

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686bcc69bf6c832a9fece9f73ae2644c