### PR TITLE
Refactor patient budget tab to use table view

### DIFF
--- a/resources/views/pacientes/orcamentos.blade.php
+++ b/resources/views/pacientes/orcamentos.blade.php
@@ -1,0 +1,64 @@
+@php
+    $orcamentos = [
+        ['id' => 'O001', 'data' => '22/03/2024', 'valor' => 'R$ 7.650,00', 'status' => 'Aprovado'],
+        ['id' => 'O002', 'data' => '02/07/2024', 'valor' => 'R$ 5.300,00', 'status' => 'Pendente'],
+    ];
+    $statusColors = [
+        'Aprovado' => 'bg-emerald-100 text-emerald-800',
+        'Pendente' => 'bg-orange-100 text-orange-800',
+        'Recusado' => 'bg-red-100 text-red-800',
+    ];
+@endphp
+<div class="space-y-4">
+    <div class="flex items-center justify-between">
+        <div class="flex space-x-2">
+            <input type="text" placeholder="Buscar..." class="px-3 py-2 border rounded">
+            <select class="px-3 py-2 border rounded">
+                <option value="">Todos status</option>
+                <option>Aprovado</option>
+                <option>Pendente</option>
+                <option>Recusado</option>
+            </select>
+        </div>
+        <a href="#" class="inline-flex items-center px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+            </svg>
+            Gerar Novo Orçamento
+        </a>
+    </div>
+    <div class="overflow-x-auto bg-white rounded-lg shadow">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">ID</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Data</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Valor</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Status</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Ações</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @foreach ($orcamentos as $o)
+                    <tr>
+                        <td class="px-4 py-2 whitespace-nowrap">{{ $o['id'] }}</td>
+                        <td class="px-4 py-2 whitespace-nowrap">{{ $o['data'] }}</td>
+                        <td class="px-4 py-2 whitespace-nowrap">{{ $o['valor'] }}</td>
+                        <td class="px-4 py-2 whitespace-nowrap">
+                            <span class="px-2 py-1 rounded-full text-xs {{ $statusColors[$o['status']] ?? 'bg-gray-100 text-gray-800' }}">{{ $o['status'] }}</span>
+                        </td>
+                        <td class="px-4 py-2 whitespace-nowrap">
+                            <a href="#" class="text-gray-600 hover:text-blue-600" title="Visualizar">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7z" />
+                                </svg>
+                            </a>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</div>
+

--- a/resources/views/pacientes/show.blade.php
+++ b/resources/views/pacientes/show.blade.php
@@ -169,25 +169,7 @@
         @include('pacientes.financeiro')
     </section>
     <section x-show="activeTab === 'orcamentos'" x-cloak>
-        <div class="mb-4">
-            <h2 class="text-xl font-semibold text-gray-700">Orçamentos</h2>
-            <p class="text-sm text-gray-500">Propostas de tratamento e valores</p>
-        </div>
-        <a href="#" class="mb-4 inline-flex items-center px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-3.314 0-6 1.343-6 3s2.686 3 6 3 6-1.343 6-3-2.686-3-6-3z"/>
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 11v5c0 1.657 2.686 3 6 3s6-1.343 6-3v-5" />
-            </svg>
-            Gerar Novo Orçamento
-        </a>
-        @include('components.orcamento-card', [
-            'titulo' => 'Orçamento – Tratamento Ortodôntico',
-            'dataGeracao' => '22/03/2024',
-            'validade' => '30 dias',
-            'valorTotal' => 'R$ 8.500,00',
-            'desconto' => '-R$ 850,00',
-            'valorFinal' => 'R$ 7.650,00'
-        ])
+        @include('pacientes.orcamentos')
     </section>
     <section x-show="activeTab === 'agendamentos'" x-cloak>
         <p class="text-gray-700">Conteúdo de Agendamentos</p>


### PR DESCRIPTION
## Summary
- add a partial with a simple budgets table layout
- include this partial in the patient's Orçamentos tab

## Testing
- `php -l resources/views/pacientes/orcamentos.blade.php`
- `php -l resources/views/pacientes/show.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_687d20bf4b70832aaac482a2d3093951