### PR TITLE
Add weekly scheduling view

### DIFF
--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -16,7 +16,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
             </svg>
         </button>
-        <a href="#" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center">
+        <a href="{{ route('agendamentos.index') }}" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center">
             + Nova Consulta
         </a>
     </div>

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -1,0 +1,114 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Agenda', 'url' => route('agenda.index')],
+    ['label' => 'Novo Agendamento']
+]])
+<div class="mb-6">
+    <h1 class="text-2xl font-bold">Agendamentos</h1>
+    <p class="text-gray-600">Agenda semanal por profissional</p>
+</div>
+@php
+    use Illuminate\Support\Carbon;
+    $months = [1=>'Janeiro',2=>'Fevereiro',3=>'Mar\xC3\xA7o',4=>'Abril',5=>'Maio',6=>'Junho',7=>'Julho',8=>'Agosto',9=>'Setembro',10=>'Outubro',11=>'Novembro',12=>'Dezembro'];
+    $week = ['SEG','TER','QUA','QUI','SEX','SAB','DOM'];
+    $start = Carbon::now()->startOfWeek(Carbon::MONDAY);
+    $days = [];
+    for($i=0;$i<7;$i++){
+        $d = $start->copy()->addDays($i);
+        $days[] = [
+            'label'=>$week[$i],
+            'number'=>$d->day,
+            'month'=>$months[$d->month],
+            'active'=>$d->isToday(),
+            'past'=>$d->lt(Carbon::today()),
+        ];
+    }
+    $professionals = [
+        ['id'=>1,'name'=>'Dr. Jo\xC3\xA3o'],
+        ['id'=>2,'name'=>'Dra. Ana'],
+        ['id'=>3,'name'=>'Dr. Pedro'],
+    ];
+    $horarios = ['08:00','09:00','10:00','11:00','14:00','15:00','16:00'];
+    $agenda = [
+        1 => [
+            '08:00' => ['paciente'=>'Maria','tipo'=>'Consulta','contato'=>'(11) 91234-5678','status'=>'confirmado'],
+            '15:00' => ['paciente'=>'Jo\xC3\xA3o','tipo'=>'Retorno','contato'=>'(11) 99876-5432','status'=>'cancelado'],
+        ],
+        2 => [
+            '09:00' => ['paciente'=>'Ana','tipo'=>'Consulta','contato'=>'(11) 95555-4444','status'=>'confirmado'],
+            '16:00' => ['paciente'=>'Luis','tipo'=>'Consulta','contato'=>'(11) 97777-2222','status'=>'vago'],
+        ],
+        3 => [
+            '10:00' => ['paciente'=>'Pedro','tipo'=>'Consulta','contato'=>'(11) 94444-3333','status'=>'confirmado'],
+        ],
+    ];
+@endphp
+<div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2">
+        <button class="p-1 border rounded bg-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+        </button>
+        <div class="flex gap-2">
+            @foreach($days as $day)
+                <x-agenda.dia :label="$day['label']" :numero="$day['number']" :mes="$day['month']" :active="$day['active']" :past="$day['past']" />
+            @endforeach
+        </div>
+        <button class="p-1 border rounded bg-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </button>
+    </div>
+    <div class="relative">
+        <button class="p-2 border rounded bg-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+        </button>
+        <span class="absolute -top-1 -right-1 bg-red-600 text-white text-[10px] rounded-full px-1">23</span>
+    </div>
+</div>
+<div class="flex items-center gap-2 overflow-x-auto mb-4">
+    <x-agenda.profissional name="Todos os Profissionais" active />
+    @foreach($professionals as $prof)
+        <x-agenda.profissional :name="$prof['name']" />
+    @endforeach
+</div>
+<div class="flex space-x-6 border-b mb-4 text-sm">
+    <button class="pb-2 border-b-2 border-primary text-primary">Por Consult\xC3\xB3rio</button>
+    <button class="pb-2 text-gray-600">Fila de Espera</button>
+    <button class="pb-2 text-gray-600">Filtrar</button>
+</div>
+<div class="overflow-auto">
+    <table class="min-w-full text-sm">
+        <thead>
+            <tr>
+                <th class="p-2 bg-gray-50"></th>
+                @foreach($professionals as $prof)
+                    <th class="p-2 bg-gray-50 text-left whitespace-nowrap">{{ $prof['name'] }}</th>
+                @endforeach
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($horarios as $hora)
+                <tr class="border-t">
+                    <td class="bg-gray-50"><x-agenda.horario :time="$hora" /></td>
+                    @foreach($professionals as $prof)
+                        <td class="w-40 h-16">
+                            @isset($agenda[$prof['id']][$hora])
+                                @php $item = $agenda[$prof['id']][$hora]; @endphp
+                                <x-agenda.agendamento :paciente="$item['paciente']" :tipo="$item['tipo']" :contato="$item['contato']" :status="$item['status']" />
+                            @endisset
+                        </td>
+                    @endforeach
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/resources/views/components/agenda/agendamento.blade.php
+++ b/resources/views/components/agenda/agendamento.blade.php
@@ -1,0 +1,14 @@
+@props(['paciente', 'tipo', 'contato', 'status' => 'vago'])
+@php
+    $color = match($status) {
+        'confirmado' => 'bg-green-100 text-green-700',
+        'cancelado' => 'bg-red-100 text-red-700',
+        'vago' => 'bg-gray-100 text-gray-700',
+        default => 'bg-gray-100 text-gray-700',
+    };
+@endphp
+<div {{ $attributes->merge(['class' => "rounded p-2 text-xs $color"]) }}>
+    <div class="font-semibold">{{ $paciente }}</div>
+    <div>{{ $tipo }}</div>
+    <div class="text-[10px]">{{ $contato }}</div>
+</div>

