### PR TITLE
Add billing address to organizations forms

### DIFF
--- a/app/Http/Controllers/Admin/OrganizationController.php
+++ b/app/Http/Controllers/Admin/OrganizationController.php
@@ -35,11 +35,27 @@ class OrganizationController extends Controller
             'cnpj' => 'required',
             'email' => 'required|email|unique:users,email',
             'telefone' => 'nullable',
-            'endereco_faturamento' => 'nullable',
+            'cep' => 'nullable',
+            'endereco_rua' => 'nullable',
+            'numero' => 'nullable',
+            'complemento' => 'nullable',
+            'bairro' => 'nullable',
+            'cidade' => 'nullable',
+            'estado' => 'nullable',
             'logo_url' => 'nullable',
             'status' => 'in:ativo,inativo,suspenso',
             'password' => 'nullable|string|min:8|confirmed',
         ]);
+
+        $billingAddress = [
+            'cep' => $data['cep'] ?? null,
+            'logradouro' => $data['endereco_rua'] ?? null,
+            'numero' => $data['numero'] ?? null,
+            'complemento' => $data['complemento'] ?? null,
+            'bairro' => $data['bairro'] ?? null,
+            'cidade' => $data['cidade'] ?? null,
+            'estado' => $data['estado'] ?? null,
+        ];
 
         $organization = Organization::create([
             'nome_fantasia' => $data['nome_fantasia'],
@@ -47,7 +63,7 @@ class OrganizationController extends Controller
             'cnpj' => $data['cnpj'],
             'email' => $data['email'],
             'telefone' => $data['telefone'] ?? null,
-            'endereco_faturamento' => $data['endereco_faturamento'] ?? null,
+            'endereco_faturamento' => $billingAddress,
             'logo_url' => $data['logo_url'] ?? null,
             'status' => $data['status'] ?? 'ativo',
         ]);
@@ -115,11 +131,27 @@ class OrganizationController extends Controller
             'cnpj' => 'required',
             'email' => 'required|email',
             'telefone' => 'nullable',
-            'endereco_faturamento' => 'nullable',
+            'cep' => 'nullable',
+            'endereco_rua' => 'nullable',
+            'numero' => 'nullable',
+            'complemento' => 'nullable',
+            'bairro' => 'nullable',
+            'cidade' => 'nullable',
+            'estado' => 'nullable',
             'logo_url' => 'nullable',
             'status' => 'in:ativo,inativo,suspenso',
             'password' => 'nullable|string|min:8|confirmed',
         ]);
+
+        $billingAddress = [
+            'cep' => $data['cep'] ?? null,
+            'logradouro' => $data['endereco_rua'] ?? null,
+            'numero' => $data['numero'] ?? null,
+            'complemento' => $data['complemento'] ?? null,
+            'bairro' => $data['bairro'] ?? null,
+            'cidade' => $data['cidade'] ?? null,
+            'estado' => $data['estado'] ?? null,
+        ];
 
         $organization->update([
             'nome_fantasia' => $data['nome_fantasia'],
@@ -127,7 +159,7 @@ class OrganizationController extends Controller
             'cnpj' => $data['cnpj'],
             'email' => $data['email'],
             'telefone' => $data['telefone'] ?? null,
-            'endereco_faturamento' => $data['endereco_faturamento'] ?? null,
+            'endereco_faturamento' => $billingAddress,
             'logo_url' => $data['logo_url'] ?? null,
             'status' => $data['status'] ?? $organization->status,
         ]);

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -17,6 +17,10 @@ class Organization extends Model
         'status',
     ];
 
+    protected $casts = [
+        'endereco_faturamento' => 'array',
+    ];
+
     public function clinics()
     {
         return $this->hasMany(Clinic::class);

--- a/resources/views/backend/organizations/create.blade.php
+++ b/resources/views/backend/organizations/create.blade.php
@@ -62,6 +62,39 @@
             </div>
         </div>
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
+            <h2 class="mb-4 text-sm font-medium text-gray-700">Endereço de Faturamento</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">CEP</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cep" value="{{ old('cep') }}" />
+                </div>
+                <div class="sm:col-span-2">
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco_rua" value="{{ old('endereco_rua') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Número</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="numero" value="{{ old('numero') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Complemento</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="complemento" value="{{ old('complemento') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Bairro</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="bairro" value="{{ old('bairro') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cidade" value="{{ old('cidade') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Estado</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="estado" value="{{ old('estado') }}" />
+                </div>
+            </div>
+        </div>
+        <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Senha</h2>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>

--- a/resources/views/backend/organizations/edit.blade.php
+++ b/resources/views/backend/organizations/edit.blade.php
@@ -6,6 +6,9 @@
     ['label' => 'Organizações', 'url' => route('organizacoes.index')],
     ['label' => 'Editar']
 ]])
+@php
+    $billing = $organization->endereco_faturamento ?? [];
+@endphp
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Organização</h1>
     @if ($errors->any())
@@ -59,6 +62,39 @@
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Telefone</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="telefone" value="{{ old('telefone', $organization->telefone) }}" />
+                </div>
+            </div>
+        </div>
+        <div class="rounded-sm border border-stroke bg-gray-50 p-4">
+            <h2 class="mb-4 text-sm font-medium text-gray-700">Endereço de Faturamento</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">CEP</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cep" value="{{ old('cep', $billing['cep'] ?? '') }}" />
+                </div>
+                <div class="sm:col-span-2">
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco_rua" value="{{ old('endereco_rua', $billing['logradouro'] ?? '') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Número</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="numero" value="{{ old('numero', $billing['numero'] ?? '') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Complemento</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="complemento" value="{{ old('complemento', $billing['complemento'] ?? '') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Bairro</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="bairro" value="{{ old('bairro', $billing['bairro'] ?? '') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cidade" value="{{ old('cidade', $billing['cidade'] ?? '') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Estado</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="estado" value="{{ old('estado', $billing['estado'] ?? '') }}" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add billing address fields when creating/editing organizations
- store billing address as JSON array in `Organization`
- decode billing address for edit form
- cast `endereco_faturamento` attribute to array
- fix billing address handling in edit view

## Testing
- `php -v`
- `php -l resources/views/backend/organizations/edit.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_687be1dc927c832ab6d7ee71338eb249