### PR TITLE
Fix admin view of units without clinic

### DIFF
--- a/app/Traits/BelongsToClinic.php
+++ b/app/Traits/BelongsToClinic.php
@@ -9,7 +9,7 @@ trait BelongsToClinic
 {
     protected static function bootBelongsToClinic()
     {
-        if (! auth()->check()) {
+        if (! auth()->check() || is_null(auth()->user()->clinic_id)) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- show all records when a logged user has no clinic

## Testing
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_6873bea30928832abc99a64707e7a521