### PR TITLE
Add patient module

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Patient;
+use Illuminate\Http\Request;
+
+class PatientController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Patient::query();
+
+        if ($request->filled('q')) {
+            $query->where('nome', 'like', '%' . $request->q . '%');
+        }
+
+        $patients = $query->orderBy('nome')->get();
+
+        $total = Patient::count();
+        $lastThirty = Patient::where('created_at', '>=', now()->subDays(30))->count();
+        $variation = $total > 0 ? ($lastThirty / $total) * 100 : 0;
+
+        $scheduledAppointments = Patient::whereNotNull('proxima_consulta')
+            ->whereBetween('proxima_consulta', [now(), now()->addDays(30)])
+            ->count();
+
+        $pendingReturns = Patient::whereNull('proxima_consulta')
+            ->whereNotNull('ultima_consulta')
+            ->count();
+
+        return view('patients.index', compact(
+            'patients',
+            'total',
+            'variation',
+            'scheduledAppointments',
+            'pendingReturns'
+        ));
+    }
+
+    public function create()
+    {
+        return view('patients.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nome' => 'required',
+            'responsavel' => 'nullable',
+            'idade' => 'nullable|integer',
+            'telefone' => 'nullable',
+            'ultima_consulta' => 'nullable|date',
+            'proxima_consulta' => 'nullable|date',
+        ]);
+
+        Patient::create($data);
+
+        return redirect()->route('pacientes.index')->with('success', 'Paciente salvo com sucesso.');
+    }
+
+    public function edit(Patient $paciente)
+    {
+        return view('patients.edit', compact('paciente'));
+    }
+
+    public function update(Request $request, Patient $paciente)
+    {
+        $data = $request->validate([
+            'nome' => 'required',
+            'responsavel' => 'nullable',
+            'idade' => 'nullable|integer',
+            'telefone' => 'nullable',
+            'ultima_consulta' => 'nullable|date',
+            'proxima_consulta' => 'nullable|date',
+        ]);
+
+        $paciente->update($data);
+
+        return redirect()->route('pacientes.index')->with('success', 'Paciente atualizado com sucesso.');
+    }
+
+    public function destroy(Patient $paciente)
+    {
+        $paciente->delete();
+
+        return redirect()->route('pacientes.index')->with('success', 'Paciente removido com sucesso.');
+    }
+}

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\BelongsToClinic;
+
+class Patient extends Model
+{
+    use BelongsToClinic;
+
+    protected $fillable = [
+        'clinic_id',
+        'nome',
+        'responsavel',
+        'idade',
+        'telefone',
+        'ultima_consulta',
+        'proxima_consulta',
+    ];
+
+    protected $dates = [
+        'ultima_consulta',
+        'proxima_consulta',
+    ];
+}

--- a/database/migrations/2025_07_15_153424_create_patients_table.php
+++ b/database/migrations/2025_07_15_153424_create_patients_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('patients', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinic_id')->constrained()->cascadeOnDelete();
+            $table->string('nome');
+            $table->string('responsavel')->nullable();
+            $table->integer('idade')->nullable();
+            $table->string('telefone')->nullable();
+            $table->date('ultima_consulta')->nullable();
+            $table->date('proxima_consulta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('patients');
+    }
+};

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -8,7 +8,7 @@
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0h6" /></svg>
             <span class="ml-3" x-show="!sidebarCollapsed">Dashboard</span>
         </a>
-        <a href="#" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Pacientes' : ''">
+        <a href="{{ route('pacientes.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Pacientes' : ''">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 15c2.33 0 4.5.533 6.879 1.532M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
             <span class="ml-3" x-show="!sidebarCollapsed">Pacientes</span>
         </a>

