### PR TITLE
Add Dockerfile for Render deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules
+vendor
+.env
+storage/*.key
+storage/*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM composer:2.7 AS build
+
+# Install Node.js 22
+RUN apt-get update \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g npm@latest \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Install PHP dependencies and build front-end assets
+RUN composer install --no-dev --optimize-autoloader \
+    && npm install \
+    && npm run build \
+    && rm -rf node_modules
+
+FROM php:8.3-cli
+
+# Install system packages and PHP extensions
+RUN apt-get update \
+    && apt-get install -y git unzip libpq-dev \
+    && docker-php-ext-install pdo pdo_pgsql \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/bin/composer /usr/local/bin/composer
+WORKDIR /app
+COPY --from=build /app /app
+
+# Ensure necessary permissions
+RUN chmod -R ug+w storage bootstrap/cache
+
+EXPOSE 8080
+
+CMD php artisan migrate --force && php artisan serve --host 0.0.0.0 --port ${PORT:-8080}


### PR DESCRIPTION
## Summary
- provide Dockerfile to run PHP, Composer and Node for Render
- ignore local and build artifacts with `.dockerignore`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877ca313d7c832ab61997aabf4e5aa1