### PR TITLE
Simplify patient creation

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -48,9 +48,12 @@ class PatientController extends Controller
     {
         $data = $request->validate([
             'nome' => 'required',
+            'cpf' => 'required',
             'responsavel' => 'nullable',
             'idade' => 'nullable|integer',
             'telefone' => 'nullable',
+            'menor_idade' => 'nullable|boolean',
+            'responsavel_cpf' => 'required_if:menor_idade,1',
             'ultima_consulta' => 'nullable|date',
             'proxima_consulta' => 'nullable|date',
         ]);
@@ -69,9 +72,12 @@ class PatientController extends Controller
     {
         $data = $request->validate([
             'nome' => 'required',
+            'cpf' => 'required',
             'responsavel' => 'nullable',
             'idade' => 'nullable|integer',
             'telefone' => 'nullable',
+            'menor_idade' => 'nullable|boolean',
+            'responsavel_cpf' => 'required_if:menor_idade,1',
             'ultima_consulta' => 'nullable|date',
             'proxima_consulta' => 'nullable|date',
         ]);

--- a/resources/views/patients/create.blade.php
+++ b/resources/views/patients/create.blade.php
@@ -6,23 +6,9 @@
     ['label' => 'Pacientes', 'url' => route('pacientes.index')],
     ['label' => 'Novo']
 ]])
-<div x-data="{ activeTab: 'dados', menor: false }" class="w-full bg-white p-6 rounded-lg shadow">
+<div x-data="{ menor: false }" class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Novo Paciente</h1>
 
-    <ul class="flex border-b mb-6">
-        <li class="mr-1">
-            <button @click="activeTab = 'dados'" :class="activeTab === 'dados' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'" class="bg-white inline-block py-2 px-4 font-semibold border-b-2">Dados Pessoais</button>
-        </li>
-        <li class="mr-1">
-            <button @click="activeTab = 'anamnese'" :class="activeTab === 'anamnese' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'" class="bg-white inline-block py-2 px-4 font-semibold border-b-2">Anamnese</button>
-        </li>
-        <li class="mr-1">
-            <button @click="activeTab = 'odontograma'" :class="activeTab === 'odontograma' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'" class="bg-white inline-block py-2 px-4 font-semibold border-b-2">Odontograma</button>
-        </li>
-        <li class="mr-1">
-            <button @click="activeTab = 'documentos'" :class="activeTab === 'documentos' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'" class="bg-white inline-block py-2 px-4 font-semibold border-b-2">Documentos</button>
-        </li>
-    </ul>
 
     @if ($errors->any())
         <div class="mb-4">
@@ -37,7 +23,7 @@
     <form method="POST" action="{{ route('pacientes.store') }}" class="space-y-6">
         @csrf
 
-        <div x-show="activeTab === 'dados'" x-cloak>
+        <div>
             <div class="rounded-sm border border-stroke bg-gray-50 p-4 mb-4">
                 <h2 class="mb-4 text-sm font-medium text-gray-700">Informações Básicas</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -51,11 +37,7 @@
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">CPF</label>
-                        <input type="text" name="cpf" value="{{ old('cpf') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
-                    </div>
-                    <div>
-                        <label class="mb-2 block text-sm font-medium text-gray-700">RG</label>
-                        <input type="text" name="rg" value="{{ old('rg') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                        <input type="text" name="cpf" value="{{ old('cpf') }}" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Menor de idade?</label>
@@ -72,7 +54,7 @@
                             </div>
                             <div>
                                 <label class="mb-2 block text-sm font-medium text-gray-700">CPF do responsável</label>
-                                <input type="text" name="responsavel_cpf" value="{{ old('responsavel_cpf') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                                <input type="text" name="responsavel_cpf" value="{{ old('responsavel_cpf') }}" x-bind:required="menor == 1" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                             </div>
                         </div>
                     </div>
@@ -110,17 +92,6 @@
             </div>
         </div>
 
-        <div x-show="activeTab === 'anamnese'" x-cloak>
-            <p class="text-sm text-gray-500">Conteúdo de anamnese ainda não disponível.</p>
-        </div>
-
-        <div x-show="activeTab === 'odontograma'" x-cloak>
-            <p class="text-sm text-gray-500">Conteúdo de odontograma ainda não disponível.</p>
-        </div>
-
-        <div x-show="activeTab === 'documentos'" x-cloak>
-            <p class="text-sm text-gray-500">Área de documentos ainda não disponível.</p>
-        </div>
 
         <div class="flex justify-end gap-2 pt-4">
             <a href="{{ route('pacientes.index') }}" class="py-2 px-4 rounded border border-stroke text-gray-700">Cancelar</a>


### PR DESCRIPTION
## Summary
- show only patient registration fields when creating patients
- drop RG field and require CPF
- require responsible CPF for minors

## Testing
- `php -l app/Http/Controllers/Admin/PatientController.php`
- `php -l resources/views/patients/create.blade.php`
- `php artisan --version` *(fails: vendor missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878c744d608832a828c2b6b85628623