### PR TITLE
Generate random dashboard stats

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $totalPacientes = random_int(300, 500);
+        $consultasHoje = random_int(10, 40);
+        $cancelamentosHoje = random_int(0, 10);
+        $faturamentoDiario = random_int(5000, 20000);
+
+        $consultas = [
+            'agendadas' => random_int(15, 30),
+            'confirmadas' => random_int(10, 25),
+            'canceladas' => random_int(0, 5),
+        ];
+        $consultas['realizadas'] = max(0, $consultas['confirmadas'] - $consultas['canceladas']);
+
+        return view('dashboard', [
+            'totalPacientes' => $totalPacientes,
+            'consultasHoje' => $consultasHoje,
+            'cancelamentosHoje' => $cancelamentosHoje,
+            'faturamentoDiario' => 'R$ ' . number_format($faturamentoDiario, 2, ',', '.'),
+            'consultas' => $consultas,
+        ]);
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -14,25 +14,25 @@
 <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 mb-6">
     <x-dashboard.stats-card
         title="Total de Pacientes"
-        value="350"
+        :value="$totalPacientes"
         comparison="+15% em relação ao mês anterior"
         :icon="'<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 15c2.33 0 4.5.533 6.879 1.532M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>'"
     />
     <x-dashboard.stats-card
         title="Consultas Hoje"
-        value="28"
+        :value="$consultasHoje"
         comparison="+5% em relação ao mês anterior"
         :icon="'<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>'"
     />
     <x-dashboard.stats-card
         title="Cancelamentos Hoje"
-        value="3"
+        :value="$cancelamentosHoje"
         comparison="+2 em relação ao mês anterior"
         :icon="'<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m4-8a4 4 0 110 8 4 4 0 010-8z" /></svg>'"
     />
     <x-dashboard.stats-card
         title="Faturamento Diário"
-        value="R$ 12.000"
+        :value="$faturamentoDiario"
         comparison="+10% em relação ao mês anterior"
         :icon="'<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3 1.343 3 3-1.343 3-3 3m0-12V4m0 16v-4m0 4c1.657 0 3-1.343 3-3s-1.343-3-3-3-3-1.343-3-3 1.343-3 3-3" /></svg>'"
     />
@@ -40,10 +40,10 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
     <x-dashboard.chart title="Consultas do Dia">
         <ul class="mt-4 space-y-1 text-sm">
-            <li class="flex justify-between"><span>Agendadas</span><span>20</span></li>
-            <li class="flex justify-between"><span>Confirmadas</span><span>15</span></li>
-            <li class="flex justify-between"><span>Canceladas</span><span>3</span></li>
-            <li class="flex justify-between"><span>Realizadas</span><span>12</span></li>
+            <li class="flex justify-between"><span>Agendadas</span><span>{{ $consultas['agendadas'] }}</span></li>
+            <li class="flex justify-between"><span>Confirmadas</span><span>{{ $consultas['confirmadas'] }}</span></li>
+            <li class="flex justify-between"><span>Canceladas</span><span>{{ $consultas['canceladas'] }}</span></li>
+            <li class="flex justify-between"><span>Realizadas</span><span>{{ $consultas['realizadas'] }}</span></li>
         </ul>
     </x-dashboard.chart>
     <x-dashboard.chart title="Ocupação Semanal">

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -8,10 +8,9 @@ use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Admin\FormularioController;
 use App\Http\Controllers\Admin\PatientController;
 use App\Http\Controllers\Admin\AgendaController;
+use App\Http\Controllers\Admin\DashboardController;
 
-Route::get('/', function () {
-    return view('dashboard');
-})->name('admin.index');
+Route::get('/', [DashboardController::class, 'index'])->name('admin.index');
 
 Route::get('agenda', [AgendaController::class, 'index'])->name('agenda.index');
 Route::view('agendamentos', 'agendamentos.index')->name('agendamentos.index');


### PR DESCRIPTION
## Summary
- create `DashboardController` to supply random data
- route dashboard through controller
- render stats and charts with passed values

## Testing
- `php -l routes/admin.php app/Http/Controllers/Admin/DashboardController.php`

------
https://chatgpt.com/codex/tasks/task_e_687d3b26f374832a9839dda2b63aab1e