### PR TITLE
Fix missing variables in agenda view

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -13,7 +13,7 @@ Route::get('/', function () {
     return view('dashboard');
 })->name('admin.index');
 
-Route::view('agenda', 'agenda')->name('agenda.index');
+Route::get('agenda', [AgendaController::class, 'index'])->name('agenda.index');
 Route::view('agendamentos', 'agendamentos.index')->name('agendamentos.index');
 
 


### PR DESCRIPTION
## Summary
- route the admin agenda page through `AgendaController` so `$prevDate` and other variables are defined

## Testing
- `composer check` *(fails: No lockfile found)*

------
https://chatgpt.com/codex/tasks/task_e_687d26d99b28832ab2929f23b89038dd