### PR TITLE
Add anamnese form management

### DIFF
--- a/app/Http/Controllers/Admin/FormularioController.php
+++ b/app/Http/Controllers/Admin/FormularioController.php
@@ -1,0 +1,92 @@
+<?php
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Formulario;
+use Illuminate\Http\Request;
+
+class FormularioController extends Controller
+{
+    public function index()
+    {
+        $formularios = Formulario::orderBy('nome')->get();
+        return view('admin.formularios.index', compact('formularios'));
+    }
+
+    public function create()
+    {
+        return view('admin.formularios.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nome' => 'required',
+            'perguntas' => 'array',
+            'perguntas.*.enunciado' => 'required',
+            'perguntas.*.tipo' => 'required',
+            'perguntas.*.opcoes' => 'nullable',
+        ]);
+
+        $formulario = Formulario::create(['nome' => $data['nome']]);
+
+        foreach ($data['perguntas'] ?? [] as $ordem => $pergunta) {
+            $formulario->perguntas()->create([
+                'enunciado' => $pergunta['enunciado'],
+                'tipo' => $pergunta['tipo'],
+                'opcoes' => $pergunta['opcoes'] ?? null,
+                'ordem' => $ordem,
+            ]);
+        }
+
+        return redirect()->route('formularios.index')->with('success', 'Formul\u00e1rio salvo com sucesso.');
+    }
+
+    public function edit(Formulario $formulario)
+    {
+        if ($formulario->respostas()->exists()) {
+            return redirect()->route('formularios.index')->with('error', 'Formul\u00e1rio j\u00e1 respondido e n\u00e3o pode ser editado.');
+        }
+
+        $formulario->load('perguntas');
+        return view('admin.formularios.edit', compact('formulario'));
+    }
+
+    public function update(Request $request, Formulario $formulario)
+    {
+        if ($formulario->respostas()->exists()) {
+            return redirect()->route('formularios.index')->with('error', 'Formul\u00e1rio j\u00e1 respondido e n\u00e3o pode ser editado.');
+        }
+
+        $data = $request->validate([
+            'nome' => 'required',
+            'perguntas' => 'array',
+            'perguntas.*.enunciado' => 'required',
+            'perguntas.*.tipo' => 'required',
+            'perguntas.*.opcoes' => 'nullable',
+        ]);
+
+        $formulario->update(['nome' => $data['nome']]);
+
+        $formulario->perguntas()->delete();
+        foreach ($data['perguntas'] ?? [] as $ordem => $pergunta) {
+            $formulario->perguntas()->create([
+                'enunciado' => $pergunta['enunciado'],
+                'tipo' => $pergunta['tipo'],
+                'opcoes' => $pergunta['opcoes'] ?? null,
+                'ordem' => $ordem,
+            ]);
+        }
+
+        return redirect()->route('formularios.index')->with('success', 'Formul\u00e1rio atualizado com sucesso.');
+    }
+
+    public function destroy(Formulario $formulario)
+    {
+        if ($formulario->respostas()->exists()) {
+            return redirect()->route('formularios.index')->with('error', 'Formul\u00e1rio n\u00e3o pode ser removido pois possui respostas.');
+        }
+        $formulario->delete();
+        return redirect()->route('formularios.index')->with('success', 'Formul\u00e1rio removido com sucesso.');
+    }
+}

--- a/app/Http/Controllers/Admin/FormularioRespostaController.php
+++ b/app/Http/Controllers/Admin/FormularioRespostaController.php
@@ -1,0 +1,46 @@
+<?php
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Formulario;
+use App\Models\Pergunta;
+use App\Models\Resposta;
+use App\Models\Patient;
+use Illuminate\Http\Request;
+
+class FormularioRespostaController extends Controller
+{
+    public function create(Patient $paciente, Formulario $formulario)
+    {
+        $formulario->load('perguntas');
+        return view('admin.formularios.responder', compact('paciente', 'formulario'));
+    }
+
+    public function store(Request $request, Patient $paciente, Formulario $formulario)
+    {
+        $formulario->load('perguntas');
+        $data = $request->validate([
+            'respostas' => 'required|array',
+        ]);
+
+        foreach ($formulario->perguntas as $pergunta) {
+            if (!array_key_exists($pergunta->id, $data['respostas'])) {
+                return back()->withErrors(['respostas' => 'Responda todas as perguntas.']);
+            }
+        }
+
+        foreach ($data['respostas'] as $perguntaId => $resposta) {
+            if (is_array($resposta)) {
+                $resposta = json_encode($resposta);
+            }
+            Resposta::create([
+                'paciente_id' => $paciente->id,
+                'formulario_id' => $formulario->id,
+                'pergunta_id' => $perguntaId,
+                'resposta' => $resposta,
+            ]);
+        }
+
+        return redirect()->route('pacientes.edit', $paciente)->with('success', 'Respostas salvas com sucesso.');
+    }
+}

