### PR TITLE
Link patients menu to patients page

### DIFF
--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -28,7 +28,7 @@
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0h6" /></svg>
             <span class="ml-3" x-show="!sidebarCollapsed">Dashboard</span>
         </a>
-        <a href="#" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Pacientes' : ''">
+        <a href="{{ route('pacientes.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Pacientes' : ''">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 15c2.33 0 4.5.533 6.879 1.532M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
             <span class="ml-3" x-show="!sidebarCollapsed">Pacientes</span>
         </a>


### PR DESCRIPTION
## Summary
- fix sidebar navigation so the Patients item leads to the patients page

## Testing
- `php -l resources/views/partials/sidebar.blade.php`

------
https://chatgpt.com/codex/tasks/task_e_687ce7c3d5e8832aa65c4a7045495c63