### PR TITLE
Add employee scheduling system

### DIFF
--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\BelongsToOrganization;
+use App\Traits\BelongsToClinic;
+
+class Appointment extends Model
+{
+    use BelongsToOrganization, BelongsToClinic;
+
+    protected $fillable = [
+        'organization_id',
+        'clinic_id',
+        'cadeira_id',
+        'patient_id',
+        'user_id',
+        'starts_at',
+        'ends_at',
+    ];
+
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+    ];
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class);
+    }
+
+    public function cadeira()
+    {
+        return $this->belongsTo(Cadeira::class);
+    }
+
+    public function patient()
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function organization()
+    {
+        return $this->belongsTo(Organization::class);
+    }
+}

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -42,6 +42,16 @@ class Clinic extends Model
         return $this->hasMany(Cadeira::class);
     }
 
+    public function workSchedules()
+    {
+        return $this->hasMany(WorkSchedule::class);
+    }
+
+    public function appointments()
+    {
+        return $this->hasMany(Appointment::class);
+    }
+
     public function organization()
     {
         return $this->belongsTo(Organization::class);

--- a/app/Models/ClinicUser.php
+++ b/app/Models/ClinicUser.php
@@ -12,4 +12,9 @@ class ClinicUser extends Pivot
     {
         return $this->belongsTo(Profile::class);
     }
+
+    public function employeeContracts()
+    {
+        return $this->hasMany(EmployeeContract::class);
+    }
 }

--- a/app/Models/EmployeeContract.php
+++ b/app/Models/EmployeeContract.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\BelongsToOrganization;
+
+class EmployeeContract extends Model
+{
+    use BelongsToOrganization;
+
+    protected $fillable = [
+        'organization_id',
+        'clinic_user_id',
+        'tipo_contrato',
+        'data_inicio',
+        'data_fim',
+    ];
+
+    protected $casts = [
+        'data_inicio' => 'date',
+        'data_fim' => 'date',
+    ];
+
+    public function clinicUser()
+    {
+        return $this->belongsTo(ClinicUser::class);
+    }
+
+    public function organization()
+    {
+        return $this->belongsTo(Organization::class);
+    }
+}

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -42,4 +42,9 @@ class Patient extends Model
     {
         return $this->belongsTo(Organization::class);
     }
+
+    public function appointments()
+    {
+        return $this->hasMany(Appointment::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -70,6 +70,16 @@ class User extends Authenticatable
             ->withTimestamps();
     }
 
+    public function workSchedules()
+    {
+        return $this->hasMany(WorkSchedule::class);
+    }
+
+    public function appointments()
+    {
+        return $this->hasMany(Appointment::class);
+    }
+
     public function isSuperAdmin(): bool
     {
         return $this->profiles()->where('nome', 'Super Administrador')->exists();

--- a/app/Models/WorkSchedule.php
+++ b/app/Models/WorkSchedule.php
@@ -5,17 +5,18 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use App\Traits\BelongsToOrganization;
 use App\Traits\BelongsToClinic;
-use App\Models\Organization;
 
-class Cadeira extends Model
+class WorkSchedule extends Model
 {
     use BelongsToOrganization, BelongsToClinic;
 
     protected $fillable = [
-        'clinic_id',
         'organization_id',
-        'nome',
-        'status',
+        'clinic_id',
+        'user_id',
+        'dia_semana',
+        'hora_inicio',
+        'hora_fim',
     ];
 
     public function clinic()
@@ -23,13 +24,13 @@ class Cadeira extends Model
         return $this->belongsTo(Clinic::class);
     }
 
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
     public function organization()
     {
         return $this->belongsTo(Organization::class);
-    }
-
-    public function appointments()
-    {
-        return $this->hasMany(Appointment::class);
     }
 }

--- a/database/migrations/2025_08_20_000000_create_employee_contracts_table.php
+++ b/database/migrations/2025_08_20_000000_create_employee_contracts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('employee_contracts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_id')->constrained('organizations');
+            $table->foreignId('clinic_user_id')->constrained('clinic_user');
+            $table->string('tipo_contrato');
+            $table->date('data_inicio');
+            $table->date('data_fim')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_contracts');
+    }
+};

--- a/database/migrations/2025_08_20_000001_create_work_schedules_table.php
+++ b/database/migrations/2025_08_20_000001_create_work_schedules_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('work_schedules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_id')->constrained('organizations');
+            $table->foreignId('clinic_id')->constrained('clinics');
+            $table->foreignId('user_id')->constrained('users');
+            $table->enum('dia_semana', ['segunda', 'terca', 'quarta', 'quinta', 'sexta', 'sabado', 'domingo']);
+            $table->time('hora_inicio');
+            $table->time('hora_fim');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('work_schedules');
+    }
+};

--- a/database/migrations/2025_08_20_000002_create_appointments_table.php
+++ b/database/migrations/2025_08_20_000002_create_appointments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('appointments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_id')->constrained('organizations');
+            $table->foreignId('clinic_id')->constrained('clinics');
+            $table->foreignId('cadeira_id')->nullable()->constrained('cadeiras');
+            $table->foreignId('patient_id')->constrained('patients');
+            $table->foreignId('user_id')->constrained('users');
+            $table->dateTime('starts_at');
+            $table->dateTime('ends_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('appointments');
+    }
+};


### PR DESCRIPTION
## Summary
- add `EmployeeContract`, `WorkSchedule`, and `Appointment` models
- create migrations for employee contracts, work schedules and appointments
- link schedules and appointments to clinics, users, patients and chairs

## Testing
- `php -l app/Models/EmployeeContract.php`
- `php -l app/Models/WorkSchedule.php`
- `php -l app/Models/Appointment.php`
- `php -l database/migrations/2025_08_20_000000_create_employee_contracts_table.php`
- `php -l database/migrations/2025_08_20_000001_create_work_schedules_table.php`
- `php -l database/migrations/2025_08_20_000002_create_appointments_table.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e5e984d2c832aa1725bfd32b8c3ca