--- a/resources/views/components/agenda/dia.blade.php
+++ b/resources/views/components/agenda/dia.blade.php
@@ -1,0 +1,16 @@
+@props(['label', 'numero', 'mes', 'active' => false, 'past' => false])
+@php
+    $classes = 'flex flex-col items-center p-2 rounded cursor-pointer text-xs';
+    if ($active) {
+        $classes .= ' bg-black text-white';
+    } elseif ($past) {
+        $classes .= ' text-gray-400';
+    } else {
+        $classes .= ' text-gray-700';
+    }
+@endphp
+<div {{ $attributes->merge(['class' => $classes]) }}>
+    <span class="uppercase">{{ $label }}</span>
+    <span class="font-semibold">{{ $numero }}</span>
+    <span>{{ $mes }}</span>
+</div>

--- a/resources/views/components/agenda/horario.blade.php
+++ b/resources/views/components/agenda/horario.blade.php
@@ -1,0 +1,4 @@
+@props(['time'])
+<div {{ $attributes->merge(['class' => 'p-2 text-right text-xs text-gray-500 whitespace-nowrap']) }}>
+    {{ $time }}
+</div>

--- a/resources/views/components/agenda/profissional.blade.php
+++ b/resources/views/components/agenda/profissional.blade.php
@@ -1,0 +1,6 @@
+@props(['name', 'active' => false])
+@php
+    $classes = 'px-4 py-2 rounded border text-sm whitespace-nowrap';
+    $classes .= $active ? ' bg-primary text-white' : ' bg-white text-gray-700';
+@endphp
+<button {{ $attributes->merge(['class' => $classes]) }}>{{ $name }}</button>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -13,6 +13,7 @@ Route::get('/', function () {
 })->name('admin.index');
 
 Route::view('agenda', 'agenda')->name('agenda.index');
+Route::view('agendamentos', 'agendamentos.index')->name('agendamentos.index');
 
 Route::resource('clinicas', ClinicController::class)
     ->parameters(['clinicas' => 'clinic']);


### PR DESCRIPTION
## Summary
- add route for new `agendamentos` page
- connect `Nova Consulta` button to new view
- create agenda components (`dia`, `horario`, `profissional`, `agendamento`)
- mock weekly agenda interface in `agendamentos/index.blade.php`

## Testing
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d24e5305c832a90dbf5cc34b3211d