### PR TITLE
Add clinic allocation and scheduling tabs for professionals

### DIFF
--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Horario;
 use App\Models\Cadeira;
+use App\Models\ClinicaProfissional;
+use App\Models\HorarioProfissional;
 use App\Traits\BelongsToOrganization;
 use App\Models\Organization;
 use App\Models\ClinicUser;
@@ -40,6 +42,16 @@ class Clinic extends Model
     public function cadeiras()
     {
         return $this->hasMany(Cadeira::class);
+    }
+
+    public function clinicasProfissional()
+    {
+        return $this->hasMany(ClinicaProfissional::class, 'clinica_id');
+    }
+
+    public function horariosProfissional()
+    {
+        return $this->hasMany(HorarioProfissional::class, 'clinica_id');
     }
 
     public function organization()

--- a/app/Models/ClinicaProfissional.php
+++ b/app/Models/ClinicaProfissional.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ClinicaProfissional extends Model
+{
+    protected $table = 'clinica_profissional';
+
+    protected $fillable = [
+        'clinica_id',
+        'profissional_id',
+        'status',
+        'comissao',
+    ];
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class, 'clinica_id');
+    }
+
+    public function profissional()
+    {
+        return $this->belongsTo(User::class, 'profissional_id');
+    }
+}

--- a/app/Models/HorarioProfissional.php
+++ b/app/Models/HorarioProfissional.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class HorarioProfissional extends Model
+{
+    protected $table = 'horarios_profissional';
+
+    protected $fillable = [
+        'clinica_id',
+        'profissional_id',
+        'dia_semana',
+        'hora_inicio',
+        'hora_fim',
+    ];
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class, 'clinica_id');
+    }
+
+    public function profissional()
+    {
+        return $this->belongsTo(User::class, 'profissional_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,8 @@ use App\Models\Organization;
 use App\Models\ClinicUser;
 use App\Models\Permission;
 use App\Models\Patient;
+use App\Models\ClinicaProfissional;
+use App\Models\HorarioProfissional;
 
 class User extends Authenticatable
 {
@@ -74,6 +76,16 @@ class User extends Authenticatable
     public function patient()
     {
         return $this->hasOne(Patient::class);
+    }
+
+    public function clinicasProfissional()
+    {
+        return $this->hasMany(ClinicaProfissional::class, 'profissional_id');
+    }
+
+    public function horariosProfissional()
+    {
+        return $this->hasMany(HorarioProfissional::class, 'profissional_id');
     }
 
     public function isSuperAdmin(): bool

--- a/database/migrations/2025_07_21_000001_create_clinica_profissional_table.php
+++ b/database/migrations/2025_07_21_000001_create_clinica_profissional_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('clinica_profissional', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinica_id')->constrained('clinics');
+            $table->foreignId('profissional_id')->constrained('users');
+            $table->enum('status', ['Ativo', 'Inativo'])->default('Ativo');
+            $table->decimal('comissao', 5, 2)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clinica_profissional');
+    }
+};

--- a/database/migrations/2025_07_21_000002_create_horarios_profissional_table.php
+++ b/database/migrations/2025_07_21_000002_create_horarios_profissional_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('horarios_profissional', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinica_id')->constrained('clinics');
+            $table->foreignId('profissional_id')->constrained('users');
+            $table->enum('dia_semana', ['segunda', 'terca', 'quarta', 'quinta', 'sexta', 'sabado', 'domingo']);
+            $table->time('hora_inicio');
+            $table->time('hora_fim');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('horarios_profissional');
+    }
+};

--- a/resources/views/admin/professionals/create.blade.php
+++ b/resources/views/admin/professionals/create.blade.php
@@ -17,8 +17,14 @@
             </ul>
         </div>
     @endif
-    <form method="POST" action="{{ route('profissionais.store') }}" enctype="multipart/form-data" class="space-y-6">
+    <form method="POST" action="{{ route('profissionais.store') }}" enctype="multipart/form-data" class="space-y-6" x-data="{ tab: 'dados', horarioClinic: '' }">
         @csrf
+        <div class="mb-4 border-b flex gap-4">
+            <button type="button" @click="tab='dados'" :class="tab==='dados' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Dados</button>
+            <button type="button" @click="tab='clinicas'" :class="tab==='clinicas' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Clínicas</button>
+            <button type="button" @click="tab='horarios'" :class="tab==='horarios' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Horários</button>
+        </div>
+        <div x-show="tab==='dados'" class="space-y-6">
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Dados do Profissional</h2>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -146,6 +152,73 @@
                     </div>
                 </div>
             </template>
+        </div>
+        </div> <!-- end dados tab -->
+        <div x-show="tab==='clinicas'" class="space-y-4">
+            @foreach ($clinics as $clinic)
+                <div class="border rounded p-4 space-y-2">
+                    <div class="flex items-center gap-2">
+                        <input type="checkbox" name="clinicas[{{ $clinic->id }}][selected]" value="1" class="rounded">
+                        <span class="font-medium text-sm">{{ $clinic->nome }}</span>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <label class="text-sm block mb-1">Comissão (%)</label>
+                            <input type="number" step="0.01" name="clinicas[{{ $clinic->id }}][comissao]" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm">
+                        </div>
+                        <div>
+                            <label class="text-sm block mb-1">Status</label>
+                            <select name="clinicas[{{ $clinic->id }}][status]" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm">
+                                <option value="Ativo">Ativo</option>
+                                <option value="Inativo">Inativo</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+            <div class="space-y-2">
+                <label class="inline-flex items-center text-sm">
+                    <input type="checkbox" name="compartilhar_agenda" value="1" class="rounded mr-2"> Compartilhar agenda entre clínicas
+                </label>
+                <label class="inline-flex items-center text-sm">
+                    <input type="checkbox" name="comissao_unica" value="1" class="rounded mr-2"> Usar a mesma comissão em todas as clínicas
+                </label>
+            </div>
+        </div>
+
+        <div x-show="tab==='horarios'" class="space-y-4" x-cloak>
+            <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700">Clínica</label>
+                <select x-model="horarioClinic" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm">
+                    <option value="">Selecione</option>
+                    @foreach ($clinics as $clinic)
+                        <option value="{{ $clinic->id }}">{{ $clinic->nome }}</option>
+                    @endforeach
+                </select>
+            </div>
+            @php
+                $diasSemana = [
+                    'segunda' => 'Segunda',
+                    'terca' => 'Terça',
+                    'quarta' => 'Quarta',
+                    'quinta' => 'Quinta',
+                    'sexta' => 'Sexta',
+                    'sabado' => 'Sábado',
+                    'domingo' => 'Domingo',
+                ];
+            @endphp
+            @foreach ($clinics as $clinic)
+                <div x-show="horarioClinic == '{{ $clinic->id }}'" x-cloak class="space-y-2">
+                    @foreach ($diasSemana as $diaKey => $diaLabel)
+                        <div class="flex items-center gap-2">
+                            <input type="checkbox" name="horarios[{{ $clinic->id }}][{{ $diaKey }}][ativo]" class="rounded">
+                            <span class="w-28 text-sm">{{ $diaLabel }}</span>
+                            <input type="time" name="horarios[{{ $clinic->id }}][{{ $diaKey }}][hora_inicio]" class="border rounded px-2 py-1 text-sm">
+                            <input type="time" name="horarios[{{ $clinic->id }}][{{ $diaKey }}][hora_fim]" class="border rounded px-2 py-1 text-sm">
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
         </div>
         <div class="flex justify-end pt-4">
             <button type="submit" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700">Salvar</button>


### PR DESCRIPTION
## Summary
- add models and migrations for clinic-professional associations and schedules
- extend user and clinic models with new relations
- update professional controller to handle clinic and schedule data
- implement tabbed UI for managing clinics and schedules on professional creation page

## Testing
- `php -l app/Models/ClinicaProfissional.php`
- `php -l app/Models/HorarioProfissional.php`
- `php -l database/migrations/2025_07_21_000001_create_clinica_profissional_table.php`
- `php -l database/migrations/2025_07_21_000002_create_horarios_profissional_table.php`
- `php -l app/Http/Controllers/Admin/ProfessionalController.php`
- `php -l resources/views/admin/professionals/create.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_687e8e727890832ab025e7e6a0de91ae