### PR TITLE
Separar campos de nome de pacientes

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -55,7 +55,9 @@ class PatientController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'nome' => 'required',
+            'primeiro_nome' => 'required',
+            'nome_meio' => 'nullable',
+            'ultimo_nome' => 'required',
             'cpf' => 'required',
             'responsavel' => 'nullable',
             'idade' => 'nullable|integer',
@@ -65,6 +67,9 @@ class PatientController extends Controller
             'ultima_consulta' => 'nullable|date',
             'proxima_consulta' => 'nullable|date',
         ]);
+
+        $data['nome'] = trim($data['primeiro_nome'].' '.($data['nome_meio'] ? $data['nome_meio'].' ' : '').$data['ultimo_nome']);
+        unset($data['primeiro_nome'], $data['nome_meio'], $data['ultimo_nome']);
 
         $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
         $user = auth()->user();
@@ -98,7 +103,9 @@ class PatientController extends Controller
     public function update(Request $request, Patient $paciente)
     {
         $data = $request->validate([
-            'nome' => 'required',
+            'primeiro_nome' => 'required',
+            'nome_meio' => 'nullable',
+            'ultimo_nome' => 'required',
             'cpf' => 'required',
             'responsavel' => 'nullable',
             'idade' => 'nullable|integer',
@@ -108,6 +115,9 @@ class PatientController extends Controller
             'ultima_consulta' => 'nullable|date',
             'proxima_consulta' => 'nullable|date',
         ]);
+
+        $data['nome'] = trim($data['primeiro_nome'].' '.($data['nome_meio'] ? $data['nome_meio'].' ' : '').$data['ultimo_nome']);
+        unset($data['primeiro_nome'], $data['nome_meio'], $data['ultimo_nome']);
 
         $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
         if (! auth()->user()->isOrganizationAdmin() && $paciente->clinic_id != $currentClinic) {

--- a/resources/views/patients/create.blade.php
+++ b/resources/views/patients/create.blade.php
@@ -27,9 +27,17 @@
             <div class="rounded-sm border border-stroke bg-gray-50 p-4 mb-4">
                 <h2 class="mb-4 text-sm font-medium text-gray-700">Informações Básicas</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+                        <input type="text" name="primeiro_nome" value="{{ old('primeiro_nome') }}" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    </div>
+                    <div>
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
+                        <input type="text" name="nome_meio" value="{{ old('nome_meio') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    </div>
                     <div class="sm:col-span-2">
-                        <label class="mb-2 block text-sm font-medium text-gray-700">Nome completo</label>
-                        <input type="text" name="nome" value="{{ old('nome') }}" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Último nome</label>
+                        <input type="text" name="ultimo_nome" value="{{ old('ultimo_nome') }}" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Data de nascimento</label>

--- a/resources/views/patients/edit.blade.php
+++ b/resources/views/patients/edit.blade.php
@@ -6,6 +6,12 @@
     ['label' => 'Pacientes', 'url' => route('pacientes.index')],
     ['label' => 'Editar']
 ]])
+@php
+    $nameParts = preg_split('/\s+/', $paciente->nome);
+    $primeiroNome = array_shift($nameParts);
+    $ultimoNome = array_pop($nameParts);
+    $nomeMeio = implode(' ', $nameParts);
+@endphp
 <div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Paciente</h1>
     @if ($errors->any())
@@ -25,9 +31,17 @@
             <div class="rounded-sm border border-stroke bg-gray-50 p-4 mb-4">
                 <h2 class="mb-4 text-sm font-medium text-gray-700">Informações Básicas</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div class="sm:col-span-2">
+                    <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
-                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" value="{{ old('nome', $paciente->nome) }}" required />
+                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="primeiro_nome" value="{{ old('primeiro_nome', $primeiroNome) }}" required />
+                    </div>
+                    <div>
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
+                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome_meio" value="{{ old('nome_meio', $nomeMeio) }}" />
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Último nome</label>
+                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="ultimo_nome" value="{{ old('ultimo_nome', $ultimoNome) }}" required />
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Responsável</label>


### PR DESCRIPTION
## Resumo
- separar nome em primeiro, do meio e último nos formulários de paciente
- concatenar partes do nome antes de salvar

## Testes
- `php artisan --version` *(falha: falta do vendor)*
- `composer install` *(falha: conexão 403)*

------
https://chatgpt.com/codex/tasks/task_e_687bc21477e0832aa7c3af7f8f110c48