### PR TITLE
Redirect root to login or admin

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {
-    public const HOME = '/home';
+    public const HOME = '/admin';
 
     public function boot()
     {

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,6 +1,0 @@
-@extends('layouts.app')
-
-@section('content')
-<h1>Bem-vindo ao Dentix</h1>
-<a href="/admin">Ir para Administração</a>
-@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,14 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Auth;
 
 Route::get('/', function () {
-    return view('welcome');
+    if (Auth::check()) {
+        return redirect()->route('admin.index');
+    }
+
+    return redirect()->route('login');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- redirect root route based on authentication
- remove unused welcome screen
- send users to the admin panel after login

## Testing
- `php artisan` *(fails: command not found)*
- `npm test` *(fails: missing script and network access)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c25b44114832aa3bd225f023ed8b4