### PR TITLE
Add Finance tab layout

### DIFF
--- a/resources/views/components/financeiro/card.blade.php
+++ b/resources/views/components/financeiro/card.blade.php
@@ -1,0 +1,10 @@
+@props(['label', 'value', 'icon', 'color' => 'bg-blue-500'])
+<div {{ $attributes->merge(['class' => "flex items-center p-4 text-white rounded-lg $color"]) }}>
+    <div class="mr-4">
+        {!! $icon !!}
+    </div>
+    <div>
+        <p class="text-sm">{{ $label }}</p>
+        <p class="text-xl font-semibold">{{ $value }}</p>
+    </div>
+</div>

--- a/resources/views/components/financeiro/table.blade.php
+++ b/resources/views/components/financeiro/table.blade.php
@@ -1,0 +1,15 @@
+@props(['headings' => []])
+<div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-gray-200 text-sm">
+        <thead class="bg-gray-50">
+            <tr>
+                @foreach ($headings as $heading)
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">{{ $heading }}</th>
+                @endforeach
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+            {{ $slot }}
+        </tbody>
+    </table>
+</div>

--- a/resources/views/pacientes/financeiro.blade.php
+++ b/resources/views/pacientes/financeiro.blade.php
@@ -1,0 +1,184 @@
+@php
+    $orcamentos = [
+        ['id' => 101, 'data' => '01/04/2024', 'valor' => 'R$ 7.650,00', 'status' => 'Aprovado', 'profissional' => 'Dr. Paulo'],
+        ['id' => 102, 'data' => '15/05/2024', 'valor' => 'R$ 3.200,00', 'status' => 'Pendente', 'profissional' => 'Dra. Ana'],
+        ['id' => 103, 'data' => '20/05/2024', 'valor' => 'R$ 4.500,00', 'status' => 'Recusado', 'profissional' => 'Dr. João'],
+    ];
+
+    $pagamentos = [
+        ['data' => '05/04/2024', 'valor' => 'R$ 2.000,00', 'forma' => 'Cartão', 'parcela' => '1/3', 'status' => 'Pago'],
+        ['data' => '05/05/2024', 'valor' => 'R$ 2.000,00', 'forma' => 'PIX', 'parcela' => '2/3', 'status' => 'Pago'],
+        ['data' => '05/06/2024', 'valor' => 'R$ 2.000,00', 'forma' => 'PIX', 'parcela' => '3/3', 'status' => 'Pendente'],
+    ];
+
+    $faturas = [
+        ['id' => 'F001', 'valor' => 'R$ 2.000,00', 'status' => 'Pago', 'data' => '05/04/2024'],
+        ['id' => 'F002', 'valor' => 'R$ 2.000,00', 'status' => 'Pago', 'data' => '05/05/2024'],
+        ['id' => 'F003', 'valor' => 'R$ 2.000,00', 'status' => 'Aberto', 'data' => '05/06/2024'],
+    ];
+
+    $estornos = [
+        ['data' => '10/05/2024', 'valor' => 'R$ 100,00', 'motivo' => 'Ajuste de cobrança', 'metodo' => 'PIX'],
+    ];
+
+    $statusColors = [
+        'Aprovado' => 'bg-emerald-100 text-emerald-800',
+        'Pendente' => 'bg-orange-100 text-orange-800',
+        'Recusado' => 'bg-red-100 text-red-800',
+        'Pago' => 'bg-emerald-100 text-emerald-800',
+        'Vencido' => 'bg-red-100 text-red-800',
+        'Aberto' => 'bg-orange-100 text-orange-800',
+    ];
+@endphp
+<div class="space-y-6">
+    <div>
+        <h2 class="text-xl font-semibold text-gray-700">Resumo Financeiro</h2>
+        <p class="text-sm text-gray-500">{{ $paciente->nome }} {{ $paciente->ultimo_nome }} • ID {{ $paciente->id }}</p>
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <x-financeiro.card
+            label="Valor do orçamento aprovado"
+            value="R$ 7.650,00"
+            color="bg-blue-500"
+            icon="<svg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 8c-3.314 0-6 1.343-6 3s2.686 3 6 3 6-1.343 6-3-2.686-3-6-3z'/><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 11v5c0 1.657 2.686 3 6 3s6-1.343 6-3v-5'/></svg>" />
+        <x-financeiro.card
+            label="Valor total pago"
+            value="R$ 4.000,00"
+            color="bg-emerald-500"
+            icon="<svg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 8c-3.314 0-6 1.343-6 3s2.686 3 6 3 6-1.343 6-3-2.686-3-6-3z'/><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 11v5c0 1.657 2.686 3 6 3s6-1.343 6-3v-5'/></svg>" />
+        <x-financeiro.card
+            label="Saldo devedor"
+            value="R$ 3.650,00"
+            color="bg-red-500"
+            icon="<svg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 8c-3.314 0-6 1.343-6 3s2.686 3 6 3 6-1.343 6-3-2.686-3-6-3z'/><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 11v5c0 1.657 2.686 3 6 3s6-1.343 6-3v-5'/></svg>" />
+    </div>
+    <div class="space-y-4">
+        <div>
+            <h3 class="text-lg font-semibold text-gray-700">Orçamentos</h3>
+            <div class="flex flex-col sm:flex-row sm:items-end gap-4 mt-2">
+                <select class="w-full sm:w-40 rounded border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none">
+                    <option value="">Todos</option>
+                    <option value="Aprovado">Aprovado</option>
+                    <option value="Pendente">Pendente</option>
+                    <option value="Recusado">Recusado</option>
+                </select>
+                <input type="date" class="rounded border-stroke bg-gray-2 py-2 px-3 text-sm text-black focus:border-primary focus:outline-none" />
+            </div>
+        </div>
+        <x-financeiro.table :headings="['ID', 'Data', 'Valor total', 'Status', 'Profissional', 'Ações']">
+            @foreach ($orcamentos as $orcamento)
+                <tr>
+                    <td class="px-4 py-2">{{ $orcamento['id'] }}</td>
+                    <td class="px-4 py-2">{{ $orcamento['data'] }}</td>
+                    <td class="px-4 py-2">{{ $orcamento['valor'] }}</td>
+                    <td class="px-4 py-2">
+                        <span class="px-2 py-1 rounded-full text-xs {{ $statusColors[$orcamento['status']] ?? '' }}">{{ $orcamento['status'] }}</span>
+                    </td>
+                    <td class="px-4 py-2">{{ $orcamento['profissional'] }}</td>
+                    <td class="px-4 py-2 space-x-2">
+                        <a href="#" class="text-gray-600 hover:text-blue-600" title="Ver">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                            </svg>
+                        </a>
+                        <a href="#" class="text-gray-600 hover:text-blue-600" title="Editar">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m0 0a2.5 2.5 0 01-3.536 3.536L9 20.036l-4 1 1-4 6.232-6.232a2.5 2.5 0 013.536-3.536z" />
+                            </svg>
+                        </a>
+                    </td>
+                </tr>
+            @endforeach
+        </x-financeiro.table>
+    </div>
+    <div class="space-y-4">
+        <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold text-gray-700">Pagamentos</h3>
+            <a href="#" class="inline-flex items-center px-3 py-2 bg-primary text-white rounded hover:bg-primary/90 text-sm">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
+                Adicionar Pagamento
+            </a>
+        </div>
+        <x-financeiro.table :headings="['Data', 'Valor', 'Forma', 'Parcela', 'Status', 'Ações']">
+            @foreach ($pagamentos as $p)
+                <tr>
+                    <td class="px-4 py-2">{{ $p['data'] }}</td>
+                    <td class="px-4 py-2">{{ $p['valor'] }}</td>
+                    <td class="px-4 py-2">{{ $p['forma'] }}</td>
+                    <td class="px-4 py-2">{{ $p['parcela'] }}</td>
+                    <td class="px-4 py-2">
+                        @php $color = $statusColors[$p['status']] ?? 'bg-gray-100 text-gray-800'; @endphp
+                        <span class="px-2 py-1 rounded-full text-xs {{ $color }}">{{ $p['status'] }}</span>
+                    </td>
+                    <td class="px-4 py-2 space-x-2">
+                        <a href="#" class="text-gray-600 hover:text-blue-600" title="Editar">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m0 0a2.5 2.5 0 01-3.536 3.536L9 20.036l-4 1 1-4 6.232-6.232a2.5 2.5 0 013.536-3.536z" />
+                            </svg>
+                        </a>
+                        <a href="#" class="text-red-600 hover:text-red-800" title="Excluir">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M10 7V4a1 1 0 011-1h2a1 1 0 011 1v3" />
+                            </svg>
+                        </a>
+                    </td>
+                </tr>
+            @endforeach
+        </x-financeiro.table>
+    </div>
+    <div class="space-y-4">
+        <h3 class="text-lg font-semibold text-gray-700">Faturas e Recibos</h3>
+        <x-financeiro.table :headings="['ID', 'Valor', 'Status', 'Recibo', 'Data']">
+            @foreach ($faturas as $f)
+                <tr>
+                    <td class="px-4 py-2">{{ $f['id'] }}</td>
+                    <td class="px-4 py-2">{{ $f['valor'] }}</td>
+                    <td class="px-4 py-2"><span class="px-2 py-1 rounded-full text-xs {{ $statusColors[$f['status']] ?? '' }}">{{ $f['status'] }}</span></td>
+                    <td class="px-4 py-2">
+                        <a href="#" class="text-gray-600 hover:text-blue-600" title="Baixar PDF">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v16h16V4H4zm8 10v-6m0 6l-3-3m3 3l3-3" />
+                            </svg>
+                        </a>
+                    </td>
+                    <td class="px-4 py-2">{{ $f['data'] }}</td>
+                </tr>
+            @endforeach
+        </x-financeiro.table>
+    </div>
+    <div class="space-y-4">
+        <h3 class="text-lg font-semibold text-gray-700">Estornos ou Reembolsos</h3>
+        <x-financeiro.table :headings="['Data', 'Valor', 'Motivo', 'Método']">
+            @foreach ($estornos as $e)
+                <tr>
+                    <td class="px-4 py-2">{{ $e['data'] }}</td>
+                    <td class="px-4 py-2">{{ $e['valor'] }}</td>
+                    <td class="px-4 py-2">{{ $e['motivo'] }}</td>
+                    <td class="px-4 py-2">{{ $e['metodo'] }}</td>
+                </tr>
+            @endforeach
+        </x-financeiro.table>
+    </div>
+    <div class="space-y-2">
+        <h3 class="text-lg font-semibold text-gray-700">Convênio</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+            <div>
+                <span class="text-gray-500">Nome do convênio</span>
+                <p class="text-gray-900">Unimed</p>
+            </div>
+            <div>
+                <span class="text-gray-500">Carteirinha</span>
+                <p class="text-gray-900">1234567890</p>
+            </div>
+            <div>
+                <span class="text-gray-500">Coparticipação</span>
+                <p class="text-gray-900">20%</p>
+            </div>
+        </div>
+    </div>
+    <div>
+        <h3 class="text-lg font-semibold text-gray-700 mb-2">Observações Financeiras</h3>
+        <textarea class="w-full rounded border-stroke bg-gray-2 p-3 text-sm text-black focus:border-primary focus:outline-none" rows="4" placeholder="Anotações internas"></textarea>
+    </div>
+</div>

--- a/resources/views/pacientes/show.blade.php
+++ b/resources/views/pacientes/show.blade.php
@@ -166,7 +166,7 @@
         <p class="text-gray-700">Conteúdo de Documentos</p>
     </section>
     <section x-show="activeTab === 'financeiro'" x-cloak>
-        <p class="text-gray-700">Conteúdo de Financeiro</p>
+        @include('pacientes.financeiro')
     </section>
     <section x-show="activeTab === 'orcamentos'" x-cloak>
         <div class="mb-4">


### PR DESCRIPTION
## Summary
- create reusable finance components
- add finance tab content for patient view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d1c459530832a9f1ab06b6afa2484