### PR TITLE
Fix profile permission lookup

### DIFF
--- a/resources/views/admin/profiles/edit.blade.php
+++ b/resources/views/admin/profiles/edit.blade.php
@@ -25,10 +25,10 @@
                     @foreach($modules as $module)
                     <tr>
                         <td class="px-4 py-2">{{ $module }}</td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][leitura]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions[$module])->leitura)></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][escrita]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions[$module])->escrita)></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][atualizacao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions[$module])->atualizacao)></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][exclusao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions[$module])->exclusao)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][leitura]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions->get($module))->leitura)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][escrita]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions->get($module))->escrita)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][atualizacao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions->get($module))->atualizacao)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][exclusao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions->get($module))->exclusao)></td>
                     </tr>
                     @endforeach
                 </tbody>


### PR DESCRIPTION
## Summary
- avoid PHP undefined key when editing profiles

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*
- `php artisan --version` *(fails: Failed to open vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_6875684a46b0832aacd72e72e3e75950