### PR TITLE
Show flash success alerts

### DIFF
--- a/app/Http/Controllers/Admin/CadeiraController.php
+++ b/app/Http/Controllers/Admin/CadeiraController.php
@@ -33,6 +33,6 @@ class CadeiraController extends Controller
 
         Cadeira::create($data);
 
-        return redirect()->route('cadeiras.index');
+        return redirect()->route('cadeiras.index')->with('success', 'Cadeira salva com sucesso.');
     }
 }

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -33,6 +33,6 @@ class ClinicController extends Controller
 
         Clinic::create($data);
 
-        return redirect()->route('clinicas.index');
+        return redirect()->route('clinicas.index')->with('success', 'Clínica salva com sucesso.');
     }
 }

--- a/app/Http/Controllers/Admin/UnidadeController.php
+++ b/app/Http/Controllers/Admin/UnidadeController.php
@@ -50,7 +50,7 @@ class UnidadeController extends Controller
             }
         }
 
-        return redirect()->route('unidades.index');
+        return redirect()->route('unidades.index')->with('success', 'Unidade salva com sucesso.');
     }
 
     public function edit(Unidade $unidade)
@@ -88,6 +88,6 @@ class UnidadeController extends Controller
             }
         }
 
-        return redirect()->route('unidades.index');
+        return redirect()->route('unidades.index')->with('success', 'Unidade atualizada com sucesso.');
     }
 }

--- a/resources/views/components/alert-success.blade.php
+++ b/resources/views/components/alert-success.blade.php
@@ -1,0 +1,13 @@
+<div x-data="{ show: true }" x-show="show" x-transition class="mb-4 flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-700">
+    <div class="flex items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+        <span>{{ $slot }}</span>
+    </div>
+    <button @click="show = false" class="text-green-700 hover:text-green-900">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+    </button>
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,6 +17,9 @@
             @include('partials.topbar')
         @endauth
         <main class="flex-1 p-6 overflow-y-auto">
+            @if (session('success'))
+                @include('components.alert-success', ['slot' => session('success')])
+            @endif
             @yield('content')
         </main>
     </div>


### PR DESCRIPTION
## Summary
- add TailAdmin-style success alert component
- show flash success message in app layout
- return success flash from clinic, unidade, and cadeira controllers

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873bf49fbf4832a8969d8ff079b3bd3