--- a/app/Models/Formulario.php
+++ b/app/Models/Formulario.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Formulario extends Model
+{
+    protected $fillable = ['nome'];
+
+    public function perguntas()
+    {
+        return $this->hasMany(Pergunta::class);
+    }
+
+    public function respostas()
+    {
+        return $this->hasMany(Resposta::class);
+    }
+}

--- a/app/Models/Pergunta.php
+++ b/app/Models/Pergunta.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Pergunta extends Model
+{
+    protected $fillable = ['formulario_id','enunciado','tipo','opcoes','ordem'];
+
+    public function formulario()
+    {
+        return $this->belongsTo(Formulario::class);
+    }
+
+    public function respostas()
+    {
+        return $this->hasMany(Resposta::class);
+    }
+
+    public function opcoesArray(): array
+    {
+        return $this->opcoes ? array_map('trim', explode(',', $this->opcoes)) : [];
+    }
+}

--- a/app/Models/Resposta.php
+++ b/app/Models/Resposta.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Resposta extends Model
+{
+    protected $fillable = ['paciente_id','formulario_id','pergunta_id','resposta'];
+
+    public function formulario()
+    {
+        return $this->belongsTo(Formulario::class);
+    }
+
+    public function pergunta()
+    {
+        return $this->belongsTo(Pergunta::class);
+    }
+
+    public function paciente()
+    {
+        return $this->belongsTo(Patient::class, 'paciente_id');
+    }
+}

--- a/database/migrations/2025_07_26_000000_create_formularios_table.php
+++ b/database/migrations/2025_07_26_000000_create_formularios_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('formularios', function (Blueprint $table) {
+            $table->id();
+            $table->string('nome');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('formularios');
+    }
+};

--- a/database/migrations/2025_07_26_000100_create_perguntas_table.php
+++ b/database/migrations/2025_07_26_000100_create_perguntas_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('perguntas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('formulario_id')->constrained('formularios')->cascadeOnDelete();
+            $table->string('enunciado');
+            $table->string('tipo');
+            $table->text('opcoes')->nullable();
+            $table->integer('ordem')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('perguntas');
+    }
+};

--- a/database/migrations/2025_07_26_000200_create_respostas_table.php
+++ b/database/migrations/2025_07_26_000200_create_respostas_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('respostas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('paciente_id')->constrained('patients')->cascadeOnDelete();
+            $table->foreignId('formulario_id')->constrained('formularios')->cascadeOnDelete();
+            $table->foreignId('pergunta_id')->constrained('perguntas')->cascadeOnDelete();
+            $table->text('resposta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('respostas');
+    }
+};

