### PR TITLE
Fix clinic form weekday label wrapping

### DIFF
--- a/resources/views/admin/clinics/create.blade.php
+++ b/resources/views/admin/clinics/create.blade.php
@@ -67,7 +67,7 @@
             @endphp
             @foreach ($diasSemana as $diaKey => $diaLabel)
                 <div class="flex items-center space-x-2 mb-2">
-                    <span class="w-32 text-sm">{{ $diaLabel }}</span>
+                    <span class="w-40 text-sm whitespace-nowrap flex-shrink-0">{{ $diaLabel }}</span>
                     <input type="time" name="horarios[{{ $diaKey }}][abertura]" value="{{ old('horarios.' . $diaKey . '.abertura') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
                     <input type="time" name="horarios[{{ $diaKey }}][fechamento]" value="{{ old('horarios.' . $diaKey . '.fechamento') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>

--- a/resources/views/admin/clinics/edit.blade.php
+++ b/resources/views/admin/clinics/edit.blade.php
@@ -67,7 +67,7 @@
                     $fechamento = old('horarios.' . $diaKey . '.fechamento', $horarios[$diaKey]['fechamento'] ?? '');
                 @endphp
                 <div class="flex items-center space-x-2 mb-2">
-                    <span class="w-32 text-sm">{{ $diaLabel }}</span>
+                    <span class="w-40 text-sm whitespace-nowrap flex-shrink-0">{{ $diaLabel }}</span>
                     <input type="time" name="horarios[{{ $diaKey }}][abertura]" value="{{ $abertura }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
                     <input type="time" name="horarios[{{ $diaKey }}][fechamento]" value="{{ $fechamento }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>


### PR DESCRIPTION
## Summary
- prevent line breaks for weekday labels in admin clinic forms

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access blocked)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68775e441f54832ab886a791514b20d4