### PR TITLE
Add cargo and specialty fields

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -47,6 +47,8 @@ class ProfessionalController extends Controller
             'cpf' => 'nullable',
             'dentista' => 'nullable|boolean',
             'cro' => 'required_if:dentista,1|nullable',
+            'cargo' => 'nullable',
+            'especialidade' => 'nullable',
             'profiles' => 'required|array|min:1',
             'profiles.*.profile_id' => 'required|exists:profiles,id',
             'profiles.*.clinic_id' => 'required|exists:clinics,id',
@@ -83,6 +85,8 @@ class ProfessionalController extends Controller
         $user->cpf = $data['cpf'] ?? null;
         $user->dentista = $data['dentista'] ?? true;
         $user->cro = $data['cro'] ?? null;
+        $user->cargo = $data['cargo'] ?? null;
+        $user->especialidade = $data['especialidade'] ?? null;
         $user->organization_id = auth()->user()->organization_id;
         $user->password = Hash::make($password);
         $user->must_change_password = true;
@@ -174,6 +178,8 @@ class ProfessionalController extends Controller
             'cpf' => 'nullable',
             'dentista' => 'nullable|boolean',
             'cro' => 'required_if:dentista,1|nullable',
+            'cargo' => 'nullable',
+            'especialidade' => 'nullable',
             'profiles' => 'required|array|min:1',
             'profiles.*.profile_id' => 'required|exists:profiles,id',
             'profiles.*.clinic_id' => 'required|exists:clinics,id',
@@ -207,6 +213,8 @@ class ProfessionalController extends Controller
         $profissional->cpf = $data['cpf'] ?? null;
         $profissional->dentista = $data['dentista'] ?? true;
         $profissional->cro = $data['cro'] ?? null;
+        $profissional->cargo = $data['cargo'] ?? null;
+        $profissional->especialidade = $data['especialidade'] ?? null;
 
         if ($request->filled('password')) {
             $profissional->password = Hash::make($data['password']);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,6 +36,8 @@ class User extends Authenticatable
         'cpf',
         'dentista',
         'cro',
+        'cargo',
+        'especialidade',
         'photo_path',
         'password',
         'organization_id',

--- a/database/migrations/2025_08_17_000000_add_cargo_especialidade_to_users_table.php
+++ b/database/migrations/2025_08_17_000000_add_cargo_especialidade_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('cargo')->nullable()->after('cro');
+            $table->string('especialidade')->nullable()->after('cargo');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['cargo', 'especialidade']);
+        });
+    }
+};

--- a/resources/views/admin/professionals/create.blade.php
+++ b/resources/views/admin/professionals/create.blade.php
@@ -153,11 +153,18 @@
             <div class="rounded-sm border border-stroke bg-gray-50 p-4">
                 <h2 class="mb-4 text-sm font-medium text-gray-700">Dados Profissionais</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div class="sm:col-span-2">
+                        <label class="mb-2 block text-sm font-medium text-gray-700">Cargo</label>
+                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cargo" value="{{ old('cargo') }}" />
+                    </div>
                     <div class="sm:col-span-2" x-data="{ dentista: {{ old('dentista') ? 'true' : 'false' }} }">
                         <label class="inline-flex items-center gap-2 mb-2 text-sm font-medium text-gray-700">
                             <input type="checkbox" name="dentista" x-model="dentista" value="1" class="rounded" @checked(old('dentista')) /> Dentista
                         </label>
-                        <input x-bind:required="dentista" x-show="dentista" x-cloak class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cro" placeholder="CRO" value="{{ old('cro') }}" />
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4" x-show="dentista" x-cloak>
+                            <input x-bind:required="dentista" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cro" placeholder="CRO" value="{{ old('cro') }}" />
+                            <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="especialidade" placeholder="Especialidade" value="{{ old('especialidade') }}" />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/views/admin/professionals/edit.blade.php
+++ b/resources/views/admin/professionals/edit.blade.php
@@ -44,11 +44,18 @@
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Dados Profissionais</h2>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div class="sm:col-span-2">
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Cargo</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cargo" value="{{ old('cargo', $profissional->cargo) }}" />
+                </div>
                 <div class="sm:col-span-2" x-data="{ dentista: {{ old('dentista', $profissional->dentista) ? 'true' : 'false' }} }">
                     <label class="inline-flex items-center gap-2 mb-2 text-sm font-medium text-gray-700">
                         <input type="checkbox" name="dentista" x-model="dentista" value="1" class="rounded" @checked(old('dentista', $profissional->dentista)) /> Dentista
                     </label>
-                    <input x-bind:required="dentista" x-show="dentista" x-cloak class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cro" placeholder="CRO" value="{{ old('cro', $profissional->cro) }}" />
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4" x-show="dentista" x-cloak>
+                        <input x-bind:required="dentista" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cro" placeholder="CRO" value="{{ old('cro', $profissional->cro) }}" />
+                        <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="especialidade" placeholder="Especialidade" value="{{ old('especialidade', $profissional->especialidade) }}" />
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add migration for cargo and especialidade
- allow cargo and especialidade in user model
- handle new fields in professional controller
- expose Cargo field and show CRO/Especialidade inputs when Dentista is checked

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e96244294832aabebd171a1b565ab