--- a/resources/views/admin/formularios/create.blade.php
+++ b/resources/views/admin/formularios/create.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Formul\u00e1rios', 'url' => route('formularios.index')],
+    ['label' => 'Novo']
+]])
+<div x-data="questionsForm()" class="w-full bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">Novo Formul\u00e1rio</h1>
+    @if ($errors->any())
+        <x-alert-error>{{ implode(', ', $errors->all()) }}</x-alert-error>
+    @endif
+    <form method="POST" action="{{ route('formularios.store') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2">Nome do formul\u00e1rio</label>
+            <input type="text" name="nome" value="{{ old('nome') }}" required class="w-full rounded border border-stroke py-2 px-3" />
+        </div>
+        <template x-for="(q, index) in questions" :key="index">
+            <div class="border p-4 rounded mb-4">
+                <div class="flex justify-between items-center mb-2">
+                    <h2 class="font-medium">Pergunta <span x-text="index + 1"></span></h2>
+                    <button type="button" class="text-red-600" @click="remove(index)">Remover</button>
+                </div>
+                <div class="space-y-2">
+                    <div>
+                        <label class="block text-sm">Enunciado</label>
+                        <input type="text" :name="`perguntas[`+index+`][enunciado]`" x-model="q.enunciado" class="w-full rounded border border-stroke py-2 px-3" required>
+                    </div>
+                    <div>
+                        <label class="block text-sm">Tipo</label>
+                        <select :name="`perguntas[`+index+`][tipo]`" x-model="q.tipo" class="w-full rounded border border-stroke py-2 px-3">
+                            <option value="texto">Texto</option>
+                            <option value="select">Select</option>
+                            <option value="checkbox">Checkbox</option>
+                            <option value="radio">Radio</option>
+                        </select>
+                    </div>
+                    <div x-show="['select','checkbox','radio'].includes(q.tipo)">
+                        <label class="block text-sm">Op\u00e7\u00f5es (separadas por v\u00edrgula)</label>
+                        <input type="text" :name="`perguntas[`+index+`][opcoes]`" x-model="q.opcoes" class="w-full rounded border border-stroke py-2 px-3" />
+                    </div>
+                </div>
+            </div>
+        </template>
+        <button type="button" class="py-2 px-4 bg-green-600 text-white rounded" @click="add">Nova Pergunta</button>
+        <div>
+            <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded">Salvar</button>
+        </div>
+    </form>
+</div>
+<script>
+function questionsForm() {
+    return {
+        questions: [],
+        add() { this.questions.push({enunciado:'',tipo:'texto',opcoes:''}); },
+        remove(i) { this.questions.splice(i,1); }
+    };
+}
+</script>
+@endsection

--- a/resources/views/admin/formularios/edit.blade.php
+++ b/resources/views/admin/formularios/edit.blade.php
@@ -1,0 +1,63 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Formul\u00e1rios', 'url' => route('formularios.index')],
+    ['label' => 'Editar']
+]])
+<div x-data="questionsForm({{ $formulario->perguntas->toJson() }})" class="w-full bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">Editar Formul\u00e1rio</h1>
+    @if ($errors->any())
+        <x-alert-error>{{ implode(', ', $errors->all()) }}</x-alert-error>
+    @endif
+    <form method="POST" action="{{ route('formularios.update', $formulario) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2">Nome do formul\u00e1rio</label>
+            <input type="text" name="nome" value="{{ old('nome', $formulario->nome) }}" required class="w-full rounded border border-stroke py-2 px-3" />
+        </div>
+        <template x-for="(q, index) in questions" :key="index">
+            <div class="border p-4 rounded mb-4">
+                <div class="flex justify-between items-center mb-2">
+                    <h2 class="font-medium">Pergunta <span x-text="index + 1"></span></h2>
+                    <button type="button" class="text-red-600" @click="remove(index)">Remover</button>
+                </div>
+                <div class="space-y-2">
+                    <div>
+                        <label class="block text-sm">Enunciado</label>
+                        <input type="text" :name="`perguntas[`+index+`][enunciado]`" x-model="q.enunciado" class="w-full rounded border border-stroke py-2 px-3" required>
+                    </div>
+                    <div>
+                        <label class="block text-sm">Tipo</label>
+                        <select :name="`perguntas[`+index+`][tipo]`" x-model="q.tipo" class="w-full rounded border border-stroke py-2 px-3">
+                            <option value="texto">Texto</option>
+                            <option value="select">Select</option>
+                            <option value="checkbox">Checkbox</option>
+                            <option value="radio">Radio</option>
+                        </select>
+                    </div>
+                    <div x-show="['select','checkbox','radio'].includes(q.tipo)">
+                        <label class="block text-sm">Op\u00e7\u00f5es (separadas por v\u00edrgula)</label>
+                        <input type="text" :name="`perguntas[`+index+`][opcoes]`" x-model="q.opcoes" class="w-full rounded border border-stroke py-2 px-3" />
+                    </div>
+                </div>
+            </div>
+        </template>
+        <button type="button" class="py-2 px-4 bg-green-600 text-white rounded" @click="add">Nova Pergunta</button>
+        <div>
+            <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded">Salvar</button>
+        </div>
+    </form>
+</div>
+<script>
+function questionsForm(existing) {
+    return {
+        questions: existing || [],
+        add() { this.questions.push({enunciado:'',tipo:'texto',opcoes:''}); },
+        remove(i) { this.questions.splice(i,1); }
+    };
+}
+</script>
+@endsection

