### PR TITLE
Add access management profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ Isso recriará o autoloader do Composer e permitirá que a classe seja encontrad
 Ele gerará a conta `admin@example.com` com a senha `password`. Acesse com essas
 credenciais e, se desejar, altere a senha após o login.
 
+Esse seeder também cria o perfil **Administrador** com todas as permissões e o
+associa automaticamente a esse usuário para que você já possa gerenciar novos
+perfis e usuários.
+

--- a/app/Http/Controllers/Admin/ProfileController.php
+++ b/app/Http/Controllers/Admin/ProfileController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Profile;
+use Illuminate\Http\Request;
+
+class ProfileController extends Controller
+{
+    public function index()
+    {
+        $profiles = Profile::all();
+        return view('admin.profiles.index', compact('profiles'));
+    }
+
+    public function create()
+    {
+        $modules = $this->modules();
+        return view('admin.profiles.create', compact('modules'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nome' => 'required',
+            'permissions' => 'array',
+        ]);
+
+        $profile = Profile::create([
+            'nome' => $data['nome'],
+            'clinic_id' => auth()->user()->clinic_id,
+        ]);
+
+        $this->syncPermissions($profile, $data['permissions'] ?? []);
+
+        return redirect()->route('perfis.index')->with('success', 'Perfil salvo com sucesso.');
+    }
+
+    public function edit(Profile $perfil)
+    {
+        $modules = $this->modules();
+        $permissions = $perfil->permissions->keyBy('modulo');
+        return view('admin.profiles.edit', compact('perfil', 'modules', 'permissions'));
+    }
+
+    public function update(Request $request, Profile $perfil)
+    {
+        $data = $request->validate([
+            'nome' => 'required',
+            'permissions' => 'array',
+        ]);
+
+        $perfil->update(['nome' => $data['nome']]);
+
+        $perfil->permissions()->delete();
+        $this->syncPermissions($perfil, $data['permissions'] ?? []);
+
+        return redirect()->route('perfis.index')->with('success', 'Perfil atualizado com sucesso.');
+    }
+
+    public function destroy(Profile $perfil)
+    {
+        $perfil->delete();
+        return redirect()->route('perfis.index')->with('success', 'Perfil removido com sucesso.');
+    }
+
+    private function modules(): array
+    {
+        return [
+            'Pacientes',
+            'Agenda',
+            'Prontuários',
+            'Profissionais',
+            'Estoque',
+            'Financeiro',
+            'Clínicas',
+            'Unidades',
+            'Cadeiras',
+            'Usuários',
+        ];
+    }
+
+    private function syncPermissions(Profile $profile, array $permissions): void
+    {
+        foreach ($permissions as $module => $values) {
+            $profile->permissions()->create([
+                'modulo' => $module,
+                'leitura' => isset($values['leitura']),
+                'escrita' => isset($values['escrita']),
+                'atualizacao' => isset($values['atualizacao']),
+                'exclusao' => isset($values['exclusao']),
+            ]);
+        }
+    }
+}

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Permission extends Model
+{
+    protected $fillable = [
+        'profile_id',
+        'modulo',
+        'leitura',
+        'escrita',
+        'atualizacao',
+        'exclusao',
+    ];
+
+    public function profile()
+    {
+        return $this->belongsTo(Profile::class);
+    }
+}

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\BelongsToClinic;
+
+class Profile extends Model
+{
+    use BelongsToClinic;
+
+    protected $fillable = [
+        'clinic_id',
+        'nome',
+    ];
+
+    public function permissions()
+    {
+        return $this->hasMany(Permission::class);
+    }
+
+    public function users()
+    {
+        return $this->hasMany(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,13 +7,18 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Traits\BelongsToClinic;
+use App\Models\Profile;
 
 class User extends Authenticatable
 {
     use HasFactory, Notifiable, BelongsToClinic;
 
     protected $fillable = [
-        'name', 'email', 'password', 'clinic_id'
+        'name',
+        'email',
+        'password',
+        'clinic_id',
+        'profile_id',
     ];
 
     protected $hidden = [
@@ -28,4 +33,10 @@ class User extends Authenticatable
     {
         return $this->belongsTo(Clinic::class);
     }
+
+    public function profile()
+    {
+        return $this->belongsTo(Profile::class);
+    }
 }
+

--- a/database/migrations/2025_07_14_170000_create_profiles_table.php
+++ b/database/migrations/2025_07_14_170000_create_profiles_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinic_id')->nullable()->constrained('clinics');
+            $table->string('nome');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('profiles');
+    }
+};

--- a/database/migrations/2025_07_14_170100_create_permissions_table.php
+++ b/database/migrations/2025_07_14_170100_create_permissions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('profile_id')->constrained('profiles')->onDelete('cascade');
+            $table->string('modulo');
+            $table->boolean('leitura')->default(false);
+            $table->boolean('escrita')->default(false);
+            $table->boolean('atualizacao')->default(false);
+            $table->boolean('exclusao')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/database/migrations/2025_07_14_170200_add_profile_id_to_users_table.php
+++ b/database/migrations/2025_07_14_170200_add_profile_id_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('profile_id')->nullable()->after('clinic_id')->constrained('profiles');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['profile_id']);
+            $table->dropColumn('profile_id');
+        });
+    }
+};

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -5,17 +5,56 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 use App\Models\User;
+use App\Models\Profile;
+use App\Models\Permission;
 
 class AdminUserSeeder extends Seeder
 {
     public function run(): void
     {
-        User::updateOrCreate(
+        $user = User::updateOrCreate(
             ['email' => 'admin@example.com'],
             [
                 'name' => 'Admin',
                 'password' => Hash::make('password')
             ]
         );
+
+        $profile = Profile::firstOrCreate([
+            'nome' => 'Administrador',
+            'clinic_id' => null,
+        ]);
+
+        $modules = [
+            'Pacientes',
+            'Agenda',
+            'Prontuários',
+            'Profissionais',
+            'Estoque',
+            'Financeiro',
+            'Clínicas',
+            'Unidades',
+            'Cadeiras',
+            'Usuários',
+            'Perfis',
+        ];
+
+        foreach ($modules as $module) {
+            Permission::updateOrCreate(
+                [
+                    'profile_id' => $profile->id,
+                    'modulo' => $module,
+                ],
+                [
+                    'leitura' => true,
+                    'escrita' => true,
+                    'atualizacao' => true,
+                    'exclusao' => true,
+                ]
+            );
+        }
+
+        $user->profile()->associate($profile);
+        $user->save();
     }
 }

--- a/resources/views/admin/profiles/create.blade.php
+++ b/resources/views/admin/profiles/create.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">Criar Perfil</h1>
+    <form method="POST" action="{{ route('perfis.store') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" required />
+        </div>
+        <div class="overflow-x-auto bg-white rounded-lg shadow">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Módulo</th>
+                        <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Leitura</th>
+                        <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Escrita</th>
+                        <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Atualização</th>
+                        <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Exclusão</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                    @foreach($modules as $module)
+                    <tr>
+                        <td class="px-4 py-2">{{ $module }}</td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][leitura]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][escrita]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][atualizacao]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][exclusao]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/admin/profiles/edit.blade.php
+++ b/resources/views/admin/profiles/edit.blade.php
@@ -1,0 +1,40 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">Editar Perfil</h1>
+    <form method="POST" action="{{ route('perfis.update', $perfil) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" value="{{ $perfil->nome }}" required />
+        </div>
+        <div class="overflow-x-auto bg-white rounded-lg shadow">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Módulo</th>
+                        <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Leitura</th>
+                        <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Escrita</th>
+                        <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Atualização</th>
+                        <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Exclusão</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                    @foreach($modules as $module)
+                    <tr>
+                        <td class="px-4 py-2">{{ $module }}</td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][leitura]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions[$module])->leitura)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][escrita]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions[$module])->escrita)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][atualizacao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions[$module])->atualizacao)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][exclusao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions[$module])->exclusao)></td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/admin/profiles/index.blade.php
+++ b/resources/views/admin/profiles/index.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mb-4 flex justify-between items-center">
+    <h1 class="text-xl font-semibold">Perfis</h1>
+    <a class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700" href="{{ route('perfis.create') }}">Novo Perfil</a>
+</div>
+<div class="overflow-x-auto bg-white rounded-lg shadow">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Nome</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Ações</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+            @forelse ($profiles as $profile)
+                <tr>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $profile->nome }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">
+                        <a href="{{ route('perfis.edit', $profile) }}" class="text-blue-600 hover:underline">Editar</a>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="2" class="px-4 py-2 text-center">Nenhum perfil cadastrado.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -44,5 +44,17 @@
                 <a href="{{ route('cadeiras.index') }}" class="block py-1 hover:underline">Cadeiras</a>
             </div>
         </div>
