### PR TITLE
Fix 'horarios_disponiveis' error

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ verifique a pasta `database/migrations` e remova qualquer arquivo antigo chamado
 A coluna `horarios_funcionamento` foi substituída pela tabela `horarios` e essa
 migration não é mais necessária.
 
+### Erro "Field 'horarios_disponiveis' doesn't have a default value"
+
+Se, ao criar uma cadeira, surgir o erro:
+
+```
+SQLSTATE[HY000]: General error: 1364 Field 'horarios_disponiveis' doesn't have a default value
+```
+
+significa que sua tabela `cadeiras` ainda possui a coluna `horarios_disponiveis`. Remova-a executando a migration
+`2025_07_13_160000_remove_horarios_disponiveis_from_cadeiras_table.php` com `php artisan migrate`.
+
 ### Criando um usuário MySQL
 
 Para evitar usar a conta `root`, você pode criar um usuário e um banco exclusivos para o Dentix. Abra o terminal do Laragon e execute:

--- a/database/migrations/2025_07_13_160000_remove_horarios_disponiveis_from_cadeiras_table.php
+++ b/database/migrations/2025_07_13_160000_remove_horarios_disponiveis_from_cadeiras_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cadeiras', function (Blueprint $table) {
+            if (Schema::hasColumn('cadeiras', 'horarios_disponiveis')) {
+                $table->dropColumn('horarios_disponiveis');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cadeiras', function (Blueprint $table) {
+            if (!Schema::hasColumn('cadeiras', 'horarios_disponiveis')) {
+                $table->string('horarios_disponiveis')->nullable();
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- drop `horarios_disponiveis` column from chairs table
- document how to resolve the missing default value error

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6873d47d5760832ab0dad8096a2ad417