### PR TITLE
Remove password/profile inputs for professionals

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
-use App\Models\Profile;
-use App\Models\Clinic;
 use App\Models\ClinicaProfissional;
 use App\Models\HorarioProfissional;
 use App\Models\Horario;
@@ -23,9 +21,8 @@ class ProfessionalController extends Controller
 
     public function create()
     {
-        $profiles = Profile::all();
         $clinics = auth()->user()->organization->clinics ?? [];
-        return view('admin.professionals.create', compact('profiles', 'clinics'));
+        return view('admin.professionals.create', compact('clinics'));
     }
 
     public function store(Request $request)
@@ -49,9 +46,6 @@ class ProfessionalController extends Controller
             'cro' => 'required_if:dentista,1|nullable',
             'cargo' => 'nullable',
             'especialidade' => 'nullable',
-            'profiles' => 'required|array|min:1',
-            'profiles.*.profile_id' => 'required|exists:profiles,id',
-            'profiles.*.clinic_id' => 'required|exists:clinics,id',
             'photo' => 'nullable|image',
             'clinicas' => 'nullable|array',
             'clinicas.*.comissao' => 'nullable|numeric',
@@ -105,9 +99,6 @@ class ProfessionalController extends Controller
 
         $user->save();
 
-        foreach ($data['profiles'] as $pair) {
-            $user->clinics()->attach($pair['clinic_id'], ['profile_id' => $pair['profile_id']]);
-        }
 
         if (!empty($data['clinicas'])) {
             foreach ($data['clinicas'] as $clinicId => $info) {
@@ -154,9 +145,8 @@ class ProfessionalController extends Controller
 
     public function edit(User $profissional)
     {
-        $profiles = Profile::all();
         $clinics = auth()->user()->organization->clinics ?? [];
-        return view('admin.professionals.edit', compact('profissional', 'profiles', 'clinics'));
+        return view('admin.professionals.edit', compact('profissional', 'clinics'));
     }
 
     public function update(Request $request, User $profissional)
@@ -180,9 +170,6 @@ class ProfessionalController extends Controller
             'cro' => 'required_if:dentista,1|nullable',
             'cargo' => 'nullable',
             'especialidade' => 'nullable',
-            'profiles' => 'required|array|min:1',
-            'profiles.*.profile_id' => 'required|exists:profiles,id',
-            'profiles.*.clinic_id' => 'required|exists:clinics,id',
             'photo' => 'nullable|image',
             'clinicas' => 'nullable|array',
             'clinicas.*.comissao' => 'nullable|numeric',
@@ -235,10 +222,6 @@ class ProfessionalController extends Controller
 
         $profissional->save();
 
-        $profissional->clinics()->detach();
-        foreach ($data['profiles'] as $pair) {
-            $profissional->clinics()->attach($pair['clinic_id'], ['profile_id' => $pair['profile_id']]);
-        }
 
         ClinicaProfissional::where('profissional_id', $profissional->id)->delete();
         HorarioProfissional::where('profissional_id', $profissional->id)->delete();

--- a/resources/views/admin/professionals/create.blade.php
+++ b/resources/views/admin/professionals/create.blade.php
@@ -52,57 +52,6 @@
             <h2 class="mb-4 text-sm font-medium text-gray-700">Foto</h2>
             <input type="file" name="photo" class="w-full text-sm" />
         </div>
-        <div class="rounded-sm border border-stroke bg-gray-50 p-4">
-            <h2 class="mb-4 text-sm font-medium text-gray-700">Senha</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Senha (opcional)</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="password" name="password" />
-                </div>
-                <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Confirmar Senha</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="password" name="password_confirmation" />
-                </div>
-            </div>
-            <p class="text-xs text-gray-500 mt-1">Se deixado em branco, uma senha aleatória será criada e enviada por e-mail.</p>
-        </div>
-        <div>
-            <h2 class="mb-4 text-sm font-medium text-gray-700">Perfis</h2>
-            <div id="profiles-container" class="space-y-4"></div>
-            <button type="button" id="add-profile" class="py-2 px-4 bg-gray-200 rounded hover:bg-gray-300 text-sm">Adicionar perfil</button>
-            <template id="profile-clinic-template">
-                <div class="profile-clinic-row rounded-sm border border-stroke bg-gray-50 p-4 space-y-4">
-                    <div class="flex justify-between items-center">
-                        <h3 class="font-medium text-sm profile-number">Perfil __number__</h3>
-                        <button type="button" class="remove-profile text-red-600 hover:text-red-800">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                        </button>
-                    </div>
-                    <div class="flex flex-col sm:flex-row gap-4">
-                        <div class="flex-1">
-                            <label class="mb-2 block text-sm font-medium text-gray-700">Perfil</label>
-                            <select name="profiles[__index__][profile_id]" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
-                                <option value="">Selecione</option>
-                                @foreach ($profiles as $profile)
-                                    <option value="{{ $profile->id }}">{{ $profile->nome }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="flex-1">
-                            <label class="mb-2 block text-sm font-medium text-gray-700">Clínica</label>
-                            <select name="profiles[__index__][clinic_id]" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
-                                <option value="">Selecione</option>
-                                @foreach ($clinics as $clinic)
-                                    <option value="{{ $clinic->id }}">{{ $clinic->nome }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                    </div>
-                </div>
-            </template>
-        </div>
         </div> <!-- end dados tab -->
         <div x-show="tab==='contato'" class="space-y-6" x-cloak>
             <div class="rounded-sm border border-stroke bg-gray-50 p-4">
@@ -250,40 +199,5 @@
     </form>
 </div>
 
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const container = document.getElementById('profiles-container');
-        const template = document.getElementById('profile-clinic-template').innerHTML;
-        let index = 0;
 
-        function updateTitles() {
-            container.querySelectorAll('.profile-number').forEach((el, idx) => {
-                el.textContent = 'Perfil ' + (idx + 1);
-            });
-        }
-
-        function addRow(profile = '', clinic = '') {
-            const html = template.replace(/__index__/g, index).replace(/__number__/g, container.children.length + 1);
-            container.insertAdjacentHTML('beforeend', html);
-            const row = container.lastElementChild;
-            row.querySelector('.remove-profile').addEventListener('click', () => {
-                row.remove();
-                updateTitles();
-            });
-            if (profile) row.querySelector(`select[name="profiles[${index}][profile_id]"]`).value = profile;
-            if (clinic) row.querySelector(`select[name="profiles[${index}][clinic_id]"]`).value = clinic;
-            index++;
-            updateTitles();
-        }
-
-        document.getElementById('add-profile').addEventListener('click', () => addRow());
-
-        const oldProfiles = @json(old('profiles', []));
-        if (oldProfiles.length) {
-            oldProfiles.forEach(p => addRow(p.profile_id ?? '', p.clinic_id ?? ''));
-        } else {
-            addRow();
-        }
-    });
-</script>
 @endsection

--- a/resources/views/admin/professionals/edit.blade.php
+++ b/resources/views/admin/professionals/edit.blade.php
@@ -77,57 +77,6 @@
             <h2 class="mb-4 text-sm font-medium text-gray-700">Foto</h2>
             <input type="file" name="photo" class="w-full text-sm" />
         </div>
-        <div class="rounded-sm border border-stroke bg-gray-50 p-4">
-            <h2 class="mb-4 text-sm font-medium text-gray-700">Senha</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Senha (opcional)</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="password" name="password" />
-                </div>
-                <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Confirmar Senha</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="password" name="password_confirmation" />
-                </div>
-            </div>
-            <p class="text-xs text-gray-500 mt-1">Se deixado em branco, a senha permanecerá inalterada.</p>
-        </div>
-        <div>
-            <h2 class="mb-4 text-sm font-medium text-gray-700">Perfis</h2>
-            <div id="profiles-container" class="space-y-4"></div>
-            <button type="button" id="add-profile" class="py-2 px-4 bg-gray-200 rounded hover:bg-gray-300 text-sm">Adicionar perfil</button>
-            <template id="profile-clinic-template">
-                <div class="profile-clinic-row rounded-sm border border-stroke bg-gray-50 p-4 space-y-4">
-                    <div class="flex justify-between items-center">
-                        <h3 class="font-medium text-sm profile-number">Perfil __number__</h3>
-                        <button type="button" class="remove-profile text-red-600 hover:text-red-800">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                        </button>
-                    </div>
-                    <div class="flex flex-col sm:flex-row gap-4">
-                        <div class="flex-1">
-                            <label class="mb-2 block text-sm font-medium text-gray-700">Perfil</label>
-                            <select name="profiles[__index__][profile_id]" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
-                                <option value="">Selecione</option>
-                                @foreach ($profiles as $profile)
-                                    <option value="{{ $profile->id }}">{{ $profile->nome }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="flex-1">
-                            <label class="mb-2 block text-sm font-medium text-gray-700">Clínica</label>
-                            <select name="profiles[__index__][clinic_id]" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
-                                <option value="">Selecione</option>
-                                @foreach ($clinics as $clinic)
-                                    <option value="{{ $clinic->id }}">{{ $clinic->nome }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                    </div>
-                </div>
-            </template>
-        </div>
         </div>
         <div x-show="tab==='contato'" class="space-y-6" x-cloak>
             <div class="rounded-sm border border-stroke bg-gray-50 p-4">
@@ -184,39 +133,4 @@
     </form>
 </div>
 
-@push('scripts')
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const container = document.getElementById('profiles-container');
-        const template = document.getElementById('profile-clinic-template').innerHTML;
-        let index = 0;
-
-        function updateTitles() {
-            container.querySelectorAll('.profile-number').forEach((el, idx) => {
-                el.textContent = 'Perfil ' + (idx + 1);
-            });
-        }
-
-        function addRow(profile = '', clinic = '') {
-            const html = template.replace(/__index__/g, index).replace(/__number__/g, container.children.length + 1);
-            container.insertAdjacentHTML('beforeend', html);
-            const row = container.lastElementChild;
-            row.querySelector('.remove-profile').addEventListener('click', () => {
-                row.remove();
-                updateTitles();
-            });
-            row.querySelector(`select[name="profiles[${index}][profile_id]"]`).value = profile;
-            row.querySelector(`select[name="profiles[${index}][clinic_id]"]`).value = clinic;
-            index++;
-            updateTitles();
-        }
-
-        document.getElementById('add-profile').addEventListener('click', () => addRow());
-
-        @foreach ($profissional->clinics as $clinic)
-            addRow('{{ $clinic->pivot->profile_id }}', '{{ $clinic->id }}');
-        @endforeach
-    });
-</script>
-@endpush
 @endsection


### PR DESCRIPTION
## Summary
- remove password and profile fields from professional create/edit views
- stop passing `profiles` to the views and drop related validation
- keep professional clinic settings and scheduling intact

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687ea573bc90832abc3f842aee836811