### PR TITLE
Add edit action to professionals list

### DIFF
--- a/resources/views/admin/profissionais/index.blade.php
+++ b/resources/views/admin/profissionais/index.blade.php
@@ -148,6 +148,11 @@
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3 1.343 3 3-1.343 3-3 3m0-12V4m0 16v-4m0 4c1.657 0 3-1.343 3-3s-1.343-3-3-3-3-1.343-3-3 1.343-3 3-3" />
                                     </svg>
                                 </a>
+                                <a href="{{ route('profissionais.edit', $profissional) }}" class="text-gray-600 hover:text-blue-600" title="Editar">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m0 0a2.5 2.5 0 01-3.536 3.536L9 20.036l-4 1 1-4 6.232-6.232a2.5 2.5 0 013.536-3.536z" />
+                                    </svg>
+                                </a>
                             </div>
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary
- enable editing from the professionals list by adding an edit icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eaa08dd80832a9d04395602399121