### PR TITLE
Fix backend access check

### DIFF
--- a/app/Http/Middleware/EnsureSuperAdmin.php
+++ b/app/Http/Middleware/EnsureSuperAdmin.php
@@ -8,7 +8,7 @@ class EnsureSuperAdmin
 {
     public function handle($request, Closure $next)
     {
-        if (Auth::check() && optional(Auth::user()->profile)->nome === 'Super Administrador') {
+        if (Auth::check() && Auth::user()->isSuperAdmin()) {
             return $next($request);
         }
 


### PR DESCRIPTION
## Summary
- ensure the superadmin middleware uses the `isSuperAdmin()` helper

## Testing
- `php -v`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68791cd419e8832a9ff11df8c19fae54