### PR TITLE
Fix layout in professional edit form

### DIFF
--- a/resources/views/admin/professionals/edit.blade.php
+++ b/resources/views/admin/professionals/edit.blade.php
@@ -48,6 +48,9 @@
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cpf" value="{{ old('cpf', $profissional->cpf) }}" />
                 </div>
             </div>
+        <div class="rounded-sm border border-stroke bg-gray-50 p-4">
+            <h2 class="mb-4 text-sm font-medium text-gray-700">Foto</h2>
+            <input type="file" name="photo" class="w-full text-sm" />
         </div>
         </div>
         <div x-show="tab==='profissionais'" class="space-y-6" x-cloak>
@@ -75,10 +78,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="rounded-sm border border-stroke bg-gray-50 p-4">
-            <h2 class="mb-4 text-sm font-medium text-gray-700">Foto</h2>
-            <input type="file" name="photo" class="w-full text-sm" />
         </div>
         </div>
         <div x-show="tab==='contato'" class="space-y-6" x-cloak>


### PR DESCRIPTION
## Summary
- ensure `edit.blade.php` tabs render correctly by closing divs properly and moving the photo field inside the personal data tab

## Testing
- `composer install --no-interaction --no-ansi` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687ffa6d5334832aadf635518f8fefa2