### PR TITLE
Add login error alert

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -15,7 +15,7 @@
                 @csrf
                 <div>
                     <label for="email" class="mb-2 block text-sm font-medium text-gray-700">Email</label>
-                    <input id="email" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="email" name="email" required autofocus />
+                    <input id="email" value="{{ old('email') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="email" name="email" required autofocus />
                 </div>
                 <div>
                     <label for="password" class="mb-2 block text-sm font-medium text-gray-700">Senha</label>

--- a/resources/views/components/alert-error.blade.php
+++ b/resources/views/components/alert-error.blade.php
@@ -1,0 +1,13 @@
+<div x-data="{ show: true }" x-show="show" x-transition class="mb-4 flex items-center justify-between rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+    <div class="flex items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M4.93 4.93l1.42 1.42A9 9 0 1121 12h0a9 9 0 11-7.07-7.07L4.93 4.93z" />
+        </svg>
+        <span>{{ $slot }}</span>
+    </div>
+    <button @click="show = false" class="text-red-700 hover:text-red-900">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+    </button>
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,6 +21,9 @@
             @endunless
         @endauth
         <main class="flex-1 p-6 overflow-y-auto">
+            @if ($errors->any())
+                @include('components.alert-error', ['slot' => $errors->first()])
+            @endif
             @if (session('success'))
                 @include('components.alert-success', ['slot' => session('success')])
             @endif


### PR DESCRIPTION
## Summary
- show error alert in layout when authentication fails
- preserve entered email on login form
- create alert-error component

## Testing
- `composer validate --no-check-all --strict`
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9cbccbf8832aa3a18caed2603802