### PR TITLE
Atualiza agenda dinâmica

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -106,13 +106,25 @@ window.updateScheduleTable = function(openTimes, start, end, closed) {
     if (closed) {
         if (container) container.classList.remove('hidden');
         if (table) table.classList.add('hidden');
-        if (closedMsg) closedMsg.classList.remove('hidden');
+        if (closedMsg) {
+            closedMsg.textContent = 'A clínica está fechada neste dia.';
+            closedMsg.classList.remove('hidden');
+        }
         return;
     }
 
     if (closedMsg) closedMsg.classList.add('hidden');
     if (table) table.classList.remove('hidden');
 
+
+    document.querySelectorAll('tr[data-row]').forEach(tr => {
+        const time = tr.dataset.row;
+        if (start && end && (time < start || time > end)) {
+            tr.classList.add('hidden');
+        } else {
+            tr.classList.remove('hidden');
+        }
+    });
 
     document.querySelectorAll('td[data-professional]').forEach(td => {
         const time = td.dataset.time;

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -33,8 +33,8 @@
     ];
     $patients = ['João','Maria','Pedro','Ana','Carlos'];
     $horarios = [];
-    $startTime = Carbon::createFromTime(7, 0);
-    $endTime = Carbon::createFromTime(19, 0);
+    $startTime = Carbon::createFromTime(0, 0);
+    $endTime = Carbon::createFromTime(23, 30);
     for ($time = $startTime->copy(); $time <= $endTime; $time->addMinutes(30)) {
         $horarios[] = $time->format('H:i');
     }
@@ -97,7 +97,7 @@
     <button class="pb-2 text-gray-600">Filtrar</button>
 </div>
 <div class="overflow-auto" id="schedule-container">
-    <div id="schedule-closed" class="hidden text-center py-4 text-gray-500">Clínica fechada</div>
+    <div id="schedule-closed" class="hidden text-center py-4 text-gray-500">A clínica está fechada neste dia.</div>
     <table id="schedule-table" class="min-w-full text-sm">
         <thead>
             <tr>


### PR DESCRIPTION
## Summary
- extend schedule table with full-day time slots
- show closed clinic message
- hide rows outside clinic opening hours via JS
- update JS to refresh view when clinic/day changes

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687ff5f08518832abea42df6c3d07923