### PR TITLE
Fix agenda date bar width

### DIFF
--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -53,7 +53,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
             </svg>
         </button>
-        <div class="flex gap-2">
+        <div class="flex gap-2 flex-1">
             @foreach($days as $day)
                 <x-agenda.dia :label="$day['label']" :numero="$day['number']" :mes="$day['month']" :active="$day['active']" :past="$day['past']" />
             @endforeach

--- a/resources/views/components/agenda/dia.blade.php
+++ b/resources/views/components/agenda/dia.blade.php
@@ -1,6 +1,6 @@
 @props(['label', 'numero', 'mes', 'active' => false, 'past' => false])
 @php
-    $classes = 'flex flex-col items-center p-2 rounded cursor-pointer text-xs';
+    $classes = 'flex flex-col items-center p-2 rounded cursor-pointer text-xs flex-1 text-center';
     if ($active) {
         $classes .= ' bg-black text-white';
     } elseif ($past) {


### PR DESCRIPTION
## Summary
- expand date bar to full width on the admin agenda page
- make each date grow to fill available width

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2cf8a894832ab8ac4c35795f64e8