### PR TITLE
Implement CNPJ validation and plan selection

### DIFF
--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\Clinic;
+use App\Models\Plano;
+use App\Rules\Cnpj;
 use Illuminate\Http\Request;
 
 class ClinicController extends Controller
@@ -16,17 +18,17 @@ class ClinicController extends Controller
 
     public function create()
     {
-        return view('admin.clinics.create');
+        $planos = Plano::all();
+        return view('admin.clinics.create', compact('planos'));
     }
 
     public function store(Request $request)
     {
         $data = $request->validate([
             'nome' => 'required',
-            'cnpj' => 'required',
+            'cnpj' => ['required', new Cnpj],
             'responsavel' => 'required',
-            'plano' => 'required',
-            'idioma_preferido' => 'required',
+            'plano_id' => 'required|exists:planos,id',
         ]);
 
         Clinic::create($data);

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -3,10 +3,16 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Plano;
 class Clinic extends Model
 {
 
     protected $fillable = [
-        'nome', 'cnpj', 'responsavel', 'plano', 'idioma_preferido'
+        'nome', 'cnpj', 'responsavel', 'plano_id'
     ];
+
+    public function plano()
+    {
+        return $this->belongsTo(Plano::class);
+    }
 }

--- a/app/Models/Plano.php
+++ b/app/Models/Plano.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Plano extends Model
+{
+    protected $fillable = ['nome'];
+}

--- a/app/Rules/Cnpj.php
+++ b/app/Rules/Cnpj.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class Cnpj implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        $cnpj = preg_replace('/\D/', '', $value);
+
+        if (strlen($cnpj) != 14 || preg_match('/^(\d)\1+$/', $cnpj)) {
+            return false;
+        }
+
+        $calc = function($cnpj, $length) {
+            $sum = 0;
+            $pos = $length - 7;
+            for ($i = $length; $i >= 1; $i--) {
+                $sum += $cnpj[$length - $i] * $pos--;
+                if ($pos < 2) $pos = 9;
+            }
+            $result = $sum % 11;
+            return ($result < 2) ? 0 : 11 - $result;
+        };
+
+        $digit1 = $calc($cnpj, 12);
+        $digit2 = $calc($cnpj, 13);
+
+        return $cnpj[12] == $digit1 && $cnpj[13] == $digit2;
+    }
+
+    public function message()
+    {
+        return 'CNPJ inválido.';
+    }
+}

--- a/database/migrations/2024_01_01_000005_create_planos_table.php
+++ b/database/migrations/2024_01_01_000005_create_planos_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('planos', function (Blueprint $table) {
+            $table->id();
+            $table->string('nome');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('planos');
+    }
+};

--- a/database/migrations/2024_01_01_000006_update_clinics_table_add_plano_id.php
+++ b/database/migrations/2024_01_01_000006_update_clinics_table_add_plano_id.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clinics', function (Blueprint $table) {
+            $table->foreignId('plano_id')->nullable()->constrained('planos');
+            $table->dropColumn('plano');
+            $table->dropColumn('idioma_preferido');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clinics', function (Blueprint $table) {
+            $table->string('plano');
+            $table->string('idioma_preferido');
+            $table->dropForeign(['plano_id']);
+            $table->dropColumn('plano_id');
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,3 +3,17 @@ import Alpine from 'alpinejs';
 window.Alpine = Alpine;
 
 Alpine.start();
+
+document.addEventListener('DOMContentLoaded', () => {
+    const cnpjInput = document.querySelector('input[name="cnpj"]');
+    if (cnpjInput) {
+        cnpjInput.addEventListener('input', e => {
+            let v = e.target.value.replace(/\D/g, '').slice(0, 14);
+            v = v.replace(/^(\d{2})(\d)/, '$1.$2');
+            v = v.replace(/^(\d{2}\.\d{3})(\d)/, '$1.$2');
+            v = v.replace(/^(\d{2}\.\d{3}\.\d{3})(\d)/, '$1/$2');
+            v = v.replace(/^(\d{2}\.\d{3}\.\d{3}\/\d{4})(\d)/, '$1-$2');
+            e.target.value = v;
+        });
+    }
+});

--- a/resources/views/admin/clinics/create.blade.php
+++ b/resources/views/admin/clinics/create.blade.php
@@ -19,11 +19,12 @@
         </div>
         <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Plano</label>
-            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="plano" required />
-        </div>
-        <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700">Idioma Preferido</label>
-            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="idioma_preferido" required />
+            <select name="plano_id" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
+                <option value="">Selecione</option>
+                @foreach ($planos as $plano)
+                    <option value="{{ $plano->id }}">{{ $plano->nome }}</option>
+                @endforeach
+            </select>
         </div>
         <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
     </form>


### PR DESCRIPTION
## Summary
- validate CNPJ using a custom rule
- add `Plano` model and migrations for plans
- update clinic controller to load plans and validate CNPJ and plan ID
- remove language field from clinic form
- add plan dropdown
- add client-side CNPJ input mask

## Testing
- `php -l app/Rules/Cnpj.php`
- `php -l app/Http/Controllers/Admin/ClinicController.php`
- `php -l app/Models/Plano.php`
- `php -l resources/views/admin/clinics/create.blade.php`

------
https://chatgpt.com/codex/tasks/task_e_68728edbc2b4832a8bb5d1bee6b29d75