### PR TITLE
Link budget signing page

### DIFF
--- a/resources/views/components/orcamento-card.blade.php
+++ b/resources/views/components/orcamento-card.blade.php
@@ -8,7 +8,7 @@
         <p class="text-sm text-emerald-600">Desconto Convênio: {{ $desconto }}</p>
         <p class="text-sm text-gray-700">Valor Final: <span class="font-medium text-gray-900">{{ $valorFinal }}</span></p>
     </div>
-    <a href="#" class="inline-flex items-center px-4 py-2 bg-primary text-white rounded hover:bg-primary/90">
+    <a href="{{ route('orcamentos.assinar') }}" class="inline-flex items-center px-4 py-2 bg-primary text-white rounded hover:bg-primary/90">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 20h9" />
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16.5 3.5a3 3 0 11-4.5 4.5L5 15v4h4l7-7a3 3 0 014.5-4.5z" />

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -24,3 +24,5 @@ Route::resource('formularios', FormularioController::class);
 Route::resource('pacientes', PatientController::class)
     ->parameters(['pacientes' => 'paciente']);
 
+Route::view('orcamentos/assinar', 'orcamentos.assinar')->name('orcamentos.assinar');
+


### PR DESCRIPTION
## Summary
- add a route for the budget signature page
- link the "Assinar (Responsável)" button to that route

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_687d0fea51e0832a9e90a7abed83d67d