+
+        <div class="mt-2" x-data="{ openAccess: false }">
+            <button @click="openAccess = !openAccess" class="flex items-center w-full px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Gestão de Acessos' : ''">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m2 0a2 2 0 100-4 2 2 0 00-2 2m-6 0a2 2 0 11-4 0 2 2 0 004 0zm0 6h6m2 0a2 2 0 100-4 2 2 0 00-2 2m-6 0a2 2 0 11-4 0 2 2 0 004 0z" /></svg>
+                <span class="ml-3" x-show="!sidebarCollapsed">Gestão de Acessos</span>
+                <svg x-show="!sidebarCollapsed" :class="{'rotate-90': openAccess}" class="w-4 h-4 ml-auto transform transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+            </button>
+            <div x-show="openAccess && !sidebarCollapsed" x-collapse class="mt-1 space-y-1 pl-12" x-cloak>
+                <a href="#" class="block py-1 hover:underline">Usuários</a>
+                <a href="{{ route('perfis.index') }}" class="block py-1 hover:underline">Perfis</a>
+            </div>
+        </div>
     </nav>
 </div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\ClinicController;
 use App\Http\Controllers\Admin\UnidadeController;
 use App\Http\Controllers\Admin\CadeiraController;
+use App\Http\Controllers\Admin\ProfileController;
 
 Route::get('/', function () {
     return view('dashboard');
@@ -13,3 +14,4 @@ Route::resource('clinicas', ClinicController::class)
     ->parameters(['clinicas' => 'clinic']);
 Route::resource('unidades', UnidadeController::class);
 Route::resource('cadeiras', CadeiraController::class);
+Route::resource('perfis', ProfileController::class)->parameters(['perfis' => 'perfil']);


### PR DESCRIPTION
## Summary
- create `ProfileController` and Blade templates for managing profiles
- allow `profiles` migration to have nullable `clinic_id`
- extend `AdminUserSeeder` to seed a default Admin profile with full permissions
- add routes and sidebar menu entry for access management
- document the seeded Admin profile in README

## Testing
- `php -l app/Http/Controllers/Admin/ProfileController.php`
- `php -l database/seeders/AdminUserSeeder.php`
- `php -l database/migrations/2025_07_14_170000_create_profiles_table.php`
- `php -l resources/views/admin/profiles/index.blade.php`
- `php -l resources/views/admin/profiles/create.blade.php`
- `php -l resources/views/admin/profiles/edit.blade.php`
- `php -l resources/views/partials/sidebar.blade.php`
- `php -l routes/admin.php`
- ❌ `composer install` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68753bae76f4832a9503e6f05ecf02c1