### PR TITLE
Adjust responsible lastname field width

### DIFF
--- a/resources/views/patients/create.blade.php
+++ b/resources/views/patients/create.blade.php
@@ -68,7 +68,7 @@
                         <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
                         <input type="text" name="responsavel_nome_meio" value="{{ old('responsavel_nome_meio') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                     </div>
-                    <div class="sm:col-span-2">
+                    <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Último nome</label>
                         <input type="text" name="responsavel_ultimo_nome" value="{{ old('responsavel_ultimo_nome') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                     </div>

--- a/resources/views/patients/edit.blade.php
+++ b/resources/views/patients/edit.blade.php
@@ -85,7 +85,7 @@
                         <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
                         <input type="text" name="responsavel_nome_meio" value="{{ old('responsavel_nome_meio', $respMeio) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                     </div>
-                    <div class="sm:col-span-2">
+                    <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Último nome</label>
                         <input type="text" name="responsavel_ultimo_nome" value="{{ old('responsavel_ultimo_nome', $respUltimo) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                     </div>


### PR DESCRIPTION
## Summary
- keep responsible's last name input width consistent with other fields

## Testing
- `composer validate`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd0216978832a996f93d8143c404e