### PR TITLE
Fix ambiguous column check for clinic selection

### DIFF
--- a/app/Http/Controllers/Admin/ClinicContextController.php
+++ b/app/Http/Controllers/Admin/ClinicContextController.php
@@ -12,7 +12,7 @@ class ClinicContextController extends Controller
         $clinicId = $request->input('clinic_id');
         $user = $request->user();
 
-        if ($clinicId && $user->clinics()->where('id', $clinicId)->exists()) {
+        if ($clinicId && $user->clinics()->where('clinics.id', $clinicId)->exists()) {
             session(['clinic_id' => $clinicId]);
             app()->instance('clinic_id', $clinicId);
         }


### PR DESCRIPTION
## Summary
- avoid ambiguous `id` references when verifying clinic selection

## Testing
- `php artisan test` *(fails: vendor not installed)*
- `composer install --no-interaction --no-progress` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687fe44400c4832a9c7ae28431840bee