### PR TITLE
Remove dentix label from topbar

### DIFF
--- a/resources/views/partials/topbar.blade.php
+++ b/resources/views/partials/topbar.blade.php
@@ -4,7 +4,6 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
     </button>
-    <span class="ml-4 mr-4 text-lg font-semibold">{{ config('app.name') }}</span>
     <div class="relative flex-1">
         <span class="absolute inset-y-0 left-0 flex items-center pl-3">
             <svg class="w-5 h-5 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Summary
- remove app name next to the search field in the top bar

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687538de1340832aa63d1c0828d18afd