### PR TITLE
Add interactive agenda date picker

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -196,3 +196,74 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+function agendaCalendar() {
+    const months = ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro'];
+    const week = ['SEG', 'TER', 'QUA', 'QUI', 'SEX', 'SAB', 'DOM'];
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    let start = getMonday(new Date());
+
+    function getMonday(date) {
+        const d = new Date(date);
+        const day = d.getDay();
+        const diff = day === 0 ? -6 : 1 - day;
+        d.setDate(d.getDate() + diff);
+        d.setHours(0, 0, 0, 0);
+        return d;
+    }
+
+    function isToday(date) {
+        return date.getTime() === today.getTime();
+    }
+
+    function buildDays() {
+        const arr = [];
+        for (let i = 0; i < 7; i++) {
+            const d = new Date(start);
+            d.setDate(start.getDate() + i);
+            let classes = 'flex flex-col items-center p-2 rounded cursor-pointer text-xs flex-1 text-center';
+            if (isToday(d)) {
+                classes += ' bg-black text-white';
+            } else if (d < today) {
+                classes += ' text-gray-400';
+            } else {
+                classes += ' text-gray-700';
+            }
+            arr.push({
+                date: d.toISOString().slice(0, 10),
+                label: week[i],
+                number: d.getDate(),
+                month: months[d.getMonth()],
+                classes,
+            });
+        }
+        return arr;
+    }
+
+    return {
+        days: [],
+        init() {
+            this.days = buildDays();
+        },
+        prevWeek() {
+            start.setDate(start.getDate() - 7);
+            this.days = buildDays();
+        },
+        nextWeek() {
+            start.setDate(start.getDate() + 7);
+            this.days = buildDays();
+        },
+        openDatePicker() {
+            this.$refs.picker.showPicker();
+        },
+        onDateSelected(val) {
+            const d = new Date(val);
+            if (!isNaN(d)) {
+                start = getMonday(d);
+                this.days = buildDays();
+            }
+        },
+    };
+}
+

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -57,33 +57,39 @@
         ],
     ];
 @endphp
-<div class="flex items-center justify-between mb-4">
-    <div class="flex items-center gap-2 flex-1">
-        <button class="p-1 border rounded bg-white">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-            </svg>
-        </button>
-        <div class="flex gap-2 flex-1">
-            @foreach($days as $day)
-                <x-agenda.dia :label="$day['label']" :numero="$day['number']" :mes="$day['month']" :active="$day['active']" :past="$day['past']" />
-            @endforeach
-        </div>
-        <button class="p-1 border rounded bg-white">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-            </svg>
-        </button>
-    </div>
-    <div class="relative">
-        <button class="p-2 border rounded bg-white">
+<div x-data="agendaCalendar()" x-init="init()">
+    <div class="flex justify-end mb-2 relative">
+        <button @click="openDatePicker" class="p-2 border rounded bg-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
         </button>
+        <input x-ref="picker" type="date" class="hidden" @change="onDateSelected($event.target.value)" />
         <span class="absolute -top-1 -right-1 bg-red-600 text-white text-[10px] rounded-full px-1">23</span>
     </div>
-</div>
+    <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-2 flex-1">
+            <button @click="prevWeek" class="p-1 border rounded bg-white">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                </svg>
+            </button>
+            <div class="flex gap-2 flex-1">
+                <template x-for="day in days" :key="day.date">
+                    <div :class="day.classes">
+                        <span class="uppercase" x-text="day.label"></span>
+                        <span class="font-semibold" x-text="day.number"></span>
+                        <span x-text="day.month"></span>
+                    </div>
+                </template>
+            </div>
+            <button @click="nextWeek" class="p-1 border rounded bg-white">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </button>
+        </div>
+    </div>
 <div class="flex items-center gap-2 overflow-x-auto mb-4">
     <x-agenda.profissional name="Todos os Profissionais" active />
     @foreach($professionals as $prof)
@@ -134,6 +140,7 @@
             <button id="schedule-cancel" class="px-3 py-1 border rounded">Cancelar</button>
             <button id="schedule-save" class="px-3 py-1 bg-primary text-white rounded">Salvar</button>
         </div>
-    </div>
+</div>
+</div>
 </div>
 @endsection


### PR DESCRIPTION
## Summary
- make agenda date bar interactive with Alpine.js
- move calendar icon above the bar and show inline date picker
- add `agendaCalendar` function to handle week navigation and date selection

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fd14f49c4832a99b5bbb641a25121