### PR TITLE
Add dentist details to user

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -31,6 +31,10 @@ class UserController extends Controller
             'name' => 'required',
             'email' => 'required|email|unique:users,email',
             'phone' => 'nullable',
+            'endereco' => 'nullable',
+            'cpf' => 'nullable',
+            'dentista' => 'nullable|boolean',
+            'cro' => 'required_if:dentista,1|nullable',
             'profiles' => 'required|array|min:1',
             'profiles.*.profile_id' => 'required|exists:profiles,id',
             'profiles.*.clinic_id' => 'required|exists:clinics,id',
@@ -43,6 +47,10 @@ class UserController extends Controller
         $user->name = $data['name'];
         $user->email = $data['email'];
         $user->phone = $data['phone'] ?? null;
+        $user->endereco = $data['endereco'] ?? null;
+        $user->cpf = $data['cpf'] ?? null;
+        $user->dentista = $data['dentista'] ?? false;
+        $user->cro = $data['cro'] ?? null;
         $user->organization_id = auth()->user()->organization_id;
         $user->password = Hash::make($password);
 
@@ -60,5 +68,51 @@ class UserController extends Controller
         Password::sendResetLink(['email' => $user->email]);
 
         return redirect()->route('usuarios.index')->with('success', 'Usuário salvo com sucesso.');
+    }
+
+    public function edit(User $usuario)
+    {
+        $profiles = Profile::all();
+        $clinics = auth()->user()->organization->clinics ?? [];
+        return view('admin.users.edit', compact('usuario', 'profiles', 'clinics'));
+    }
+
+    public function update(Request $request, User $usuario)
+    {
+        $data = $request->validate([
+            'name' => 'required',
+            'email' => 'required|email|unique:users,email,' . $usuario->id,
+            'phone' => 'nullable',
+            'endereco' => 'nullable',
+            'cpf' => 'nullable',
+            'dentista' => 'nullable|boolean',
+            'cro' => 'required_if:dentista,1|nullable',
+            'profiles' => 'required|array|min:1',
+            'profiles.*.profile_id' => 'required|exists:profiles,id',
+            'profiles.*.clinic_id' => 'required|exists:clinics,id',
+            'photo' => 'nullable|image',
+        ]);
+
+        $usuario->name = $data['name'];
+        $usuario->email = $data['email'];
+        $usuario->phone = $data['phone'] ?? null;
+        $usuario->endereco = $data['endereco'] ?? null;
+        $usuario->cpf = $data['cpf'] ?? null;
+        $usuario->dentista = $data['dentista'] ?? false;
+        $usuario->cro = $data['cro'] ?? null;
+
+        if ($request->hasFile('photo')) {
+            $path = $request->file('photo')->store('users', 'public');
+            $usuario->photo_path = $path;
+        }
+
+        $usuario->save();
+
+        $usuario->clinics()->detach();
+        foreach ($data['profiles'] as $pair) {
+            $usuario->clinics()->attach($pair['clinic_id'], ['profile_id' => $pair['profile_id']]);
+        }
+
+        return redirect()->route('usuarios.index')->with('success', 'Usuário atualizado com sucesso.');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,6 +19,10 @@ class User extends Authenticatable
         'name',
         'email',
         'phone',
+        'endereco',
+        'cpf',
+        'dentista',
+        'cro',
         'photo_path',
         'password',
         'organization_id',
@@ -32,6 +36,7 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
         'must_change_password' => 'boolean',
+        'dentista' => 'boolean',
     ];
 
     public function organization()

--- a/database/migrations/2025_07_19_000000_add_address_cpf_cro_to_users_table.php
+++ b/database/migrations/2025_07_19_000000_add_address_cpf_cro_to_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('endereco')->nullable()->after('phone');
+            $table->string('cpf')->nullable()->after('endereco');
+            $table->boolean('dentista')->default(false)->after('cpf');
+            $table->string('cro')->nullable()->after('dentista');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['endereco', 'cpf', 'dentista', 'cro']);
+        });
+    }
+};

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -4,37 +4,47 @@
 @include('partials.breadcrumbs', ['crumbs' => [
     ['label' => 'Dashboard', 'url' => route('admin.index')],
     ['label' => 'Usuários', 'url' => route('usuarios.index')],
-    ['label' => 'Criar']
+    ['label' => 'Editar']
 ]])
