### PR TITLE
Improve minor patient forms

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -59,7 +59,9 @@ class PatientController extends Controller
             'nome_meio' => 'nullable',
             'ultimo_nome' => 'required',
             'cpf' => 'required',
-            'responsavel' => 'nullable',
+            'responsavel_primeiro_nome' => 'nullable|required_if:menor_idade,1',
+            'responsavel_nome_meio' => 'nullable',
+            'responsavel_ultimo_nome' => 'nullable|required_if:menor_idade,1',
             'idade' => 'nullable|integer',
             'telefone' => 'nullable',
             'menor_idade' => 'nullable|boolean',
@@ -70,6 +72,11 @@ class PatientController extends Controller
 
         $data['nome'] = trim($data['primeiro_nome'].' '.($data['nome_meio'] ? $data['nome_meio'].' ' : '').$data['ultimo_nome']);
         unset($data['primeiro_nome'], $data['nome_meio'], $data['ultimo_nome']);
+
+        if ($request->filled('responsavel_primeiro_nome') || $request->filled('responsavel_nome_meio') || $request->filled('responsavel_ultimo_nome')) {
+            $data['responsavel'] = trim(($data['responsavel_primeiro_nome'] ?? '').' '.(($data['responsavel_nome_meio'] ?? '') ? $data['responsavel_nome_meio'].' ' : '').($data['responsavel_ultimo_nome'] ?? ''));
+        }
+        unset($data['responsavel_primeiro_nome'], $data['responsavel_nome_meio'], $data['responsavel_ultimo_nome']);
 
         $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
         $user = auth()->user();
@@ -107,7 +114,9 @@ class PatientController extends Controller
             'nome_meio' => 'nullable',
             'ultimo_nome' => 'required',
             'cpf' => 'required',
-            'responsavel' => 'nullable',
+            'responsavel_primeiro_nome' => 'nullable|required_if:menor_idade,1',
+            'responsavel_nome_meio' => 'nullable',
+            'responsavel_ultimo_nome' => 'nullable|required_if:menor_idade,1',
             'idade' => 'nullable|integer',
             'telefone' => 'nullable',
             'menor_idade' => 'nullable|boolean',
@@ -118,6 +127,11 @@ class PatientController extends Controller
 
         $data['nome'] = trim($data['primeiro_nome'].' '.($data['nome_meio'] ? $data['nome_meio'].' ' : '').$data['ultimo_nome']);
         unset($data['primeiro_nome'], $data['nome_meio'], $data['ultimo_nome']);
