### PR TITLE
Fix editing professional clearing dentist status

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -217,7 +217,9 @@ class ProfessionalController extends Controller
         $profissional->cidade = $data['cidade'] ?? null;
         $profissional->estado = $data['estado'] ?? null;
         $profissional->cpf = $data['cpf'] ?? null;
-        $profissional->dentista = $data['dentista'] ?? false;
+        if (array_key_exists('dentista', $data)) {
+            $profissional->dentista = $data['dentista'];
+        }
         $profissional->cro = $data['cro'] ?? null;
         $profissional->cargo = $data['cargo'] ?? null;
         $profissional->especialidade = $data['especialidade'] ?? null;


### PR DESCRIPTION
## Summary
- ensure the dentist boolean is only updated when provided

## Testing
- `php artisan test` *(fails: vendor folder missing)*
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6880b28c7830832aa164d76503c7c189