### PR TITLE
Fix organization ID auto assignment in models

### DIFF
--- a/app/Traits/BelongsToOrganization.php
+++ b/app/Traits/BelongsToOrganization.php
@@ -19,6 +19,12 @@ trait BelongsToOrganization
             static::addGlobalScope('organization', function (Builder $builder) use ($instance) {
                 $builder->where($instance->getTable() . '.organization_id', auth()->user()->organization_id);
             });
+
+            static::creating(function ($model) {
+                if (is_null($model->organization_id)) {
+                    $model->organization_id = auth()->user()->organization_id;
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure `organization_id` is set when models using `BelongsToOrganization` are created

## Testing
- `php artisan test` *(fails: vendor deps missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879167f6c2c832a92c3f5865a632663