### PR TITLE
Add breadcrumbs and adjust search bar

### DIFF
--- a/resources/views/admin/cadeiras/create.blade.php
+++ b/resources/views/admin/cadeiras/create.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Cadeiras', 'url' => route('cadeiras.index')],
+    ['label' => 'Criar']
+]])
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Criar Cadeira</h1>
     <form method="POST" action="{{ route('cadeiras.store') }}" class="space-y-4">

--- a/resources/views/admin/cadeiras/edit.blade.php
+++ b/resources/views/admin/cadeiras/edit.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Cadeiras', 'url' => route('cadeiras.index')],
+    ['label' => 'Editar']
+]])
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Cadeira</h1>
     @if ($errors->any())

--- a/resources/views/admin/cadeiras/index.blade.php
+++ b/resources/views/admin/cadeiras/index.blade.php
@@ -1,6 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Cadeiras']
+]])
 <div class="mb-4 flex justify-between items-center">
     <h1 class="text-xl font-semibold">Cadeiras</h1>
     <a class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700" href="{{ route('cadeiras.create') }}">Nova Cadeira</a>

--- a/resources/views/admin/clinics/create.blade.php
+++ b/resources/views/admin/clinics/create.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Clínicas', 'url' => route('clinicas.index')],
+    ['label' => 'Criar']
+]])
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Criar Clínica</h1>
     @if ($errors->any())

--- a/resources/views/admin/clinics/edit.blade.php
+++ b/resources/views/admin/clinics/edit.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Clínicas', 'url' => route('clinicas.index')],
+    ['label' => 'Editar']
+]])
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Clínica</h1>
     @if ($errors->any())

--- a/resources/views/admin/clinics/index.blade.php
+++ b/resources/views/admin/clinics/index.blade.php
@@ -1,6 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Clínicas']
+]])
 <div class="mb-4 flex justify-between items-center">
     <h1 class="text-xl font-semibold">Clínicas</h1>
     <a class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700" href="{{ route('clinicas.create') }}">Nova Clínica</a>

--- a/resources/views/admin/profiles/create.blade.php
+++ b/resources/views/admin/profiles/create.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Perfis', 'url' => route('perfis.index')],
+    ['label' => 'Criar']
+]])
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Criar Perfil</h1>
     <form method="POST" action="{{ route('perfis.store') }}" class="space-y-4">

--- a/resources/views/admin/profiles/edit.blade.php
+++ b/resources/views/admin/profiles/edit.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Perfis', 'url' => route('perfis.index')],
+    ['label' => 'Editar']
+]])
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Perfil</h1>
     <form method="POST" action="{{ route('perfis.update', $perfil) }}" class="space-y-4">

--- a/resources/views/admin/profiles/index.blade.php
+++ b/resources/views/admin/profiles/index.blade.php
@@ -1,6 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Perfis']
+]])
 <div class="mb-4 flex justify-between items-center">
     <h1 class="text-xl font-semibold">Perfis</h1>
     <a class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700" href="{{ route('perfis.create') }}">Novo Perfil</a>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Usuários', 'url' => route('usuarios.index')],
+    ['label' => 'Criar']
+]])
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Criar Usuário</h1>
     <form method="POST" action="{{ route('usuarios.store') }}" enctype="multipart/form-data" class="space-y-4">

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,6 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Usuários']
+]])
 <div class="mb-4 flex justify-between items-center">
     <h1 class="text-xl font-semibold">Usuários</h1>
     <a class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700" href="{{ route('usuarios.create') }}">Novo Usuário</a>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,6 +1,9 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard']
+]])
 <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
     <div class="p-4 bg-white rounded-lg shadow">
         <p class="text-sm text-gray-500">Pacientes</p>

--- a/resources/views/partials/breadcrumbs.blade.php
+++ b/resources/views/partials/breadcrumbs.blade.php
@@ -1,0 +1,17 @@
+@props(['crumbs' => []])
+<nav class="text-sm text-gray-500 mb-4" aria-label="Breadcrumb">
+    <ol class="list-reset flex items-center space-x-2">
+        @foreach ($crumbs as $crumb)
+            <li>
+                @if (isset($crumb['url']))
+                    <a href="{{ $crumb['url'] }}" class="text-blue-600 hover:underline">{{ $crumb['label'] }}</a>
+                @else
+                    <span>{{ $crumb['label'] }}</span>
+                @endif
+            </li>
+            @unless($loop->last)
+                <li>/</li>
+            @endunless
+        @endforeach
+    </ol>
+</nav>

--- a/resources/views/partials/topbar.blade.php
+++ b/resources/views/partials/topbar.blade.php
@@ -4,13 +4,15 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
     </button>
-    <div class="relative flex-1">
-        <span class="absolute inset-y-0 left-0 flex items-center pl-3">
-            <svg class="w-5 h-5 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 103 10.5a7.5 7.5 0 0013.65 6.15z" />
-            </svg>
-        </span>
-        <input type="text" placeholder="Pesquisar" class="w-full pl-10 pr-4 py-2 border rounded-lg bg-gray-100 focus:border-primary focus:ring-0" />
+    <div class="flex-1 flex justify-center">
+        <div class="relative w-full max-w-md">
+            <span class="absolute inset-y-0 left-0 flex items-center pl-3">
+                <svg class="w-5 h-5 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 103 10.5a7.5 7.5 0 0013.65 6.15z" />
+                </svg>
+            </span>
+            <input type="text" placeholder="Pesquisar" class="w-full pl-10 pr-4 py-2 border rounded-lg bg-gray-100 focus:border-primary focus:ring-0" />
+        </div>
     </div>
     <button class="ml-4 p-2 text-gray-600 hover:text-gray-900">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/resources/views/patients/create.blade.php
+++ b/resources/views/patients/create.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Pacientes', 'url' => route('pacientes.index')],
+    ['label' => 'Novo']
+]])
 <div x-data="{ activeTab: 'dados', menor: false }" class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Novo Paciente</h1>
 

--- a/resources/views/patients/edit.blade.php
+++ b/resources/views/patients/edit.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Pacientes', 'url' => route('pacientes.index')],
+    ['label' => 'Editar']
+]])
 <div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Paciente</h1>
     @if ($errors->any())

--- a/resources/views/patients/index.blade.php
+++ b/resources/views/patients/index.blade.php
@@ -1,6 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Pacientes']
+]])
 <div class="mb-4 flex justify-between items-center">
     <h1 class="text-xl font-semibold">Pacientes</h1>
     <div class="flex gap-2 items-center">


### PR DESCRIPTION
## Summary
- centralize search bar by constraining its width
- add breadcrumbs component
- show breadcrumbs on admin and patient pages

## Testing
- `php -l resources/views/partials/breadcrumbs.blade.php`
- `php -l resources/views/partials/topbar.blade.php`
- `for file in $(git status --short | awk '{print $2}'); do php -l $file; done`

------
https://chatgpt.com/codex/tasks/task_e_68775b99b0f8832a8b4f1f14548f899e