### PR TITLE
Add whatsapp field to patient contacts

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -54,6 +54,7 @@ class PatientController extends Controller
             'responsavel_ultimo_nome' => 'nullable',
             'responsavel_cpf' => 'nullable',
             'telefone' => 'nullable',
+            'whatsapp' => 'nullable',
             'email' => 'nullable|email',
             'cep' => 'nullable',
             'logradouro' => 'nullable',

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -22,6 +22,7 @@ class Patient extends Model
         'responsavel_ultimo_nome',
         'responsavel_cpf',
         'telefone',
+        'whatsapp',
         'email',
         'cep',
         'logradouro',

--- a/database/migrations/2025_08_15_000000_add_whatsapp_to_patients_table.php
+++ b/database/migrations/2025_08_15_000000_add_whatsapp_to_patients_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('patients', function (Blueprint $table) {
+            if (!Schema::hasColumn('patients', 'whatsapp')) {
+                $table->string('whatsapp')->nullable()->after('telefone');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('patients', function (Blueprint $table) {
+            if (Schema::hasColumn('patients', 'whatsapp')) {
+                $table->dropColumn('whatsapp');
+            }
+        });
+    }
+};

--- a/resources/views/pacientes/create.blade.php
+++ b/resources/views/pacientes/create.blade.php
@@ -80,6 +80,10 @@
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="telefone" value="{{ old('telefone') }}" />
                 </div>
                 <div>
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">Whatsapp</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="whatsapp" value="{{ old('whatsapp') }}" />
+                </div>
+                <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">E-mail</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="email" name="email" value="{{ old('email') }}" />
                 </div>

--- a/resources/views/pacientes/edit.blade.php
+++ b/resources/views/pacientes/edit.blade.php
@@ -111,6 +111,10 @@
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="telefone" value="{{ old('telefone', $paciente->telefone) }}" />
                 </div>
                 <div>
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">Whatsapp</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="whatsapp" value="{{ old('whatsapp', $paciente->whatsapp) }}" />
+                </div>
+                <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">E-mail</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="email" name="email" value="{{ old('email', $paciente->email) }}" />
                 </div>

--- a/resources/views/pacientes/index.blade.php
+++ b/resources/views/pacientes/index.blade.php
@@ -44,6 +44,7 @@
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Responsável</th>
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Idade</th>
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Telefone</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Whatsapp</th>
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Última Consulta</th>
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Próxima Consulta</th>
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Ações</th>
@@ -56,6 +57,7 @@
                         <td class="px-4 py-2 whitespace-nowrap">{{ $paciente->responsavel_nome ?? '-' }}</td>
                         <td class="px-4 py-2 whitespace-nowrap">{{ \Carbon\Carbon::parse($paciente->data_nascimento)->age }}</td>
                         <td class="px-4 py-2 whitespace-nowrap">{{ $paciente->telefone }}</td>
+                        <td class="px-4 py-2 whitespace-nowrap">{{ $paciente->whatsapp }}</td>
                         <td class="px-4 py-2 whitespace-nowrap">-</td>
                         <td class="px-4 py-2 whitespace-nowrap">-</td>
                         <td class="px-4 py-2 whitespace-nowrap text-center">


### PR DESCRIPTION
## Summary
- add DB migration for whatsapp field
- allow whatsapp in Patient model and controller
- include whatsapp field in patient create/edit forms
- show whatsapp column in patients list

## Testing
- `php -l app/Models/Patient.php`
- `php -l app/Http/Controllers/Admin/PatientController.php`
- `php -l database/migrations/2025_08_15_000000_add_whatsapp_to_patients_table.php`


------
https://chatgpt.com/codex/tasks/task_e_687cffab848c832a92bc37a4348204ed