### PR TITLE
Update organization address fields

### DIFF
--- a/app/Http/Controllers/Admin/OrganizationController.php
+++ b/app/Http/Controllers/Admin/OrganizationController.php
@@ -47,23 +47,22 @@ class OrganizationController extends Controller
             'password' => 'nullable|string|min:8|confirmed',
         ]);
 
-        $billingAddress = [
-            'cep' => $data['cep'] ?? null,
-            'logradouro' => $data['endereco_rua'] ?? null,
-            'numero' => $data['numero'] ?? null,
-            'complemento' => $data['complemento'] ?? null,
-            'bairro' => $data['bairro'] ?? null,
-            'cidade' => $data['cidade'] ?? null,
-            'estado' => $data['estado'] ?? null,
-        ];
-
         $organization = Organization::create([
             'nome_fantasia' => $data['nome_fantasia'],
             'razao_social' => $data['razao_social'] ?? null,
             'cnpj' => $data['cnpj'],
             'email' => $data['email'],
             'telefone' => $data['telefone'] ?? null,
-            'endereco_faturamento' => $billingAddress,
+            'responsavel_nome' => $data['nome'],
+            'responsavel_nome_meio' => $data['nome_meio'] ?? null,
+            'responsavel_ultimo_nome' => $data['sobrenome'],
+            'cep' => $data['cep'] ?? null,
+            'rua' => $data['endereco_rua'] ?? null,
+            'numero' => $data['numero'] ?? null,
+            'complemento' => $data['complemento'] ?? null,
+            'bairro' => $data['bairro'] ?? null,
+            'cidade' => $data['cidade'] ?? null,
+            'estado' => $data['estado'] ?? null,
             'logo_url' => $data['logo_url'] ?? null,
             'status' => $data['status'] ?? 'ativo',
         ]);
@@ -143,23 +142,22 @@ class OrganizationController extends Controller
             'password' => 'nullable|string|min:8|confirmed',
         ]);
 
-        $billingAddress = [
-            'cep' => $data['cep'] ?? null,
-            'logradouro' => $data['endereco_rua'] ?? null,
-            'numero' => $data['numero'] ?? null,
-            'complemento' => $data['complemento'] ?? null,
-            'bairro' => $data['bairro'] ?? null,
-            'cidade' => $data['cidade'] ?? null,
-            'estado' => $data['estado'] ?? null,
-        ];
-
         $organization->update([
             'nome_fantasia' => $data['nome_fantasia'],
             'razao_social' => $data['razao_social'] ?? null,
             'cnpj' => $data['cnpj'],
             'email' => $data['email'],
             'telefone' => $data['telefone'] ?? null,
-            'endereco_faturamento' => $billingAddress,
+            'responsavel_nome' => $data['nome'] ?? $organization->responsavel_nome,
+            'responsavel_nome_meio' => $data['nome_meio'] ?? $organization->responsavel_nome_meio,
+            'responsavel_ultimo_nome' => $data['sobrenome'] ?? $organization->responsavel_ultimo_nome,
+            'cep' => $data['cep'] ?? null,
+            'rua' => $data['endereco_rua'] ?? null,
+            'numero' => $data['numero'] ?? null,
+            'complemento' => $data['complemento'] ?? null,
+            'bairro' => $data['bairro'] ?? null,
+            'cidade' => $data['cidade'] ?? null,
+            'estado' => $data['estado'] ?? null,
             'logo_url' => $data['logo_url'] ?? null,
             'status' => $data['status'] ?? $organization->status,
         ]);

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -12,14 +12,20 @@ class Organization extends Model
         'cnpj',
         'email',
         'telefone',
-        'endereco_faturamento',
+        'responsavel_nome',
+        'responsavel_nome_meio',
+        'responsavel_ultimo_nome',
+        'cep',
+        'rua',
+        'numero',
+        'complemento',
+        'bairro',
+        'cidade',
+        'estado',
         'logo_url',
         'status',
     ];
 
