### PR TITLE
Fix chair creation when clinic_id context is missing

### DIFF
--- a/app/Http/Controllers/Admin/CadeiraController.php
+++ b/app/Http/Controllers/Admin/CadeiraController.php
@@ -30,8 +30,8 @@ class CadeiraController extends Controller
             'status' => 'required',
         ]);
 
-        $currentClinic = app('clinic_id');
-        if ($data['clinic_id'] != $currentClinic) {
+        $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
+        if (is_null($currentClinic) || $data['clinic_id'] != $currentClinic) {
             abort(403);
         }
 
@@ -55,8 +55,8 @@ class CadeiraController extends Controller
             'status' => 'required',
         ]);
 
-        $currentClinic = app('clinic_id');
-        if ($cadeira->clinic_id != $currentClinic || $data['clinic_id'] != $currentClinic) {
+        $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
+        if (is_null($currentClinic) || $cadeira->clinic_id != $currentClinic || $data['clinic_id'] != $currentClinic) {
             abort(403);
         }
 

--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -58,10 +58,12 @@ class PatientController extends Controller
             'proxima_consulta' => 'nullable|date',
         ]);
 
+        $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
+
         Patient::create(array_merge(
             $data,
             [
-                'clinic_id' => app('clinic_id'),
+                'clinic_id' => $clinicId,
                 'organization_id' => auth()->user()->organization_id,
             ]
         ));


### PR DESCRIPTION
## Summary
- guard against missing `clinic_id` binding
- ensure patients are also created with optional clinic context

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68791d636e00832ab847de45d08b64e8