### PR TITLE
Implement simple canvas charts

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -72,4 +72,92 @@ document.addEventListener('DOMContentLoaded', () => {
                 .catch(() => {});
         });
     });
+
+    const charts = [
+        {
+            id: 'consultas-do-dia',
+            type: 'bar',
+            labels: ['Agendadas', 'Confirmadas', 'Canceladas', 'Realizadas'],
+            data: [20, 15, 3, 12],
+            color: '#60a5fa'
+        },
+        {
+            id: 'ocupacao-semanal',
+            type: 'line',
+            labels: ['Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom'],
+            data: [70, 65, 75, 80, 78, 60, 50],
+            color: '#34d399'
+        },
+        {
+            id: 'taxa-de-cancelamentos-e-faltas-30-dias',
+            type: 'line',
+            labels: ['1-5', '6-10', '11-15', '16-20', '21-25', '26-30'],
+            data: [2, 1, 3, 1, 2, 0],
+            color: '#f87171'
+        },
+        {
+            id: 'principais-procedimentos',
+            type: 'bar',
+            labels: ['Limpeza', 'Restauração', 'Extração', 'Clareamento', 'Canal'],
+            data: [15, 10, 5, 8, 7],
+            color: '#818cf8'
+        }
+    ];
+
+    charts.forEach(cfg => {
+        const canvas = document.getElementById(cfg.id);
+        if (!canvas) return;
+        const ctx = canvas.getContext('2d');
+        if (cfg.type === 'bar') {
+            drawBarChart(ctx, cfg.labels, cfg.data, cfg.color);
+        } else {
+            drawLineChart(ctx, cfg.labels, cfg.data, cfg.color);
+        }
+    });
 });
+
+function drawBarChart(ctx, labels, data, color) {
+    const { width, height } = ctx.canvas;
+    const max = Math.max(...data);
+    const barWidth = width / data.length;
+    ctx.clearRect(0, 0, width, height);
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    data.forEach((val, i) => {
+        const h = (val / max) * (height - 20);
+        const x = i * barWidth + barWidth * 0.1;
+        const y = height - h - 10;
+        ctx.fillStyle = color;
+        ctx.fillRect(x, y, barWidth * 0.8, h);
+        ctx.fillStyle = '#374151';
+        ctx.fillText(labels[i], i * barWidth + barWidth / 2, height - 2);
+    });
+}
+
+function drawLineChart(ctx, labels, data, color) {
+    const { width, height } = ctx.canvas;
+    const max = Math.max(...data);
+    const stepX = width / (data.length - 1);
+    ctx.clearRect(0, 0, width, height);
+    ctx.beginPath();
+    data.forEach((val, i) => {
+        const x = i * stepX;
+        const y = height - (val / max) * (height - 20) - 10;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+    ctx.fillStyle = color;
+    data.forEach((val, i) => {
+        const x = i * stepX;
+        const y = height - (val / max) * (height - 20) - 10;
+        ctx.beginPath();
+        ctx.arc(x, y, 3, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = '#374151';
+        ctx.fillText(labels[i], x, height - 2);
+    });
+}
+

--- a/resources/views/components/dashboard/chart.blade.php
+++ b/resources/views/components/dashboard/chart.blade.php
@@ -1,11 +1,16 @@
-@props(['title'])
+@props(['title', 'chartId' => null])
+
+@php
+    $id = $chartId ?: \Illuminate\Support\Str::slug($title);
+@endphp
+
 <div class="bg-white rounded-lg shadow p-4">
     <div class="mb-2 flex items-center justify-between">
         <h3 class="text-lg font-semibold text-gray-700">{{ $title }}</h3>
         {{ $header ?? '' }}
     </div>
-<div class="h-64">
-        <canvas></canvas>
+    <div class="h-64">
+        <canvas id="{{ $id }}"></canvas>
     </div>
     {{ $slot ?? '' }}
 </div>


### PR DESCRIPTION
## Summary
- add chart IDs to chart component
- draw basic bar and line charts in app.js using `<canvas>`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d3dc3d108832abdc206ea0bf80bb4