### PR TITLE
Replace dashboard stats-card component with HTML

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -12,30 +12,54 @@
     </div>
 </div>
 <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 mb-6">
-    <x-dashboard.stats-card
-        title="Total de Pacientes"
-        value="350"
-        comparison="+15% em relação ao mês anterior"
-        :icon="'<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 15c2.33 0 4.5.533 6.879 1.532M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>'"
-    />
-    <x-dashboard.stats-card
-        title="Consultas Hoje"
-        value="28"
-        comparison="+5% em relação ao mês anterior"
-        :icon="'<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>'"
-    />
-    <x-dashboard.stats-card
-        title="Cancelamentos Hoje"
-        value="3"
-        comparison="+2 em relação ao mês anterior"
-        :icon="'<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m4-8a4 4 0 110 8 4 4 0 010-8z" /></svg>'"
-    />
-    <x-dashboard.stats-card
-        title="Faturamento Diário"
-        value="R$ 12.000"
-        comparison="+10% em relação ao mês anterior"
-        :icon="'<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3 1.343 3 3-1.343 3-3 3m0-12V4m0 16v-4m0 4c1.657 0 3-1.343 3-3s-1.343-3-3-3-3-1.343-3-3 1.343-3 3-3" /></svg>'"
-    />
+    <div class="rounded-sm border border-stroke bg-white p-5 shadow">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-sm text-gray-500">Total de Pacientes</p>
+                <p class="mt-1 text-xl font-bold text-black">350</p>
+            </div>
+            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 15c2.33 0 4.5.533 6.879 1.532M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+            </div>
+        </div>
+        <p class="mt-2 text-xs text-gray-500">+15% em relação ao mês anterior</p>
+    </div>
+    <div class="rounded-sm border border-stroke bg-white p-5 shadow">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-sm text-gray-500">Consultas Hoje</p>
+                <p class="mt-1 text-xl font-bold text-black">28</p>
+            </div>
+            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+            </div>
+        </div>
+        <p class="mt-2 text-xs text-gray-500">+5% em relação ao mês anterior</p>
+    </div>
+    <div class="rounded-sm border border-stroke bg-white p-5 shadow">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-sm text-gray-500">Cancelamentos Hoje</p>
+                <p class="mt-1 text-xl font-bold text-black">3</p>
+            </div>
+            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m4-8a4 4 0 110 8 4 4 0 010-8z" /></svg>
+            </div>
+        </div>
+        <p class="mt-2 text-xs text-gray-500">+2 em relação ao mês anterior</p>
+    </div>
+    <div class="rounded-sm border border-stroke bg-white p-5 shadow">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-sm text-gray-500">Faturamento Diário</p>
+                <p class="mt-1 text-xl font-bold text-black">R$ 12.000</p>
+            </div>
+            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3 1.343 3 3-1.343 3-3 3m0-12V4m0 16v-4m0 4c1.657 0 3-1.343 3-3s-1.343-3-3-3-3-1.343-3-3 1.343-3 3-3" /></svg>
+            </div>
+        </div>
+        <p class="mt-2 text-xs text-gray-500">+10% em relação ao mês anterior</p>
+    </div>
 </div>
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
     <x-dashboard.chart title="Consultas do Dia">


### PR DESCRIPTION
## Summary
- replace `<x-dashboard.stats-card>` usages in dashboard with plain HTML markup

## Testing
- `php -l resources/views/dashboard.blade.php`

------
https://chatgpt.com/codex/tasks/task_e_687d37ad542c832a8363696fafca1281