### PR TITLE
Fix missing CSS after Docker deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@
 node_modules
 vendor
 .env
+public/hot
 storage/*.key
 storage/*.log

--- a/README.md
+++ b/README.md
@@ -146,3 +146,8 @@ php artisan migrate --force && php artisan serve --host 0.0.0.0 --port $PORT
 
 Dessa forma o layout será carregado corretamente, pois o CSS e o JavaScript
 estarão pré-compilados dentro da imagem Docker.
+
+> **Nota**: caso tenha rodado `npm run dev` antes de construir a imagem,
+> remova o arquivo `public/hot`. Esse arquivo faz o Laravel Vite apontar para o
+> servidor de desenvolvimento e impedirá o carregamento do CSS compilado em
+> produção.


### PR DESCRIPTION
## Summary
- ignore Vite dev server marker in Docker builds
- document removing the `public/hot` file before building Docker images

## Testing
- `php -v`


------
https://chatgpt.com/codex/tasks/task_e_6877fe9a983c832a944422ae79d19669