-    protected $casts = [
-        'endereco_faturamento' => 'array',
-    ];
 
     public function clinics()
     {

--- a/database/migrations/2025_07_29_000000_update_organizations_table_add_fields.php
+++ b/database/migrations/2025_07_29_000000_update_organizations_table_add_fields.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Organization;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->string('responsavel_nome')->nullable()->after('telefone');
+            $table->string('responsavel_nome_meio')->nullable()->after('responsavel_nome');
+            $table->string('responsavel_ultimo_nome')->nullable()->after('responsavel_nome_meio');
+            $table->string('cep')->nullable()->after('responsavel_ultimo_nome');
+            $table->string('rua')->nullable()->after('cep');
+            $table->string('numero')->nullable()->after('rua');
+            $table->string('complemento')->nullable()->after('numero');
+            $table->string('bairro')->nullable()->after('complemento');
+            $table->string('cidade')->nullable()->after('bairro');
+            $table->string('estado')->nullable()->after('cidade');
+        });
+
+        if (Schema::hasColumn('organizations', 'endereco_faturamento')) {
+            foreach (Organization::all() as $organization) {
+                $address = $organization->endereco_faturamento ?? [];
+                $organization->cep = $address['cep'] ?? null;
+                $organization->rua = $address['logradouro'] ?? null;
+                $organization->numero = $address['numero'] ?? null;
+                $organization->complemento = $address['complemento'] ?? null;
+                $organization->bairro = $address['bairro'] ?? null;
+                $organization->cidade = $address['cidade'] ?? null;
+                $organization->estado = $address['estado'] ?? null;
+                $organization->save();
+            }
+            Schema::table('organizations', function (Blueprint $table) {
+                $table->dropColumn('endereco_faturamento');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->json('endereco_faturamento')->nullable()->after('telefone');
+        });
+
+        foreach (Organization::all() as $organization) {
+            $organization->endereco_faturamento = [
+                'cep' => $organization->cep,
+                'logradouro' => $organization->rua,
+                'numero' => $organization->numero,
+                'complemento' => $organization->complemento,
+                'bairro' => $organization->bairro,
+                'cidade' => $organization->cidade,
+                'estado' => $organization->estado,
+            ];
+            $organization->save();
+        }
+
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropColumn([
+                'responsavel_nome',
+                'responsavel_nome_meio',
+                'responsavel_ultimo_nome',
+                'cep',
+                'rua',
+                'numero',
+                'complemento',
+                'bairro',
+                'cidade',
+                'estado',
+            ]);
+        });
+    }
+};

--- a/resources/views/backend/organizations/edit.blade.php
+++ b/resources/views/backend/organizations/edit.blade.php
@@ -6,10 +6,6 @@
     ['label' => 'Organizações', 'url' => route('organizacoes.index')],
     ['label' => 'Editar']
 ]])
-@php
-
-    $billing = $organization->endereco_faturamento ?? [];
-@endphp
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Organização</h1>
     @if ($errors->any())
@@ -29,15 +25,15 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" value="{{ old('nome') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" value="{{ old('nome', $organization->responsavel_nome) }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Nome do meio</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome_meio" value="{{ old('nome_meio') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome_meio" value="{{ old('nome_meio', $organization->responsavel_nome_meio) }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Sobrenome</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="sobrenome" value="{{ old('sobrenome') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="sobrenome" value="{{ old('sobrenome', $organization->responsavel_ultimo_nome) }}" />
                 </div>
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Nome Fantasia</label>
@@ -71,31 +67,31 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">CEP</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cep" value="{{ old('cep', $billing['cep'] ?? '') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cep" value="{{ old('cep', $organization->cep) }}" />
                 </div>
                 <div class="sm:col-span-2">
                     <label class="mb-2 block text-sm font-medium text-gray-700">Logradouro</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco_rua" value="{{ old('endereco_rua', $billing['logradouro'] ?? '') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="endereco_rua" value="{{ old('endereco_rua', $organization->rua) }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Número</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="numero" value="{{ old('numero', $billing['numero'] ?? '') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="numero" value="{{ old('numero', $organization->numero) }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Complemento</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="complemento" value="{{ old('complemento', $billing['complemento'] ?? '') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="complemento" value="{{ old('complemento', $organization->complemento) }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Bairro</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="bairro" value="{{ old('bairro', $billing['bairro'] ?? '') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="bairro" value="{{ old('bairro', $organization->bairro) }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Cidade</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cidade" value="{{ old('cidade', $billing['cidade'] ?? '') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cidade" value="{{ old('cidade', $organization->cidade) }}" />
                 </div>
                 <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">Estado</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="estado" value="{{ old('estado', $billing['estado'] ?? '') }}" />
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="estado" value="{{ old('estado', $organization->estado) }}" />
                 </div>
             </div>
         </div>

--- a/resources/views/backend/organizations/index.blade.php
+++ b/resources/views/backend/organizations/index.blade.php
@@ -25,7 +25,9 @@
                 <tr>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $organization->nome_fantasia }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $organization->cnpj }}</td>
-                    <td class="px-4 py-2 whitespace-nowrap">{{ $organization->email }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">
+                        {{ trim($organization->responsavel_nome . ' ' . ($organization->responsavel_nome_meio ? $organization->responsavel_nome_meio . ' ' : '') . $organization->responsavel_ultimo_nome) }}
+                    </td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $organization->status }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">
                         <a href="{{ route('organizacoes.edit', $organization) }}" class="text-blue-600 hover:underline">Editar</a>


### PR DESCRIPTION
## Summary
- split out organization address columns and responsible name fields
- drop `endereco_faturamento` JSON column
- update Organization model
- store/update new fields in controller
- show responsible person's full name in listing
- adjust edit form to use new fields
- add migration converting existing JSON data

## Testing
- `php -l app/Http/Controllers/Admin/OrganizationController.php`
- `php -l app/Models/Organization.php`
- `php -l resources/views/backend/organizations/edit.blade.php`
- `php -l resources/views/backend/organizations/index.blade.php`
- `php -l database/migrations/2025_07_29_000000_update_organizations_table_add_fields.php`

------
https://chatgpt.com/codex/tasks/task_e_687c0a6dfc58832a837422905eaf9094