### PR TITLE
Ensure org admin must change password

### DIFF
--- a/app/Http/Controllers/Admin/OrganizationController.php
+++ b/app/Http/Controllers/Admin/OrganizationController.php
@@ -62,7 +62,7 @@ class OrganizationController extends Controller
             'email' => $data['email'],
             'organization_id' => $organization->id,
             'password' => Hash::make($password),
-            'must_change_password' => empty($data['password']),
+            'must_change_password' => true,
         ]);
 
         $user->profiles()->syncWithoutDetaching([$profile->id => ['clinic_id' => null]]);


### PR DESCRIPTION
## Summary
- always require password change for admin account created with new organization

## Testing
- `php artisan test` *(fails: vendor autoload missing)*
- `composer install` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_687a89403258832abf649041b0bf3ab7