+
+        if ($request->filled('responsavel_primeiro_nome') || $request->filled('responsavel_nome_meio') || $request->filled('responsavel_ultimo_nome')) {
+            $data['responsavel'] = trim(($data['responsavel_primeiro_nome'] ?? '').' '.(($data['responsavel_nome_meio'] ?? '') ? $data['responsavel_nome_meio'].' ' : '').($data['responsavel_ultimo_nome'] ?? ''));
+        }
+        unset($data['responsavel_primeiro_nome'], $data['responsavel_nome_meio'], $data['responsavel_ultimo_nome']);
 
         $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
         if (! auth()->user()->isOrganizationAdmin() && $paciente->clinic_id != $currentClinic) {

--- a/resources/views/patients/create.blade.php
+++ b/resources/views/patients/create.blade.php
@@ -54,17 +54,27 @@
                             <option value="1">Sim</option>
                         </select>
                     </div>
-                    <div class="sm:col-span-2" x-show="menor == 1" x-cloak>
-                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            <div>
-                                <label class="mb-2 block text-sm font-medium text-gray-700">Nome do responsável</label>
-                                <input type="text" name="responsavel_nome" value="{{ old('responsavel_nome') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
-                            </div>
-                            <div>
-                                <label class="mb-2 block text-sm font-medium text-gray-700">CPF do responsável</label>
-                                <input type="text" name="responsavel_cpf" value="{{ old('responsavel_cpf') }}" x-bind:required="menor == 1" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
-                            </div>
-                        </div>
+                </div>
+            </div>
+
+            <div class="rounded-sm border border-stroke bg-gray-50 p-4 mb-4" x-show="menor == 1" x-cloak>
+                <h2 class="mb-4 text-sm font-medium text-gray-700">Responsável</h2>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+                        <input type="text" name="responsavel_primeiro_nome" value="{{ old('responsavel_primeiro_nome') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    </div>
+                    <div>
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
+                        <input type="text" name="responsavel_nome_meio" value="{{ old('responsavel_nome_meio') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Último nome</label>
+                        <input type="text" name="responsavel_ultimo_nome" value="{{ old('responsavel_ultimo_nome') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-2 block text-sm font-medium text-gray-700">CPF</label>
+                        <input type="text" name="responsavel_cpf" value="{{ old('responsavel_cpf') }}" x-bind:required="menor == 1" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                     </div>
                 </div>
             </div>

--- a/resources/views/patients/edit.blade.php
+++ b/resources/views/patients/edit.blade.php
@@ -11,8 +11,13 @@
     $primeiroNome = array_shift($nameParts);
     $ultimoNome = array_pop($nameParts);
     $nomeMeio = implode(' ', $nameParts);
+
+    $respParts = $paciente->responsavel ? preg_split('/\s+/', $paciente->responsavel) : [];
+    $respPrimeiro = array_shift($respParts);
+    $respUltimo = array_pop($respParts);
+    $respMeio = implode(' ', $respParts);
 @endphp
-<div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
+<div x-data="{ menor: {{ old('menor_idade', 0) }} }" class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Paciente</h1>
     @if ($errors->any())
         <div class="mb-4">
@@ -44,10 +49,6 @@
                         <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="ultimo_nome" value="{{ old('ultimo_nome', $ultimoNome) }}" required />
                     </div>
                     <div>
-                        <label class="mb-2 block text-sm font-medium text-gray-700">Responsável</label>
-                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel" value="{{ old('responsavel', $paciente->responsavel) }}" />
-                    </div>
-                    <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Idade</label>
                         <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="number" name="idade" value="{{ old('idade', $paciente->idade) }}" />
                     </div>
@@ -56,12 +57,41 @@
                         <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="telefone" value="{{ old('telefone', $paciente->telefone) }}" />
                     </div>
                     <div>
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Menor de idade?</label>
+                        <select name="menor_idade" x-model="menor" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
+                            <option value="0">Não</option>
+                            <option value="1">Sim</option>
+                        </select>
+                    </div>
+                    <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Última Consulta</label>
                         <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="ultima_consulta" value="{{ old('ultima_consulta', optional($paciente->ultima_consulta)->format('Y-m-d')) }}" />
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Próxima Consulta</label>
                         <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="proxima_consulta" value="{{ old('proxima_consulta', optional($paciente->proxima_consulta)->format('Y-m-d')) }}" />
+                    </div>
+                </div>
+            </div>
+
+            <div class="rounded-sm border border-stroke bg-gray-50 p-4 mb-4" x-show="menor == 1" x-cloak>
+                <h2 class="mb-4 text-sm font-medium text-gray-700">Responsável</h2>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+                        <input type="text" name="responsavel_primeiro_nome" value="{{ old('responsavel_primeiro_nome', $respPrimeiro) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    </div>
+                    <div>
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
+                        <input type="text" name="responsavel_nome_meio" value="{{ old('responsavel_nome_meio', $respMeio) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Último nome</label>
+                        <input type="text" name="responsavel_ultimo_nome" value="{{ old('responsavel_ultimo_nome', $respUltimo) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-2 block text-sm font-medium text-gray-700">CPF</label>
+                        <input type="text" name="responsavel_cpf" value="{{ old('responsavel_cpf') }}" x-bind:required="menor == 1" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- show responsible details only when patient is marked as minor
- split responsible name into first/middle/last fields in create and edit forms
- combine responsible name in controller before saving

## Testing
- `php -l app/Http/Controllers/Admin/PatientController.php`
- `php -l resources/views/patients/create.blade.php`
- `php -l resources/views/patients/edit.blade.php`
- `php artisan test` *(fails: vendor folder missing)*

------
https://chatgpt.com/codex/tasks/task_e_687bcc9584ec832a92e5381f8ecce1cf