### PR TITLE
Add optional admin password field

### DIFF
--- a/app/Http/Controllers/Admin/OrganizationController.php
+++ b/app/Http/Controllers/Admin/OrganizationController.php
@@ -36,6 +36,7 @@ class OrganizationController extends Controller
             'logo_url' => 'nullable',
             'status' => 'in:ativo,inativo,suspenso',
             'responsavel' => 'required',
+            'password' => 'nullable|string|min:8',
         ]);
 
         $organization = Organization::create([
@@ -54,14 +55,14 @@ class OrganizationController extends Controller
             'nome' => 'Administrador',
         ]);
 
-        $password = Str::random(10);
+        $password = $data['password'] ?? Str::random(10);
 
         $user = User::create([
             'name' => $data['responsavel'],
             'email' => $data['email'],
             'organization_id' => $organization->id,
             'password' => Hash::make($password),
-            'must_change_password' => true,
+            'must_change_password' => empty($data['password']),
         ]);
 
         $user->profiles()->syncWithoutDetaching([$profile->id => ['clinic_id' => null]]);

--- a/resources/views/backend/organizations/create.blade.php
+++ b/resources/views/backend/organizations/create.blade.php
@@ -43,6 +43,11 @@
             <label class="mb-2 block text-sm font-medium text-gray-700">Responsável</label>
             <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel" value="{{ old('responsavel') }}" required />
         </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Senha (opcional)</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="password" name="password" />
+            <p class="text-xs text-gray-500 mt-1">Se deixado em branco, uma senha aleatória será criada e enviada por e-mail.</p>
+        </div>
         <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- allow manual password entry when creating an organization
- show password field on organization creation form

## Testing
- `php -l app/Http/Controllers/Admin/OrganizationController.php`
- `php -l resources/views/backend/organizations/create.blade.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a3dc030e4832ab63543f53fa14128