### PR TITLE
Replace professionals card components

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -18,7 +18,7 @@ class ProfessionalController extends Controller
     public function index()
     {
         $users = User::where('dentista', true)->get();
-        return view('admin.professionals.index', compact('users'));
+        return view('admin.profissionais.index', compact('users'));
     }
 
     public function create()

--- a/resources/views/admin/profissionais/index.blade.php
+++ b/resources/views/admin/profissionais/index.blade.php
@@ -1,0 +1,168 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Profissionais']
+]])
+@php
+    $total = $users->count();
+    $dentistas = $users->where('dentista', true)->count();
+    $auxiliares = $total - $dentistas;
+@endphp
+<div class="mb-6 flex items-start justify-between">
+    <div>
+        <h1 class="text-2xl font-bold">Profissionais</h1>
+        <p class="text-gray-600">Gestão de profissionais e funcionários</p>
+    </div>
+    <div class="flex items-center space-x-2">
+        <a href="{{ route('profissionais.create') }}" class="py-2 px-4 bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center">
+            + Novo Profissional
+        </a>
+        <div x-data="{ open: false }" class="relative">
+            <button @click="open = !open" type="button" class="py-2 px-4 bg-white border rounded flex items-center text-sm hover:bg-gray-50">
+                Relatórios
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+            <div x-show="open" @click.away="open = false" x-cloak class="absolute right-0 mt-2 w-40 bg-white border rounded shadow">
+                <a href="#" class="block px-4 py-2 text-sm hover:bg-gray-100">Exportar CSV</a>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+    <div class="rounded-sm border border-stroke bg-white p-5 shadow">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-sm text-gray-500">Total de Profissionais</p>
+                <p class="mt-1 text-xl font-bold text-black">{{ $total }}</p>
+            </div>
+            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m4-8a4 4 0 110 8 4 4 0 010-8z" />
+                </svg>
+            </div>
+        </div>
+        <p class="mt-2 text-xs text-gray-500">{{ $dentistas . ' Dentistas | ' . $auxiliares . ' Auxiliares' }}</p>
+    </div>
+    <div class="rounded-sm border border-stroke bg-white p-5 shadow">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-sm text-gray-500">Atendimentos (último mês)</p>
+                <p class="mt-1 text-xl font-bold text-black">{{ $atendimentosMes ?? 0 }}</p>
+            </div>
+            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+            </div>
+        </div>
+        @if($variacaoAtendimentos ?? null)
+            <p class="mt-2 text-xs text-gray-500">{{ $variacaoAtendimentos }}</p>
+        @endif
+    </div>
+    <div class="rounded-sm border border-stroke bg-white p-5 shadow">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-sm text-gray-500">Comissões (total do mês)</p>
+                <p class="mt-1 text-xl font-bold text-black">{{ isset($totalComissoes) ? 'R$ '.number_format($totalComissoes, 2, ',', '.') : 'R$ 0,00' }}</p>
+            </div>
+            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3 1.343 3 3-1.343 3-3 3m0-12V4m0 16v-4m0 4c1.657 0 3-1.343 3-3s-1.343-3-3-3-3-1.343-3-3 1.343-3 3-3" />
+                </svg>
+            </div>
+        </div>
+        @if(isset($mediaComissao))
+            <p class="mt-2 text-xs text-gray-500">Média por profissional: R$ {{ number_format($mediaComissao, 2, ',', '.') }}</p>
+        @endif
+    </div>
+</div>
+<form method="GET" class="mb-4">
+    <select name="clinica_id" onchange="this.form.submit()" class="border rounded px-3 py-2 text-sm">
+        <option value="">Todas as Clínicas</option>
+        @foreach(($clinics ?? []) as $clinic)
+            <option value="{{ $clinic->id }}" @selected(request('clinica_id') == $clinic->id)>{{ $clinic->nome }}</option>
+        @endforeach
+    </select>
+</form>
+<div class="bg-white rounded-lg shadow">
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Profissional</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Cargo</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Clínicas</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Contato</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Comissão</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-500 uppercase">Atendimentos</th>
+                    <th class="px-4 py-2 text-center font-medium text-gray-500 uppercase">Ações</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @forelse ($users as $profissional)
+                    <tr>
+                        <td class="px-4 py-2">
+                            <div class="flex items-center space-x-2">
+                                <img src="{{ $profissional->photo_path ? asset('storage/'.$profissional->photo_path) : 'https://via.placeholder.com/40' }}" class="w-10 h-10 rounded-full object-cover" alt="Foto">
+                                <div>
+                                    <div class="font-medium text-gray-700">{{ $profissional->name }}</div>
+                                    @if($profissional->especialidade)
+                                        <div class="text-xs text-gray-500">{{ $profissional->especialidade }}</div>
+                                    @endif
+                                </div>
+                            </div>
+                        </td>
+                        <td class="px-4 py-2">{{ $profissional->cargo ?? ($profissional->dentista ? 'Dentista' : 'Auxiliar') }}</td>
+                        <td class="px-4 py-2 space-x-1">
+                            @foreach($profissional->clinics as $c)
+                                <span class="inline-block px-2 py-1 bg-gray-100 rounded text-xs">{{ $c->nome }}</span>
+                            @endforeach
+                        </td>
+                        <td class="px-4 py-2">
+                            <div>{{ $profissional->email }}</div>
+                            <div class="text-xs text-gray-500">{{ $profissional->phone }}</div>
+                        </td>
+                        <td class="px-4 py-2">
+                            @php $cp = $profissional->clinicasProfissional->firstWhere('clinica_id', request('clinica_id')); @endphp
+                            {{ $cp?->comissao ? $cp->comissao.'%' : '-' }}
+                        </td>
+                        <td class="px-4 py-2 text-center">{{ $profissional->atendimentos_mes ?? 0 }}</td>
+                        <td class="px-4 py-2">
+                            <div class="flex items-center justify-center space-x-2">
+                                <a href="#" class="text-gray-600 hover:text-blue-600" title="Ver Perfil">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 15c2.33 0 4.5.533 6.879 1.532M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                                    </svg>
+                                </a>
+                                <a href="#" class="text-gray-600 hover:text-blue-600" title="Ver Agenda">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                    </svg>
+                                </a>
+                                <a href="#" class="text-gray-600 hover:text-blue-600" title="Ver Pagamentos">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3 1.343 3 3-1.343 3-3 3m0-12V4m0 16v-4m0 4c1.657 0 3-1.343 3-3s-1.343-3-3-3-3-1.343-3-3 1.343-3 3-3" />
+                                    </svg>
+                                </a>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="7" class="px-4 py-2 text-center">Nenhum profissional cadastrado.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+    @if(method_exists($users, 'links'))
+        <div class="p-4">
+            {{ $users->links() }}
+        </div>
+    @endif
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- refactor professional index view to use raw div elements for summary cards

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9a506914832aabfe2cadd6cb4c1e