### PR TITLE
Fix missing Auth alias causing view errors

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -44,6 +44,7 @@ return [
         'Route' => Illuminate\Support\Facades\Route::class,
         'Hash' => Illuminate\Support\Facades\Hash::class,
         'Cache' => Illuminate\Support\Facades\Cache::class,
+        'Auth' => Illuminate\Support\Facades\Auth::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
     ],
 ];


### PR DESCRIPTION
## Summary
- register the `Auth` facade so Blade templates can reference `Auth::user()` without errors

## Testing
- `composer show`

------
https://chatgpt.com/codex/tasks/task_e_6873d665f044832a8debacc23dccea53