### PR TITLE
Fix missing cache binding for Tinker

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -24,6 +24,7 @@ return [
         Illuminate\Auth\AuthServiceProvider::class,
         Illuminate\Database\DatabaseServiceProvider::class,
         Illuminate\Filesystem\FilesystemServiceProvider::class,
+        Illuminate\Cache\CacheServiceProvider::class,
         Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
         Illuminate\Cookie\CookieServiceProvider::class,
@@ -39,5 +40,6 @@ return [
         'DB' => Illuminate\Support\Facades\DB::class,
         'Route' => Illuminate\Support\Facades\Route::class,
         'Hash' => Illuminate\Support\Facades\Hash::class,
+        'Cache' => Illuminate\Support\Facades\Cache::class,
     ],
 ];


### PR DESCRIPTION
## Summary
- register `CacheServiceProvider`
- add `Cache` alias

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_686bcf561b9c832ab7f121f1ffff14d3