--- a/resources/views/patients/create.blade.php
+++ b/resources/views/patients/create.blade.php
@@ -1,0 +1,44 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">Novo Paciente</h1>
+    @if ($errors->any())
+        <div class="mb-4">
+            <ul class="list-disc list-inside text-sm text-red-600">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+    <form method="POST" action="{{ route('pacientes.store') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" value="{{ old('nome') }}" required />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Responsável</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel" value="{{ old('responsavel') }}" />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Idade</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="number" name="idade" value="{{ old('idade') }}" />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Telefone</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="telefone" value="{{ old('telefone') }}" />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Última Consulta</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="ultima_consulta" value="{{ old('ultima_consulta') }}" />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Próxima Consulta</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="proxima_consulta" value="{{ old('proxima_consulta') }}" />
+        </div>
+        <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/patients/edit.blade.php
+++ b/resources/views/patients/edit.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">Editar Paciente</h1>
+    @if ($errors->any())
+        <div class="mb-4">
+            <ul class="list-disc list-inside text-sm text-red-600">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+    <form method="POST" action="{{ route('pacientes.update', $paciente) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" value="{{ old('nome', $paciente->nome) }}" required />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Responsável</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel" value="{{ old('responsavel', $paciente->responsavel) }}" />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Idade</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="number" name="idade" value="{{ old('idade', $paciente->idade) }}" />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Telefone</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="telefone" value="{{ old('telefone', $paciente->telefone) }}" />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Última Consulta</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="ultima_consulta" value="{{ old('ultima_consulta', optional($paciente->ultima_consulta)->format('Y-m-d')) }}" />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Próxima Consulta</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="proxima_consulta" value="{{ old('proxima_consulta', optional($paciente->proxima_consulta)->format('Y-m-d')) }}" />
+        </div>
+        <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/patients/index.blade.php
+++ b/resources/views/patients/index.blade.php
@@ -1,0 +1,73 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mb-4 flex justify-between items-center">
+    <h1 class="text-xl font-semibold">Pacientes</h1>
+    <div class="flex gap-2 items-center">
+        <form method="GET" class="relative">
+            <input type="text" name="q" value="{{ request('q') }}" placeholder="Buscar..." class="pl-8 pr-3 py-2 border rounded-lg bg-gray-100 focus:border-primary focus:ring-0" />
+            <span class="absolute inset-y-0 left-0 flex items-center pl-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 103 10.5a7.5 7.5 0 0013.65 6.15z" />
+                </svg>
+            </span>
+        </form>
+        <a class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700" href="{{ route('pacientes.create') }}">+ Novo Paciente</a>
+    </div>
+</div>
+
+<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 mb-6">
+    <div class="p-4 bg-white rounded-lg shadow">
+        <p class="text-sm text-gray-500">Total de Pacientes</p>
+        <p class="mt-2 text-2xl font-semibold text-gray-700">{{ $total }}</p>
+        <p class="text-xs text-gray-500 mt-1">Variação 30d: {{ number_format($variation, 1) }}%</p>
+    </div>
+    <div class="p-4 bg-white rounded-lg shadow">
+        <p class="text-sm text-gray-500">Consultas Agendadas</p>
+        <p class="mt-2 text-2xl font-semibold text-gray-700">{{ $scheduledAppointments }}</p>
+    </div>
+    <div class="p-4 bg-white rounded-lg shadow">
+        <p class="text-sm text-gray-500">Retornos Pendentes</p>
+        <p class="mt-2 text-2xl font-semibold text-gray-700">{{ $pendingReturns }}</p>
+    </div>
+</div>
+
+<div class="overflow-x-auto bg-white rounded-lg shadow">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Nome</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Responsável</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Idade</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Telefone</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Última Consulta</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Próxima Consulta</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Ações</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+            @forelse ($patients as $patient)
+                <tr>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $patient->nome }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $patient->responsavel }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $patient->idade }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $patient->telefone }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ optional($patient->ultima_consulta)->format('d/m/Y') }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ optional($patient->proxima_consulta)->format('d/m/Y') }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">
+                        <a href="{{ route('pacientes.edit', $patient) }}" class="text-blue-600 hover:underline">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-1.5a2.121 2.121 0 113 3L9 21H4v-5l12.732-12.732z" />
+                            </svg>
+                        </a>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="7" class="px-4 py-2 text-center">Nenhum paciente encontrado.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Admin\UnidadeController;
 use App\Http\Controllers\Admin\CadeiraController;
 use App\Http\Controllers\Admin\ProfileController;
 use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\Admin\PatientController;
 
 Route::get('/', function () {
     return view('dashboard');
@@ -17,3 +18,4 @@ Route::resource('unidades', UnidadeController::class);
 Route::resource('cadeiras', CadeiraController::class);
 Route::resource('perfis', ProfileController::class)->parameters(['perfis' => 'perfil']);
 Route::resource('usuarios', UserController::class);
+Route::resource('pacientes', PatientController::class)->parameters(['pacientes' => 'paciente']);


### PR DESCRIPTION
## Summary
- add Patient model and migration
- add PatientController with CRUD actions
- create patient views with dashboard-style cards and table listing
- wire up paciente routes and sidebar link

## Testing
- `php -l app/Models/Patient.php`
- `php -l app/Http/Controllers/Admin/PatientController.php`
- `php -l database/migrations/2025_07_15_153424_create_patients_table.php`

------
https://chatgpt.com/codex/tasks/task_e_687674667f74832a8f50e1a5f6c20240