### PR TITLE
Add birth date to professional forms

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -45,6 +45,7 @@ class ProfessionalController extends Controller
             'first_name' => 'required',
             'middle_name' => 'nullable',
             'last_name' => 'required',
+            'data_nascimento' => 'nullable|date',
             'email' => 'required|email|unique:users,email',
             'password' => 'nullable|string|min:8|confirmed',
             'phone' => 'nullable',
@@ -83,6 +84,7 @@ class ProfessionalController extends Controller
         $user->first_name = $data['first_name'];
         $user->middle_name = $data['middle_name'] ?? null;
         $user->last_name = $data['last_name'];
+        $user->data_nascimento = $data['data_nascimento'] ?? null;
         $user->name = trim($data['first_name'] . ' ' . ($data['middle_name'] ?? '') . ' ' . $data['last_name']);
         $user->email = $data['email'];
         $user->phone = $data['phone'] ?? null;
@@ -181,6 +183,7 @@ class ProfessionalController extends Controller
             'first_name' => 'required',
             'middle_name' => 'nullable',
             'last_name' => 'required',
+            'data_nascimento' => 'nullable|date',
             'email' => 'required|email|unique:users,email,' . $profissional->id,
             'phone' => 'nullable',
             'password' => 'nullable|string|min:8|confirmed',
@@ -216,6 +219,7 @@ class ProfessionalController extends Controller
         $profissional->first_name = $data['first_name'];
         $profissional->middle_name = $data['middle_name'] ?? null;
         $profissional->last_name = $data['last_name'];
+        $profissional->data_nascimento = $data['data_nascimento'] ?? null;
         $profissional->name = trim($data['first_name'] . ' ' . ($data['middle_name'] ?? '') . ' ' . $data['last_name']);
         $profissional->email = $data['email'];
         $profissional->phone = $data['phone'] ?? null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,7 @@ class User extends Authenticatable
         'first_name',
         'middle_name',
         'last_name',
+        'data_nascimento',
         'email',
         'phone',
         'logradouro',
@@ -53,6 +54,7 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'must_change_password' => 'boolean',
         'dentista' => 'boolean',
+        'data_nascimento' => 'date',
     ];
 
     public function organization()

--- a/database/migrations/2025_08_19_000000_add_data_nascimento_to_users_table.php
+++ b/database/migrations/2025_08_19_000000_add_data_nascimento_to_users_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->date('data_nascimento')->nullable()->after('last_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('data_nascimento');
+        });
+    }
+};

--- a/resources/views/admin/professionals/create.blade.php
+++ b/resources/views/admin/professionals/create.blade.php
@@ -43,6 +43,10 @@
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="last_name" value="{{ old('last_name') }}" required />
                 </div>
                 <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Data de nascimento</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="data_nascimento" value="{{ old('data_nascimento') }}" />
+                </div>
+                <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">CPF</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cpf" value="{{ old('cpf') }}" />
                 </div>

--- a/resources/views/admin/professionals/edit.blade.php
+++ b/resources/views/admin/professionals/edit.blade.php
@@ -44,6 +44,10 @@
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="last_name" value="{{ old('last_name', $profissional->last_name) }}" required />
                 </div>
                 <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Data de nascimento</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="data_nascimento" value="{{ old('data_nascimento', $profissional->data_nascimento?->format('Y-m-d')) }}" />
+                </div>
+                <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">CPF</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cpf" value="{{ old('cpf', $profissional->cpf) }}" />
                 </div>

--- a/resources/views/admin/profissionais/show.blade.php
+++ b/resources/views/admin/profissionais/show.blade.php
@@ -90,6 +90,7 @@
                 <div><span class="font-medium">Nome</span><p>{{ $profissional->first_name }}</p></div>
                 <div><span class="font-medium">Nome do meio</span><p>{{ $profissional->middle_name ?: '-' }}</p></div>
                 <div><span class="font-medium">Último nome</span><p>{{ $profissional->last_name }}</p></div>
+                <div><span class="font-medium">Data de nascimento</span><p>{{ $profissional->data_nascimento?->format('d/m/Y') ?: '-' }}</p></div>
                 <div><span class="font-medium">CPF</span><p>{{ $profissional->cpf ?: '-' }}</p></div>
                 <div class="sm:col-span-2">
                     <span class="font-medium block">Foto</span>


### PR DESCRIPTION
## Summary
- add `data_nascimento` column to users table
- allow storing and editing professional birth dates
- show professional birth date in admin view

## Testing
- `composer validate --no-check-all`
- `php -l app/Models/User.php`
- `php -l app/Http/Controllers/Admin/ProfessionalController.php`
- `php -l resources/views/admin/professionals/create.blade.php`
- `php -l resources/views/admin/professionals/edit.blade.php`
- `php -l resources/views/admin/profissionais/show.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_6880e6ff2460832ab68d461d94d40f81