### PR TITLE
Add birth date and compute age automatically

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Patient;
 use Illuminate\Http\Request;
+use Carbon\Carbon;
 
 class PatientController extends Controller
 {
@@ -62,6 +63,7 @@ class PatientController extends Controller
             'responsavel_primeiro_nome' => 'nullable|required_if:menor_idade,1',
             'responsavel_nome_meio' => 'nullable',
             'responsavel_ultimo_nome' => 'nullable|required_if:menor_idade,1',
+            'data_nascimento' => 'nullable|date',
             'idade' => 'nullable|integer',
             'telefone' => 'nullable',
             'menor_idade' => 'nullable|boolean',
@@ -77,6 +79,10 @@ class PatientController extends Controller
             $data['responsavel'] = trim(($data['responsavel_primeiro_nome'] ?? '').' '.(($data['responsavel_nome_meio'] ?? '') ? $data['responsavel_nome_meio'].' ' : '').($data['responsavel_ultimo_nome'] ?? ''));
         }
         unset($data['responsavel_primeiro_nome'], $data['responsavel_nome_meio'], $data['responsavel_ultimo_nome']);
+
+        if (! empty($data['data_nascimento'])) {
+            $data['idade'] = Carbon::parse($data['data_nascimento'])->age;
+        }
 
         $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
         $user = auth()->user();
@@ -117,6 +123,7 @@ class PatientController extends Controller
             'responsavel_primeiro_nome' => 'nullable|required_if:menor_idade,1',
             'responsavel_nome_meio' => 'nullable',
             'responsavel_ultimo_nome' => 'nullable|required_if:menor_idade,1',
+            'data_nascimento' => 'nullable|date',
             'idade' => 'nullable|integer',
             'telefone' => 'nullable',
             'menor_idade' => 'nullable|boolean',
@@ -132,6 +139,9 @@ class PatientController extends Controller
             $data['responsavel'] = trim(($data['responsavel_primeiro_nome'] ?? '').' '.(($data['responsavel_nome_meio'] ?? '') ? $data['responsavel_nome_meio'].' ' : '').($data['responsavel_ultimo_nome'] ?? ''));
         }
         unset($data['responsavel_primeiro_nome'], $data['responsavel_nome_meio'], $data['responsavel_ultimo_nome']);
+        if (! empty($data["data_nascimento"])) {
+            $data["idade"] = Carbon::parse($data["data_nascimento"])->age;
+        }
 
         $currentClinic = app()->bound('clinic_id') ? app('clinic_id') : null;
         if (! auth()->user()->isOrganizationAdmin() && $paciente->clinic_id != $currentClinic) {

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use App\Traits\BelongsToOrganization;
 use App\Traits\BelongsToClinic;
 use App\Models\Organization;
+use Carbon\Carbon;
 
 class Patient extends Model
 {
@@ -16,6 +17,7 @@ class Patient extends Model
         'organization_id',
         'nome',
         'responsavel',
+        'data_nascimento',
         'idade',
         'telefone',
         'ultima_consulta',
@@ -23,6 +25,7 @@ class Patient extends Model
     ];
 
     protected $dates = [
+        'data_nascimento',
         'ultima_consulta',
         'proxima_consulta',
     ];
@@ -30,5 +33,14 @@ class Patient extends Model
     public function organization()
     {
         return $this->belongsTo(Organization::class);
+    }
+
+    public function getIdadeAttribute($value)
+    {
+        if ($this->data_nascimento) {
+            return Carbon::parse($this->data_nascimento)->age;
+        }
+
+        return $value;
     }
 }

--- a/database/migrations/2025_07_24_000000_add_data_nascimento_to_patients_table.php
+++ b/database/migrations/2025_07_24_000000_add_data_nascimento_to_patients_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('patients', function (Blueprint $table) {
+            $table->date('data_nascimento')->nullable()->after('responsavel');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('patients', function (Blueprint $table) {
+            $table->dropColumn('data_nascimento');
+        });
+    }
+};

--- a/resources/views/patients/edit.blade.php
+++ b/resources/views/patients/edit.blade.php
@@ -49,8 +49,8 @@
                         <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="ultimo_nome" value="{{ old('ultimo_nome', $ultimoNome) }}" required />
                     </div>
                     <div>
-                        <label class="mb-2 block text-sm font-medium text-gray-700">Idade</label>
-                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="number" name="idade" value="{{ old('idade', $paciente->idade) }}" />
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Data de nascimento</label>
+                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="data_nascimento" value="{{ old('data_nascimento', optional($paciente->data_nascimento)->format('Y-m-d')) }}" />
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">Telefone</label>


### PR DESCRIPTION
## Summary
- add migration for `data_nascimento` on patients
- compute patient age from `data_nascimento`
- handle `data_nascimento` in patient controller
- show birth date field when editing patients

## Testing
- `composer --version`

------
https://chatgpt.com/codex/tasks/task_e_687bd29de498832aadec21dac8f1864b