### PR TITLE
Fix migration to drop horario column

### DIFF
--- a/database/migrations/2025_07_12_203000_force_drop_horarios_funcionamento_from_unidades_table.php
+++ b/database/migrations/2025_07_12_203000_force_drop_horarios_funcionamento_from_unidades_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('unidades', 'horarios_funcionamento')) {
+            Schema::table('unidades', function (Blueprint $table) {
+                $table->dropColumn('horarios_funcionamento');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('unidades', function (Blueprint $table) {
+            $table->string('horarios_funcionamento')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- ensure the old `horarios_funcionamento` column is removed by adding a migration

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*
- `php -l database/migrations/2025_07_12_203000_force_drop_horarios_funcionamento_from_unidades_table.php`


------
https://chatgpt.com/codex/tasks/task_e_6872ad282958832ab25352a239d3fba3