### PR TITLE
Auto-preenchimento de endereço via CEP

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -49,5 +49,28 @@ document.addEventListener('DOMContentLoaded', () => {
             v = v.replace(/(\d{5})(\d)/, '$1-$2');
             e.target.value = v;
         });
+
+        input.addEventListener('blur', e => {
+            const cep = e.target.value.replace(/\D/g, '');
+            if (cep.length !== 8) return;
+
+            fetch(`https://viacep.com.br/ws/${cep}/json/`)
+                .then(resp => resp.json())
+                .then(data => {
+                    if (data.erro) return;
+                    const form = e.target.closest('form');
+                    if (!form) return;
+                    const logradouro = form.querySelector('input[name="endereco"]') ||
+                        form.querySelector('input[name="endereco_rua"]');
+                    if (logradouro && data.logradouro) logradouro.value = data.logradouro;
+                    const bairro = form.querySelector('input[name="bairro"]');
+                    if (bairro && data.bairro) bairro.value = data.bairro;
+                    const cidade = form.querySelector('input[name="cidade"]');
+                    if (cidade && data.localidade) cidade.value = data.localidade;
+                    const estado = form.querySelector('input[name="estado"]');
+                    if (estado && data.uf) estado.value = data.uf;
+                })
+                .catch(() => {});
+        });
     });
 });

--- a/resources/views/admin/clinics/create.blade.php
+++ b/resources/views/admin/clinics/create.blade.php
@@ -45,7 +45,7 @@
             <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco') }}" required />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco') }}" placeholder="Número e complemento" required />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>

--- a/resources/views/admin/clinics/edit.blade.php
+++ b/resources/views/admin/clinics/edit.blade.php
@@ -46,7 +46,7 @@
             <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco', $clinic->endereco) }}" required />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco', $clinic->endereco) }}" placeholder="Número e complemento" required />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -55,7 +55,7 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco') }}" placeholder="Número e complemento" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -52,7 +52,7 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco', $usuario->endereco) }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco', $usuario->endereco) }}" placeholder="Número e complemento" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>

--- a/resources/views/patients/create.blade.php
+++ b/resources/views/patients/create.blade.php
@@ -78,7 +78,7 @@
                     </div>
                     <div class="sm:col-span-2">
                         <label class="mb-2 block text-sm font-medium text-gray-700">Rua</label>
-                        <input type="text" name="endereco_rua" value="{{ old('endereco_rua') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                        <input type="text" name="endereco_rua" value="{{ old('endereco_rua') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" placeholder="Número e complemento" />
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Bairro</label>


### PR DESCRIPTION
## Summary
- preencher cidade, estado e logradouro ao sair do campo CEP
- orientar o usuário a digitar somente número e complemento

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac00ded94832aa91aa3b38a781a20