### PR TITLE
Add admin user password reset feature

### DIFF
--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class AdminUserController extends Controller
+{
+    public function index()
+    {
+        $admins = User::whereHas('profiles', function ($q) {
+            $q->whereIn('nome', ['Administrador', 'Super Administrador']);
+        })->with('organization')->get();
+
+        return view('backend.admin-users.index', compact('admins'));
+    }
+
+    public function edit(User $usuario)
+    {
+        return view('backend.admin-users.edit', compact('usuario'));
+    }
+
+    public function update(Request $request, User $usuario)
+    {
+        $data = $request->validate([
+            'password' => 'required|confirmed|min:8',
+        ]);
+
+        $usuario->password = Hash::make($data['password']);
+        $usuario->must_change_password = true;
+        $usuario->save();
+
+        return redirect()->route('usuarios-admin.index')->with('success', 'Senha atualizada com sucesso.');
+    }
+}

--- a/resources/views/backend/admin-users/edit.blade.php
+++ b/resources/views/backend/admin-users/edit.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Backend', 'url' => route('backend.index')],
+    ['label' => 'Usuários Admin', 'url' => route('usuarios-admin.index')],
+    ['label' => 'Editar']
+]])
+<div class="w-full bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">Alterar Senha - {{ $usuario->name }}</h1>
+    @if ($errors->any())
+        <div class="mb-4">
+            <ul class="list-disc list-inside text-sm text-red-600">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+    <form method="POST" action="{{ route('usuarios-admin.update', $usuario) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Nova Senha</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="password" name="password" required />
+        </div>
+        <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Confirmar Senha</label>
+            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="password" name="password_confirmation" required />
+        </div>
+        <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/backend/admin-users/index.blade.php
+++ b/resources/views/backend/admin-users/index.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Backend', 'url' => route('backend.index')],
+    ['label' => 'Usuários Admin']
+]])
+<div class="mb-4 flex justify-between items-center">
+    <h1 class="text-xl font-semibold">Usuários Admin</h1>
+</div>
+<div class="overflow-x-auto bg-white rounded-lg shadow">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Nome</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Organização</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Ações</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+            @forelse ($admins as $admin)
+                <tr>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $admin->name }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $admin->email }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $admin->organization->nome_fantasia ?? 'N/A' }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">
+                        <a href="{{ route('usuarios-admin.edit', $admin) }}" class="text-blue-600 hover:underline">Editar Senha</a>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="4" class="px-4 py-2 text-center">Nenhum administrador encontrado.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -10,6 +10,10 @@
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
             <span class="ml-3" x-show="!sidebarCollapsed">Backend</span>
         </a>
+        <a href="{{ route('usuarios-admin.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Usuários Admin' : ''">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+            <span class="ml-3" x-show="!sidebarCollapsed">Usuários Admin</span>
+        </a>
         @else
         <a href="{{ route('admin.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Dashboard' : ''">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0h6" /></svg>

--- a/routes/backend.php
+++ b/routes/backend.php
@@ -1,6 +1,10 @@
 <?php
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\OrganizationController;
+use App\Http\Controllers\Admin\AdminUserController;
 
 Route::get('/', [OrganizationController::class, 'index'])->name('backend.index');
 Route::resource('organizacoes', OrganizationController::class)->parameters(['organizacoes' => 'organization']);
+Route::resource('usuarios-admin', AdminUserController::class)
+    ->only(['index', 'edit', 'update'])
+    ->parameters(['usuarios-admin' => 'usuario']);


### PR DESCRIPTION
## Summary
- allow super admin to manage admin users
- list admin users under backend
- provide form to reset passwords
- link new page from sidebar navigation

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `php artisan route:list` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9d5d79f8832ab580fce0b7007469