### PR TITLE
Add Laravel .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+/vendor/
+/node_modules/
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Laravel specific
+/public/hot
+/public/storage
+/storage/*.key
+/storage/app/public
+/storage/framework/cache/data
+/storage/framework/sessions
+/storage/framework/testing
+/storage/framework/views
+/storage/logs
+
+/.phpunit.result.cache
+Homestead.yaml
+Homestead.json
+
+# IDE and other artifacts
+.idea/
+.phpstorm.meta.php
+.DS_Store
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*


### PR DESCRIPTION
## Summary
- add a .gitignore for typical Laravel projects

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*
- `npm install --no-fund --no-audit` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877c448dfdc832a8693eba6aade4b82