### PR TITLE
Fix Remuneração tab label and add BRL currency field

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -219,6 +219,32 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    document.querySelectorAll('input.currency-brl').forEach(input => {
+        const form = input.closest('form');
+
+        const toNumber = val => val.replace(/[^0-9,]/g, '').replace(',', '.');
+        const format = val => {
+            const num = parseFloat(toNumber(val));
+            return isNaN(num) ? '' : num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+        };
+
+        if (input.value) {
+            input.value = format(input.value);
+        }
+
+        input.addEventListener('input', e => {
+            const pos = e.target.selectionStart;
+            e.target.value = format(e.target.value);
+            e.target.setSelectionRange(pos, pos);
+        });
+
+        if (form) {
+            form.addEventListener('submit', () => {
+                input.value = toNumber(input.value);
+            });
+        }
+    });
+
     const modal = document.getElementById('schedule-modal');
     const patientInput = document.getElementById('schedule-patient');
     const patientList = document.getElementById('schedule-patient-list');

--- a/resources/views/admin/professionals/create.blade.php
+++ b/resources/views/admin/professionals/create.blade.php
@@ -23,7 +23,7 @@
             <button type="button" @click="tab='dados'" :class="tab==='dados' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Dados pessoais</button>
             <button type="button" @click="tab='profissionais'" :class="tab==='profissionais' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Dados Profissionais</button>
             <button type="button" @click="tab='contato'" :class="tab==='contato' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Contato</button>
-            <button type="button" @click="tab='clinicas'" :class="tab==='clinicas' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Remuneracao</button>
+            <button type="button" @click="tab='clinicas'" :class="tab==='clinicas' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Remuneração</button>
             <button type="button" @click="tab='horarios'" :class="tab==='horarios' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Horário de trabalho</button>
         </div>
         <div x-show="tab==='dados'" class="space-y-6">
@@ -130,7 +130,7 @@
         <div x-show="tab==='clinicas'" class="space-y-4">
             <div>
                 <label class="text-sm block mb-1">Salário base</label>
-                <input type="number" step="0.01" name="salario_base" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm" value="{{ old('salario_base') }}">
+                <input type="text" name="salario_base" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm currency-brl" value="{{ old('salario_base') }}">
             </div>
             @foreach ($clinics as $clinic)
                 <div class="border rounded p-4 space-y-2">

--- a/resources/views/admin/professionals/edit.blade.php
+++ b/resources/views/admin/professionals/edit.blade.php
@@ -24,7 +24,7 @@
             <button type="button" @click="tab='dados'" :class="tab==='dados' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Dados pessoais</button>
             <button type="button" @click="tab='profissionais'" :class="tab==='profissionais' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Dados Profissionais</button>
             <button type="button" @click="tab='contato'" :class="tab==='contato' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Contato</button>
-            <button type="button" @click="tab='clinicas'" :class="tab==='clinicas' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Remuneracao</button>
+            <button type="button" @click="tab='clinicas'" :class="tab==='clinicas' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Remuneração</button>
             <button type="button" @click="tab='horarios'" :class="tab==='horarios' ? 'border-b-2 border-blue-600' : ''" class="pb-2">Horário de trabalho</button>
         </div>
         <div x-show="tab==='dados'" class="space-y-6">
@@ -131,7 +131,7 @@
         <div x-show="tab==='clinicas'" class="space-y-4" x-cloak>
             <div>
                 <label class="text-sm block mb-1">Salário base</label>
-                <input type="number" step="0.01" name="salario_base" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm" value="{{ old('salario_base', $profissional->salario_base) }}">
+                <input type="text" name="salario_base" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-2 px-3 text-sm currency-brl" value="{{ old('salario_base', $profissional->salario_base) }}">
             </div>
             @foreach ($clinics as $clinic)
                 @php $cp = $profissional->clinicasProfissional->firstWhere('clinica_id', $clinic->id); @endphp


### PR DESCRIPTION
## Summary
- fix typo in `Remuneração` tab name
- display `salario_base` fields as BRL currency and add input mask

## Testing
- `composer --version`

------
https://chatgpt.com/codex/tasks/task_e_6880ded8a774832ab559a57d71f710a6