### PR TITLE
Implement search in schedule modal

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -77,6 +77,22 @@ class PatientController extends Controller
         return redirect()->route('pacientes.index')->with('success', 'Paciente removido com sucesso.');
     }
 
+    public function search(Request $request)
+    {
+        $term = $request->get('q', '');
+        $results = Patient::where('nome', 'like', "%{$term}%")
+            ->orWhere('ultimo_nome', 'like', "%{$term}%")
+            ->orWhere('telefone', 'like', "%{$term}%")
+            ->orWhere('whatsapp', 'like', "%{$term}%")
+            ->orWhere('email', 'like', "%{$term}%")
+            ->orWhere('cpf', 'like', "%{$term}%")
+            ->orderBy('nome')
+            ->limit(10)
+            ->pluck('nome');
+
+        return response()->json($results);
+    }
+
     private function validateData(Request $request): array
     {
         $rules = [

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -74,16 +74,37 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const modal = document.getElementById('schedule-modal');
-    const patientSelect = document.getElementById('schedule-patient');
+    const patientInput = document.getElementById('schedule-patient');
+    const patientList = document.getElementById('schedule-patient-list');
     const cancelBtn = document.getElementById('schedule-cancel');
     const saveBtn = document.getElementById('schedule-save');
     let targetCell = null;
+
+    if (patientInput) {
+        patientInput.addEventListener('input', () => {
+            const q = patientInput.value.trim();
+            if (q.length < 2) {
+                patientList.innerHTML = '';
+                return;
+            }
+            fetch(`/admin/pacientes/buscar?q=${encodeURIComponent(q)}`)
+                .then(r => r.json())
+                .then(data => {
+                    patientList.innerHTML = '';
+                    data.forEach(name => {
+                        const opt = document.createElement('option');
+                        opt.value = name;
+                        patientList.appendChild(opt);
+                    });
+                });
+        });
+    }
 
     if (modal) {
         document.querySelectorAll('td[data-professional]').forEach(td => {
             td.addEventListener('click', () => {
                 targetCell = td;
-                patientSelect.value = '';
+                patientInput.value = '';
                 modal.classList.remove('hidden');
             });
         });
@@ -93,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         saveBtn.addEventListener('click', () => {
-            const name = patientSelect.value;
+            const name = patientInput.value;
             if (!name || !targetCell) return;
             targetCell.innerHTML =
                 `<div class="rounded p-2 text-xs bg-green-100 text-green-700"><div class="font-semibold">${name}</div><div>Consulta</div></div>`;

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -122,17 +122,13 @@
         </tbody>
     </table>
 </div>
-<div id="schedule-modal" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">
+<div id="schedule-modal" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
     <div class="bg-white rounded p-4 w-80">
         <h2 class="text-lg font-semibold mb-4">Agendar Horário</h2>
         <label class="block mb-4">
             <span class="text-sm">Paciente</span>
-            <select id="schedule-patient" class="mt-1 w-full border rounded p-1">
-                <option value="">Selecione...</option>
-                @foreach($patients as $patient)
-                    <option value="{{ $patient }}">{{ $patient }}</option>
-                @endforeach
-            </select>
+            <input id="schedule-patient" type="text" list="schedule-patient-list" placeholder="Buscar..." class="mt-1 w-full border rounded p-1" />
+            <datalist id="schedule-patient-list"></datalist>
         </label>
         <div class="flex justify-end gap-2">
             <button id="schedule-cancel" class="px-3 py-1 border rounded">Cancelar</button>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -27,6 +27,7 @@ Route::resource('profissionais', ProfessionalController::class);
 Route::resource('formularios', FormularioController::class);
 Route::resource('pacientes', PatientController::class)
     ->parameters(['pacientes' => 'paciente']);
+Route::get('pacientes/buscar', [PatientController::class, 'search'])->name('pacientes.search');
 
 Route::view('orcamentos/assinar', 'orcamentos.assinar')->name('orcamentos.assinar');
 


### PR DESCRIPTION
## Summary
- center schedule modal with flex container
- add search input and datalist for patients
- enable patient search API
- wire JS to fetch patient search results

## Testing
- `npm run build` *(fails: vite not found)*
- `composer install --no-interaction` *(fails: 403 Forbidden during package download)*

------
https://chatgpt.com/codex/tasks/task_e_687fb2f04914832a8ec23cfe548d7f3f