### PR TITLE
Fix BelongsToClinic usage

### DIFF
--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -3,11 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use App\Traits\BelongsToClinic;
-
 class Clinic extends Model
 {
-    use BelongsToClinic;
 
     protected $fillable = [
         'nome', 'cnpj', 'responsavel', 'plano', 'idioma_preferido'

--- a/database/migrations/2024_01_01_000002_create_cadeiras_table.php
+++ b/database/migrations/2024_01_01_000002_create_cadeiras_table.php
@@ -10,6 +10,7 @@ return new class extends Migration
     {
         Schema::create('cadeiras', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('clinic_id')->constrained('clinics');
             $table->foreignId('unidade_id')->constrained('unidades');
             $table->string('nome');
             $table->string('especialidade');


### PR DESCRIPTION
## Summary
- add `clinic_id` foreign key to `cadeiras` table
- stop applying `BelongsToClinic` trait to the `Clinic` model

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c17774e10832a9d197dc90b241414