### PR TITLE
Separate user name fields

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -27,7 +27,9 @@ class UserController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'name' => 'required',
+            'first_name' => 'required',
+            'middle_name' => 'nullable',
+            'last_name' => 'required',
             'email' => 'required|email|unique:users,email',
             'password' => 'nullable|min:8',
             'phone' => 'nullable',
@@ -49,7 +51,10 @@ class UserController extends Controller
         $password = $data['password'] ?? Str::random(10);
 
         $user = new User();
-        $user->name = $data['name'];
+        $user->first_name = $data['first_name'];
+        $user->middle_name = $data['middle_name'] ?? null;
+        $user->last_name = $data['last_name'];
+        $user->name = trim($data['first_name'] . ' ' . ($data['middle_name'] ?? '') . ' ' . $data['last_name']);
         $user->email = $data['email'];
         $user->phone = $data['phone'] ?? null;
         $user->endereco = $data['endereco'] ?? null;
@@ -89,7 +94,9 @@ class UserController extends Controller
     public function update(Request $request, User $usuario)
     {
         $data = $request->validate([
-            'name' => 'required',
+            'first_name' => 'required',
+            'middle_name' => 'nullable',
+            'last_name' => 'required',
             'email' => 'required|email|unique:users,email,' . $usuario->id,
             'phone' => 'nullable',
             'endereco' => 'nullable',
@@ -107,7 +114,10 @@ class UserController extends Controller
             'photo' => 'nullable|image',
         ]);
 
-        $usuario->name = $data['name'];
+        $usuario->first_name = $data['first_name'];
+        $usuario->middle_name = $data['middle_name'] ?? null;
+        $usuario->last_name = $data['last_name'];
+        $usuario->name = trim($data['first_name'] . ' ' . ($data['middle_name'] ?? '') . ' ' . $data['last_name']);
         $usuario->email = $data['email'];
         $usuario->phone = $data['phone'] ?? null;
         $usuario->endereco = $data['endereco'] ?? null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -18,6 +18,9 @@ class User extends Authenticatable
 
     protected $fillable = [
         'name',
+        'first_name',
+        'middle_name',
+        'last_name',
         'email',
         'phone',
         'endereco',

--- a/database/migrations/2025_07_22_000101_add_first_middle_last_name_to_users_table.php
+++ b/database/migrations/2025_07_22_000101_add_first_middle_last_name_to_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('first_name')->nullable()->after('name');
+            $table->string('middle_name')->nullable()->after('first_name');
+            $table->string('last_name')->nullable()->after('middle_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['first_name', 'middle_name', 'last_name']);
+        });
+    }
+};

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -22,9 +22,17 @@
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Dados do Usuário</h2>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div class="sm:col-span-2">
+                <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="name" value="{{ old('name') }}" required />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="first_name" value="{{ old('first_name') }}" required />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="middle_name" value="{{ old('middle_name') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Último nome</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="last_name" value="{{ old('last_name') }}" required />
                 </div>
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Email</label>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -23,9 +23,17 @@
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Dados do Usuário</h2>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div class="sm:col-span-2">
+                <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="name" value="{{ old('name', $usuario->name) }}" required />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="first_name" value="{{ old('first_name', $usuario->first_name) }}" required />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="middle_name" value="{{ old('middle_name', $usuario->middle_name) }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Último nome</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="last_name" value="{{ old('last_name', $usuario->last_name) }}" required />
                 </div>
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Email</label>


### PR DESCRIPTION
## Summary
- allow users to enter first, middle and last names
- store individual name parts on User model
- compute full name from the new fields
- show the new fields in admin create/edit forms

## Testing
- `php -l app/Http/Controllers/Admin/UserController.php`
- `php -l app/Models/User.php`
- `php -l database/migrations/2025_07_22_000101_add_first_middle_last_name_to_users_table.php`


------
https://chatgpt.com/codex/tasks/task_e_687bc2426924832a93700c52fea70551