-<div class="w-full bg-white p-6 rounded-lg shadow">
-    <h1 class="text-xl font-semibold mb-4">Criar Usuário</h1>
-    <form method="POST" action="{{ route('usuarios.store') }}" enctype="multipart/form-data" class="space-y-4">
+<div class="w-full bg-white p-6 rounded-lg shadow" x-data="{ dentista: {{ old('dentista', $usuario->dentista) ? 'true' : 'false' }} }">
+    <h1 class="text-xl font-semibold mb-4">Editar Usuário</h1>
+    @if ($errors->any())
+        <div class="mb-4">
+            <ul class="list-disc list-inside text-sm text-red-600">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+    <form method="POST" action="{{ route('usuarios.update', $usuario) }}" enctype="multipart/form-data" class="space-y-4">
         @csrf
+        @method('PUT')
         <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
-            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="name" required />
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="name" value="{{ old('name', $usuario->name) }}" required />
         </div>
         <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Email</label>
-            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="email" name="email" required />
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="email" name="email" value="{{ old('email', $usuario->email) }}" required />
         </div>
         <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Telefone</label>
-            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="phone" />
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="phone" value="{{ old('phone', $usuario->phone) }}" />
         </div>
         <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Endereço</label>
-            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" />
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco', $usuario->endereco) }}" />
         </div>
         <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">CPF</label>
-            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cpf" />
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cpf" value="{{ old('cpf', $usuario->cpf) }}" />
         </div>
-        <div x-data="{ dentista: false }">
+        <div>
             <label class="inline-flex items-center gap-2 mb-2 text-sm font-medium text-gray-700">
-                <input type="checkbox" name="dentista" x-model="dentista" value="1" class="rounded" /> Dentista
+                <input type="checkbox" name="dentista" x-model="dentista" value="1" class="rounded" @checked(old('dentista', $usuario->dentista)) /> Dentista
             </label>
-            <input x-bind:required="dentista" x-show="dentista" x-cloak class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cro" placeholder="CRO" />
+            <input x-bind:required="dentista" x-show="dentista" x-cloak class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cro" placeholder="CRO" value="{{ old('cro', $usuario->cro) }}" />
         </div>
         <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Foto</label>
@@ -78,15 +88,20 @@
             const template = document.getElementById('profile-clinic-template').innerHTML;
             let index = 0;
 
-            function addRow() {
+            function addRow(profile = '', clinic = '') {
                 const html = template.replace(/__index__/g, index);
                 container.insertAdjacentHTML('beforeend', html);
+                const row = container.lastElementChild;
+                row.querySelector('select[name="profiles['+index+'][profile_id]"]').value = profile;
+                row.querySelector('select[name="profiles['+index+'][clinic_id]"]').value = clinic;
                 index++;
             }
 
-            document.getElementById('add-profile').addEventListener('click', addRow);
+            document.getElementById('add-profile').addEventListener('click', () => addRow());
 
-            addRow();
+            @foreach ($usuario->clinics as $clinic)
+                addRow('{{ $clinic->pivot->profile_id }}', '{{ $clinic->id }}');
+            @endforeach
         });
     </script>
 @endpush


### PR DESCRIPTION
## Summary
- allow users to store address, CPF and CRO
- enforce CRO when user is a dentist
- support editing users with new fields
- add migration for new columns

## Testing
- `php -l app/Http/Controllers/Admin/UserController.php`
- `php -l database/migrations/2025_07_19_000000_add_address_cpf_cro_to_users_table.php`
- `php -l app/Models/User.php`
- `php -l resources/views/admin/users/edit.blade.php`
- `php -l resources/views/admin/users/create.blade.php`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790dbd1858832ab75ee8a50541302d