### PR TITLE
Add Render build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ Use os comandos abaixo para build e start do serviço.
 
 ### Comando de build
 ```bash
-composer install --no-dev --optimize-autoloader
-npm install && npm run build
-php artisan migrate --force
+bash render-build.sh
 ```
+
+O script `render-build.sh` instala PHP e Composer caso não estejam
+presentes no ambiente, executa `composer install`, faz o build do
+front-end com `npm run build` e aplica as migrações.
 
 ### Comando de start
 ```bash

--- a/render-build.sh
+++ b/render-build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install PHP and Composer if missing
+if ! command -v php >/dev/null; then
+  apt-get update
+  apt-get install -y php-cli unzip curl
+fi
+
+if ! command -v composer >/dev/null; then
+  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+fi
+
+composer install --no-dev --optimize-autoloader
+npm install
+npm run build
+php artisan migrate --force


### PR DESCRIPTION
## Summary
- simplify Render deploy steps by adding `render-build.sh`
- document using the script for Render build

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d48e2188832ab21a27ea05020730