### PR TITLE
Show initials when professional photo missing

### DIFF
--- a/resources/views/admin/profissionais/index.blade.php
+++ b/resources/views/admin/profissionais/index.blade.php
@@ -105,7 +105,20 @@
                     <tr>
                         <td class="px-4 py-2">
                             <div class="flex items-center space-x-2">
-                                <img src="{{ $profissional->photo_path ? asset('storage/'.$profissional->photo_path) : 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2240%22%20height%3D%2240%22%3E%3Crect%20width%3D%2240%22%20height%3D%2240%22%20fill%3D%22%23ddd%22%2F%3E%3C%2Fsvg%3E' }}" class="w-10 h-10 rounded-full object-cover" alt="Foto">
+                                @if($profissional->photo_path)
+                                    <img src="{{ asset('storage/'.$profissional->photo_path) }}" class="w-10 h-10 rounded-full object-cover" alt="Foto">
+                                @else
+                                    @php
+                                        $initials = collect(explode(' ', $profissional->name))
+                                            ->filter()
+                                            ->map(fn($part) => strtoupper(substr($part, 0, 1)))
+                                            ->take(2)
+                                            ->implode('');
+                                    @endphp
+                                    <div class="w-10 h-10 rounded-full bg-gray-300 flex items-center justify-center text-sm font-medium text-gray-700">
+                                        {{ $initials }}
+                                    </div>
+                                @endif
                                 <div>
                                     <div class="font-medium text-gray-700">{{ $profissional->name }}</div>
                                     @if($profissional->especialidade)


### PR DESCRIPTION
## Summary
- add fallback to show user's initials when no photo is uploaded on the professionals list

## Testing
- `composer check` *(fails: No lockfile found)*
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c4eaf018832abd574d4d8a6281ac