### PR TITLE
Update profile action icon

### DIFF
--- a/resources/views/admin/profissionais/index.blade.php
+++ b/resources/views/admin/profissionais/index.blade.php
@@ -147,7 +147,8 @@
                             <div class="flex items-center justify-center space-x-2">
                                 <a href="{{ route('profissionais.show', ['profissional' => $profissional->id]) }}" class="text-gray-600 hover:text-blue-600" title="Ver Perfil">
                                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 15c2.33 0 4.5.533 6.879 1.532M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                                     </svg>
                                 </a>
                                 <a href="#" class="text-gray-600 hover:text-blue-600" title="Ver Agenda">


### PR DESCRIPTION
## Summary
- adjust the profile link icon on Professionals list to use an eye icon for better clarity

## Testing
- `composer test` *(fails: command not defined)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880c59696f4832abb95447570cf70b4