### PR TITLE
Fix clinic access control

### DIFF
--- a/app/Http/Controllers/Admin/CadeiraController.php
+++ b/app/Http/Controllers/Admin/CadeiraController.php
@@ -17,8 +17,13 @@ class CadeiraController extends Controller
 
     public function create()
     {
-        $clinics = Clinic::all();
-        return view('admin.cadeiras.create', compact('clinics')); 
+        $user = auth()->user();
+        if ($user->isOrganizationAdmin()) {
+            $clinics = Clinic::all();
+        } else {
+            $clinics = $user->clinics()->get();
+        }
+        return view('admin.cadeiras.create', compact('clinics'));
     }
 
     public function store(Request $request)
@@ -31,7 +36,7 @@ class CadeiraController extends Controller
         ]);
 
         $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
-        if (is_null($currentClinic) || $data['clinic_id'] != $currentClinic) {
+        if (is_null($currentClinic) || $data['clinic_id'] != $currentClinic || !auth()->user()->clinics->contains($currentClinic)) {
             abort(403);
         }
 
@@ -42,7 +47,16 @@ class CadeiraController extends Controller
 
     public function edit(Cadeira $cadeira)
     {
-        $clinics = Clinic::all();
+        $user = auth()->user();
+        if (! $user->isOrganizationAdmin() && $cadeira->clinic_id != (app()->bound('clinic_id') ? app('clinic_id') : null)) {
+            abort(403);
+        }
+
+        if ($user->isOrganizationAdmin()) {
+            $clinics = Clinic::all();
+        } else {
+            $clinics = $user->clinics()->get();
+        }
         return view('admin.cadeiras.edit', compact('cadeira', 'clinics'));
     }
 
@@ -56,7 +70,7 @@ class CadeiraController extends Controller
         ]);
 
         $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
