### PR TITLE
Add weekly schedule fields to unidades

### DIFF
--- a/app/Http/Controllers/Admin/UnidadeController.php
+++ b/app/Http/Controllers/Admin/UnidadeController.php
@@ -30,10 +30,39 @@ class UnidadeController extends Controller
             'cidade' => 'required',
             'estado' => 'required',
             'contato' => 'required',
-            'horarios_funcionamento' => 'required',
+            'horarios' => 'required|array',
         ]);
 
+        $data['horarios_funcionamento'] = $data['horarios'];
+        unset($data['horarios']);
+
         Unidade::create($data);
+
+        return redirect()->route('unidades.index');
+    }
+
+    public function edit(Unidade $unidade)
+    {
+        $clinics = Clinic::all();
+        return view('admin.unidades.edit', compact('unidade', 'clinics'));
+    }
+
+    public function update(Request $request, Unidade $unidade)
+    {
+        $data = $request->validate([
+            'clinic_id' => 'required|exists:clinics,id',
+            'nome' => 'required',
+            'endereco' => 'required',
+            'cidade' => 'required',
+            'estado' => 'required',
+            'contato' => 'required',
+            'horarios' => 'required|array',
+        ]);
+
+        $data['horarios_funcionamento'] = $data['horarios'];
+        unset($data['horarios']);
+
+        $unidade->update($data);
 
         return redirect()->route('unidades.index');
     }

--- a/app/Models/Unidade.php
+++ b/app/Models/Unidade.php
@@ -13,6 +13,10 @@ class Unidade extends Model
         'clinic_id', 'nome', 'endereco', 'cidade', 'estado', 'contato', 'horarios_funcionamento'
     ];
 
+    protected $casts = [
+        'horarios_funcionamento' => 'array',
+    ];
+
     public function clinic()
     {
         return $this->belongsTo(Clinic::class);

--- a/resources/views/admin/unidades/create.blade.php
+++ b/resources/views/admin/unidades/create.blade.php
@@ -36,7 +36,24 @@
         </div>
         <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Horários de Funcionamento</label>
-            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="horarios_funcionamento" required />
+            @php
+                $diasSemana = [
+                    'segunda' => 'Segunda-feira',
+                    'terca' => 'Terça-feira',
+                    'quarta' => 'Quarta-feira',
+                    'quinta' => 'Quinta-feira',
+                    'sexta' => 'Sexta-feira',
+                    'sabado' => 'Sábado',
+                    'domingo' => 'Domingo',
+                ];
+            @endphp
+            @foreach ($diasSemana as $diaKey => $diaLabel)
+                <div class="flex items-center space-x-2 mb-2">
+                    <span class="w-32 text-sm">{{ $diaLabel }}</span>
+                    <input type="time" name="horarios[{{ $diaKey }}][abertura]" value="{{ old('horarios.' . $diaKey . '.abertura') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
+                    <input type="time" name="horarios[{{ $diaKey }}][fechamento]" value="{{ old('horarios.' . $diaKey . '.fechamento') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
+                </div>
+            @endforeach
         </div>
         <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
     </form>

--- a/resources/views/admin/unidades/edit.blade.php
+++ b/resources/views/admin/unidades/edit.blade.php
@@ -1,0 +1,67 @@
+@extends('layouts.app')
+
+@section('content')
+@php
+    $diasSemana = [
+        'segunda' => 'Segunda-feira',
+        'terca' => 'Terça-feira',
+        'quarta' => 'Quarta-feira',
+        'quinta' => 'Quinta-feira',
+        'sexta' => 'Sexta-feira',
+        'sabado' => 'Sábado',
+        'domingo' => 'Domingo',
+    ];
+    $horarios = $unidade->horarios_funcionamento ?? [];
+@endphp
+<div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">Editar Unidade</h1>
+    <form method="POST" action="{{ route('unidades.update', $unidade) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Clínica</label>
+            <select name="clinic_id" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
+                <option value="">Selecione</option>
+                @foreach ($clinics as $clinic)
+                    <option value="{{ $clinic->id }}" @selected(old('clinic_id', $unidade->clinic_id) == $clinic->id)>{{ $clinic->nome }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" value="{{ old('nome', $unidade->nome) }}" required />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Endereço</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco', $unidade->endereco) }}" required />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cidade" value="{{ old('cidade', $unidade->cidade) }}" required />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Estado</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="estado" value="{{ old('estado', $unidade->estado) }}" required />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Contato</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="contato" value="{{ old('contato', $unidade->contato) }}" required />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Horários de Funcionamento</label>
+            @foreach ($diasSemana as $diaKey => $diaLabel)
+                @php
+                    $abertura = old('horarios.' . $diaKey . '.abertura', $horarios[$diaKey]['abertura'] ?? '');
+                    $fechamento = old('horarios.' . $diaKey . '.fechamento', $horarios[$diaKey]['fechamento'] ?? '');
+                @endphp
+                <div class="flex items-center space-x-2 mb-2">
+                    <span class="w-32 text-sm">{{ $diaLabel }}</span>
+                    <input type="time" name="horarios[{{ $diaKey }}][abertura]" value="{{ $abertura }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
+                    <input type="time" name="horarios[{{ $diaKey }}][fechamento]" value="{{ $fechamento }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
+                </div>
+            @endforeach
+        </div>
+        <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/admin/unidades/index.blade.php
+++ b/resources/views/admin/unidades/index.blade.php
@@ -12,6 +12,7 @@
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Nome</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Cidade</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Estado</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Ações</th>
             </tr>
         </thead>
         <tbody class="divide-y divide-gray-200">
@@ -20,6 +21,9 @@
                     <td class="px-4 py-2 whitespace-nowrap">{{ $unidade->nome }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $unidade->cidade }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $unidade->estado }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">
+                        <a href="{{ route('unidades.edit', $unidade) }}" class="text-blue-600 hover:underline">Editar</a>
+                    </td>
                 </tr>
             @empty
                 <tr>


### PR DESCRIPTION
## Summary
- convert `horarios_funcionamento` to array cast
- collect weekly opening and closing hours for unidades
- allow editing existing unidades
- display edit link in unidades index

## Testing
- `php -l app/Models/Unidade.php`
- `php -l app/Http/Controllers/Admin/UnidadeController.php`
- `php -l resources/views/admin/unidades/edit.blade.php`
- `php -l resources/views/admin/unidades/create.blade.php`
- `php -l resources/views/admin/unidades/index.blade.php`
- `php artisan --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68728f786394832a88dd5d9bd05d6300