### PR TITLE
Add numero and complemento fields to user forms

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -32,6 +32,8 @@ class UserController extends Controller
             'password' => 'nullable|min:8',
             'phone' => 'nullable',
             'endereco' => 'nullable',
+            'numero' => 'nullable',
+            'complemento' => 'nullable',
             'cep' => 'nullable',
             'cidade' => 'nullable',
             'estado' => 'nullable',
@@ -51,6 +53,8 @@ class UserController extends Controller
         $user->email = $data['email'];
         $user->phone = $data['phone'] ?? null;
         $user->endereco = $data['endereco'] ?? null;
+        $user->numero = $data['numero'] ?? null;
+        $user->complemento = $data['complemento'] ?? null;
         $user->cep = $data['cep'] ?? null;
         $user->cidade = $data['cidade'] ?? null;
         $user->estado = $data['estado'] ?? null;
@@ -89,6 +93,8 @@ class UserController extends Controller
             'email' => 'required|email|unique:users,email,' . $usuario->id,
             'phone' => 'nullable',
             'endereco' => 'nullable',
+            'numero' => 'nullable',
+            'complemento' => 'nullable',
             'cep' => 'nullable',
             'cidade' => 'nullable',
             'estado' => 'nullable',
@@ -105,6 +111,8 @@ class UserController extends Controller
         $usuario->email = $data['email'];
         $usuario->phone = $data['phone'] ?? null;
         $usuario->endereco = $data['endereco'] ?? null;
+        $usuario->numero = $data['numero'] ?? null;
+        $usuario->complemento = $data['complemento'] ?? null;
         $usuario->cep = $data['cep'] ?? null;
         $usuario->cidade = $data['cidade'] ?? null;
         $usuario->estado = $data['estado'] ?? null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,8 @@ class User extends Authenticatable
         'email',
         'phone',
         'endereco',
+        'numero',
+        'complemento',
         'cep',
         'cidade',
         'estado',

--- a/database/migrations/2025_07_22_000100_add_numero_complemento_to_users_table.php
+++ b/database/migrations/2025_07_22_000100_add_numero_complemento_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('numero')->nullable()->after('endereco');
+            $table->string('complemento')->nullable()->after('numero');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['numero', 'complemento']);
+        });
+    }
+};

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -52,10 +52,22 @@
         </div>
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Endereço</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">CEP</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cep" value="{{ old('cep') }}" />
+                </div>
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco') }}" placeholder="Número e complemento" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Número</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="numero" value="{{ old('numero') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Complemento</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="complemento" value="{{ old('complemento') }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>
@@ -64,10 +76,6 @@
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Estado</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="estado" value="{{ old('estado') }}" />
-                </div>
-                <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">CEP</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cep" value="{{ old('cep') }}" />
                 </div>
             </div>
         </div>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -49,10 +49,22 @@
         </div>
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Endereço</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">CEP</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cep" value="{{ old('cep', $usuario->cep) }}" />
+                </div>
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco', $usuario->endereco) }}" placeholder="Número e complemento" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco" value="{{ old('endereco', $usuario->endereco) }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Número</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="numero" value="{{ old('numero', $usuario->numero) }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Complemento</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="complemento" value="{{ old('complemento', $usuario->complemento) }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>
@@ -61,10 +73,6 @@
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Estado</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="estado" value="{{ old('estado', $usuario->estado) }}" />
-                </div>
-                <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">CEP</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cep" value="{{ old('cep', $usuario->cep) }}" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- extend user table with `numero` and `complemento`
- allow new fields in the User model
- handle `numero` and `complemento` in admin user controller
- reorder and expand address fields on user create/edit forms

## Testing
- `php -l app/Http/Controllers/Admin/UserController.php`
- `php -l app/Models/User.php`
- `php -l database/migrations/2025_07_22_000100_add_numero_complemento_to_users_table.php`


------
https://chatgpt.com/codex/tasks/task_e_687bbda46e18832a9e2a7c3be506be95