### PR TITLE
Fix schedule hours and handle closed days

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -61,11 +61,18 @@ class AgendaController extends Controller
 
         $horarios = [];
         foreach ($intervalos as $int) {
+            if (!$int->hora_inicio || !$int->hora_fim) {
+                continue;
+            }
             $start = Carbon::createFromTimeString($int->hora_inicio);
             $end = Carbon::createFromTimeString($int->hora_fim);
             for ($time = $start->copy(); $time <= $end; $time->addMinutes(30)) {
                 $horarios[] = $time->format('H:i');
             }
+        }
+
+        if (empty($horarios)) {
+            return response()->json(['closed' => true]);
         }
 
         return response()->json(['closed' => false, 'horarios' => $horarios]);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -100,6 +100,7 @@ window.updateScheduleTable = function(openTimes) {
             td.classList.remove('bg-gray-200', 'text-gray-400', 'cursor-not-allowed');
             td.classList.add('cursor-pointer');
         } else {
+            td.classList.remove('cursor-pointer');
             td.classList.add('bg-gray-200', 'text-gray-400', 'cursor-not-allowed');
         }
     });

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -33,14 +33,9 @@
     ];
     $patients = ['João','Maria','Pedro','Ana','Carlos'];
     $horarios = [];
-    $morningStart = Carbon::createFromTime(8, 0);
-    $morningEnd = Carbon::createFromTime(11, 30);
-    for ($time = $morningStart->copy(); $time <= $morningEnd; $time->addMinutes(30)) {
-        $horarios[] = $time->format('H:i');
-    }
-    $afternoonStart = Carbon::createFromTime(14, 0);
-    $afternoonEnd = Carbon::createFromTime(16, 30);
-    for ($time = $afternoonStart->copy(); $time <= $afternoonEnd; $time->addMinutes(30)) {
+    $startTime = Carbon::createFromTime(7, 0);
+    $endTime = Carbon::createFromTime(19, 0);
+    for ($time = $startTime->copy(); $time <= $endTime; $time->addMinutes(30)) {
         $horarios[] = $time->format('H:i');
     }
     $agenda = [


### PR DESCRIPTION
## Summary
- extend generated schedule times until 19:00
- ignore intervals without start and end times so closed days appear correctly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687feb3b965c832a9f992bebee484257