### PR TITLE
Fix seeder for new organization table

### DIFF
--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -11,7 +11,6 @@ class Profile extends Model
     use BelongsToOrganization;
 
     protected $fillable = [
-        'clinic_id',
         'organization_id',
         'nome',
     ];

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -22,7 +22,7 @@ class AdminUserSeeder extends Seeder
 
         $profile = Profile::firstOrCreate([
             'nome' => 'Super Administrador',
-            'clinic_id' => null,
+            'organization_id' => null,
         ]);
 
         $modules = [


### PR DESCRIPTION
## Summary
- update AdminUserSeeder to use `organization_id` instead of deprecated `clinic_id`
- clean up `Profile` model fillable list

## Testing
- `php -l database/seeders/AdminUserSeeder.php`
- `php -l app/Models/Profile.php`


------
https://chatgpt.com/codex/tasks/task_e_6877a8acba18832a989b0880fd476221