### PR TITLE
Fix tab label

### DIFF
--- a/resources/views/admin/profissionais/show.blade.php
+++ b/resources/views/admin/profissionais/show.blade.php
@@ -74,7 +74,7 @@
             <button type="button" @click="tab='dados'" :class="tab==='dados' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Dados pessoais</button>
             <button type="button" @click="tab='profissionais'" :class="tab==='profissionais' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Dados Profissionais</button>
             <button type="button" @click="tab='contato'" :class="tab==='contato' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Contato</button>
-            <button type="button" @click="tab='clinicas'" :class="tab==='clinicas' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Clínicas</button>
+            <button type="button" @click="tab='comissoes'" :class="tab==='comissoes' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Comissões</button>
             <button type="button" @click="tab='horarios'" :class="tab==='horarios' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Comissao</button>
         </div>
         <div x-show="tab==='dados'" class="space-y-4">
@@ -112,7 +112,7 @@
                 <div><span class="font-medium">Estado</span><p>{{ $profissional->estado ?: '-' }}</p></div>
             </div>
         </div>
-        <div x-show="tab==='clinicas'" class="space-y-4" x-cloak>
+        <div x-show="tab==='comissoes'" class="space-y-4" x-cloak>
             @foreach($profissional->clinicasProfissional as $clinica)
                 <div class="border rounded p-2 text-sm flex justify-between">
                     <div>


### PR DESCRIPTION
## Summary
- rename the "Clínicas" tab to "Comissões" on the professional detail page

## Testing
- `php artisan test` *(fails: missing vendor directory)*

------
https://chatgpt.com/codex/tasks/task_e_6880d616d638832ab72081f809169b3b