--- a/resources/views/admin/formularios/index.blade.php
+++ b/resources/views/admin/formularios/index.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Formul\u00e1rios']
+]])
+<div class="mb-4 flex justify-between items-center">
+    <h1 class="text-xl font-semibold">Formul\u00e1rios</h1>
+    <a class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700" href="{{ route('formularios.create') }}">Novo Formul\u00e1rio</a>
+</div>
+<div class="overflow-x-auto bg-white rounded-lg shadow">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Nome</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">A\u00e7\u00f5es</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+            @forelse ($formularios as $formulario)
+                <tr>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $formulario->nome }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">
+                        <a href="{{ route('formularios.edit', $formulario) }}" class="text-blue-600 hover:underline">Editar</a>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="2" class="px-4 py-2 text-center">Nenhum formul\u00e1rio cadastrado.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/resources/views/admin/formularios/responder.blade.php
+++ b/resources/views/admin/formularios/responder.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Pacientes', 'url' => route('pacientes.index')],
+    ['label' => $paciente->nome, 'url' => route('pacientes.edit', $paciente)],
+    ['label' => $formulario->nome]
+]])
+<div class="w-full bg-white p-6 rounded-lg shadow">
+    <h1 class="text-xl font-semibold mb-4">{{ $formulario->nome }}</h1>
+    @if ($errors->any())
+        <x-alert-error>{{ implode(', ', $errors->all()) }}</x-alert-error>
+    @endif
+    <form method="POST" action="{{ route('pacientes.formularios.store', [$paciente,$formulario]) }}" class="space-y-4">
+        @csrf
+        @foreach ($formulario->perguntas as $pergunta)
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">{{ $pergunta->enunciado }}</label>
+                @if ($pergunta->tipo === 'texto')
+                    <input type="text" name="respostas[{{ $pergunta->id }}]" class="w-full rounded border border-stroke py-2 px-3" />
+                @elseif ($pergunta->tipo === 'select')
+                    <select name="respostas[{{ $pergunta->id }}]" class="w-full rounded border border-stroke py-2 px-3">
+                        @foreach ($pergunta->opcoesArray() as $opcao)
+                            <option value="{{ $opcao }}">{{ $opcao }}</option>
+                        @endforeach
+                    </select>
+                @elseif ($pergunta->tipo === 'checkbox')
+                    @foreach ($pergunta->opcoesArray() as $opcao)
+                        <label class="mr-4">
+                            <input type="checkbox" name="respostas[{{ $pergunta->id }}][]" value="{{ $opcao }}"> {{ $opcao }}
+                        </label>
+                    @endforeach
+                @elseif ($pergunta->tipo === 'radio')
+                    @foreach ($pergunta->opcoesArray() as $opcao)
+                        <label class="mr-4">
+                            <input type="radio" name="respostas[{{ $pergunta->id }}]" value="{{ $opcao }}"> {{ $opcao }}
+                        </label>
+                    @endforeach
+                @endif
+            </div>
+        @endforeach
+        <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded">Enviar</button>
+    </form>
+</div>
+@endsection

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -19,3 +19,10 @@ Route::resource('cadeiras', CadeiraController::class);
 Route::resource('perfis', ProfileController::class)->parameters(['perfis' => 'perfil']);
 Route::resource('usuarios', UserController::class);
 Route::resource('pacientes', PatientController::class)->parameters(['pacientes' => 'paciente']);
+use App\Http\Controllers\Admin\FormularioController;
+use App\Http\Controllers\Admin\FormularioRespostaController;
+
+Route::resource('formularios', FormularioController::class);
+Route::get('pacientes/{paciente}/formularios/{formulario}', [FormularioRespostaController::class, 'create'])->name('pacientes.formularios.create');
+Route::post('pacientes/{paciente}/formularios/{formulario}', [FormularioRespostaController::class, 'store'])->name('pacientes.formularios.store');
+


### PR DESCRIPTION
## Summary
- add migrations for form, question and answer entities
- create Formulario, Pergunta and Resposta models
- implement FormularioController and FormularioRespostaController
- add blades to manage and answer forms
- register new routes for anamnese forms

## Testing
- `php -l app/Http/Controllers/Admin/FormularioController.php`
- `php -l app/Http/Controllers/Admin/FormularioRespostaController.php`
- `php -l app/Models/Formulario.php`
- `php -l app/Models/Pergunta.php`
- `php -l app/Models/Resposta.php`
- `php -l routes/admin.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687bdaf41644832abf684f7a9fb08f0c