### PR TITLE
Fix admin user edit script loading

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -30,5 +30,6 @@
             @yield('content')
         </main>
     </div>
+    @stack('scripts')
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable script stack in layout so edit page loads existing clinics and profiles

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_687ce932bee0832a97813ccd5ec6ed2c