### PR TITLE
Add icons to patient list actions

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -45,6 +45,12 @@ class PatientController extends Controller
         return redirect()->route('pacientes.index')->with('success', 'Paciente atualizado com sucesso.');
     }
 
+    public function destroy(Patient $paciente)
+    {
+        $paciente->delete();
+        return redirect()->route('pacientes.index')->with('success', 'Paciente removido com sucesso.');
+    }
+
     private function validateData(Request $request): array
     {
         $rules = [

--- a/resources/views/pacientes/index.blade.php
+++ b/resources/views/pacientes/index.blade.php
@@ -61,12 +61,33 @@
                         <td class="px-4 py-2 whitespace-nowrap">-</td>
                         <td class="px-4 py-2 whitespace-nowrap">-</td>
                         <td class="px-4 py-2 whitespace-nowrap text-center">
-                            <a href="{{ route('pacientes.edit', $paciente) }}" class="text-blue-600 hover:underline mr-2" title="Editar">
-                                Editar
-                            </a>
-                            <a href="#" class="text-blue-600 hover:underline" title="Ver Prontuário">
-                                Ver Prontuário
-                            </a>
+                            <div class="flex items-center justify-center space-x-2">
+                                <a href="{{ route('pacientes.show', $paciente) }}" class="text-gray-600 hover:text-blue-600" title="Ver">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                    </svg>
+                                </a>
+                                <a href="{{ route('pacientes.edit', $paciente) }}" class="text-gray-600 hover:text-blue-600" title="Editar">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m0 0a2.5 2.5 0 01-3.536 3.536L9 20.036l-4 1 1-4 6.232-6.232a2.5 2.5 0 013.536-3.536z" />
+                                    </svg>
+                                </a>
+                                <a href="#" class="text-gray-600 hover:text-blue-600" title="Ver Prontuário">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 12v.01M7 8h10M7 12h.01M7 16h.01M9 16h6m2 4H7a2 2 0 01-2-2V6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v10a2 2 0 01-2 2z" />
+                                    </svg>
+                                </a>
+                                <form action="{{ route('pacientes.destroy', $paciente) }}" method="POST" onsubmit="return confirm('Tem certeza que deseja excluir este paciente?');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-red-600 hover:text-red-800" title="Excluir">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M10 7V4a1 1 0 011-1h2a1 1 0 011 1v3" />
+                                        </svg>
+                                    </button>
+                                </form>
+                            </div>
                         </td>
                     </tr>
                 @endforeach


### PR DESCRIPTION
## Summary
- add a `destroy` method for patients
- display icons for viewing, editing, medical record and deleting a patient

## Testing
- `php artisan route:list | grep pacientes | head -n 20` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d05c937e8832a9dd5c7b5a7e640ae