-        if (is_null($currentClinic) || $cadeira->clinic_id != $currentClinic || $data['clinic_id'] != $currentClinic) {
+        if (is_null($currentClinic) || $cadeira->clinic_id != $currentClinic || $data['clinic_id'] != $currentClinic || !auth()->user()->clinics->contains($currentClinic)) {
             abort(403);
         }
 

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -11,17 +11,33 @@ class ClinicController extends Controller
 {
     public function index()
     {
-        $clinics = Clinic::all();
+        $user = auth()->user();
+
+        if ($user->isOrganizationAdmin()) {
+            $clinics = Clinic::all();
+        } else {
+            $clinics = $user->clinics()->get();
+        }
+
         return view('admin.clinics.index', compact('clinics'));
     }
 
     public function create()
     {
+        if (! auth()->user()->isOrganizationAdmin()) {
+            abort(403);
+        }
+
         return view('admin.clinics.create');
     }
 
     public function store(Request $request)
     {
+        $user = auth()->user();
+        if (! $user->isOrganizationAdmin()) {
+            abort(403);
+        }
+
         $data = $request->validate([
             'nome' => 'required',
             'cnpj' => ['required', new Cnpj],
@@ -67,6 +83,11 @@ class ClinicController extends Controller
 
     public function edit(Clinic $clinic)
     {
+        $user = auth()->user();
+        if (! $user->isOrganizationAdmin() && ! $user->clinics->contains($clinic->id)) {
+            abort(403);
+        }
+
         $horarios = $clinic->horarios
             ->mapWithKeys(fn($h) => [
                 $h->dia_semana => [
@@ -80,6 +101,11 @@ class ClinicController extends Controller
 
     public function update(Request $request, Clinic $clinic)
     {
+        $user = auth()->user();
+        if (! $user->isOrganizationAdmin() && ! $user->clinics->contains($clinic->id)) {
+            abort(403);
+        }
+
         $data = $request->validate([
             'nome' => 'required',
             'cnpj' => ['required', new Cnpj],

--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -41,6 +41,10 @@ class PatientController extends Controller
 
     public function create()
     {
+        if (! auth()->user()->clinics->contains(app()->bound('clinic_id') ? app('clinic_id') : null)) {
+            abort(403);
+        }
+
         return view('patients.create');
     }
 
@@ -59,6 +63,9 @@ class PatientController extends Controller
         ]);
 
         $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
+        if (! auth()->user()->clinics->contains($clinicId)) {
+            abort(403);
+        }
 
         Patient::create(array_merge(
             $data,
@@ -73,6 +80,11 @@ class PatientController extends Controller
 
     public function edit(Patient $paciente)
     {
+        $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
+        if (! auth()->user()->isOrganizationAdmin() && $paciente->clinic_id != $currentClinic) {
+            abort(403);
+        }
+
         return view('patients.edit', compact('paciente'));
     }
 
@@ -90,6 +102,11 @@ class PatientController extends Controller
             'proxima_consulta' => 'nullable|date',
         ]);
 
+        $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
+        if (! auth()->user()->isOrganizationAdmin() && $paciente->clinic_id != $currentClinic) {
+            abort(403);
+        }
+
         $paciente->update($data);
 
         return redirect()->route('pacientes.index')->with('success', 'Paciente atualizado com sucesso.');
@@ -97,6 +114,11 @@ class PatientController extends Controller
 
     public function destroy(Patient $paciente)
     {
+        $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
+        if (! auth()->user()->isOrganizationAdmin() && $paciente->clinic_id != $currentClinic) {
+            abort(403);
+        }
+
         $paciente->delete();
 
         return redirect()->route('pacientes.index')->with('success', 'Paciente removido com sucesso.');

--- a/app/Models/Cadeira.php
+++ b/app/Models/Cadeira.php
@@ -4,11 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use App\Traits\BelongsToOrganization;
+use App\Traits\BelongsToClinic;
 use App\Models\Organization;
 
 class Cadeira extends Model
 {
-    use BelongsToOrganization;
+    use BelongsToOrganization, BelongsToClinic;
 
     protected $fillable = [
         'clinic_id',

--- a/app/Models/Horario.php
+++ b/app/Models/Horario.php
@@ -4,11 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use App\Traits\BelongsToOrganization;
+use App\Traits\BelongsToClinic;
 use App\Models\Organization;
 
 class Horario extends Model
 {
-    use BelongsToOrganization;
+    use BelongsToOrganization, BelongsToClinic;
 
     protected $fillable = [
         'clinic_id',

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -4,11 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use App\Traits\BelongsToOrganization;
+use App\Traits\BelongsToClinic;
 use App\Models\Organization;
 
 class Patient extends Model
 {
-    use BelongsToOrganization;
+    use BelongsToOrganization, BelongsToClinic;
 
     protected $fillable = [
         'clinic_id',

--- a/app/Traits/BelongsToClinic.php
+++ b/app/Traits/BelongsToClinic.php
@@ -10,7 +10,8 @@ trait BelongsToClinic
     protected static function bootBelongsToClinic()
     {
         $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
-        if (! auth()->check() || is_null($clinicId)) {
+        $user = auth()->user();
+        if (! $user || is_null($clinicId) || $user->isOrganizationAdmin() || $user->isSuperAdmin()) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- restrict access to clinics for non-admins
- scope patients, chairs and schedules by active clinic
- allow admins to bypass clinic scoping
- validate clinic access in controllers

## Testing
- `composer validate --no-check-publish`
- `php -l app/Traits/BelongsToClinic.php`
- `php -l app/Models/Cadeira.php`
- `php -l app/Models/Horario.php`
- `php -l app/Models/Patient.php`
- `php -l app/Http/Controllers/Admin/ClinicController.php`
- `php -l app/Http/Controllers/Admin/CadeiraController.php`
- `php -l app/Http/Controllers/Admin/PatientController.php`


------
https://chatgpt.com/codex/tasks/task_e_687bb2ab799c832a834b573272f97584