### PR TITLE
Add naturalidade and nacionalidade fields

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -47,6 +47,8 @@ class ProfessionalController extends Controller
             'last_name' => 'required',
             'data_nascimento' => 'nullable|date',
             'sexo' => 'nullable|in:M,F',
+            'naturalidade' => 'nullable|string',
+            'nacionalidade' => 'nullable|string',
             'email' => 'required|email|unique:users,email',
             'password' => 'nullable|string|min:8|confirmed',
             'phone' => 'nullable',
@@ -87,6 +89,8 @@ class ProfessionalController extends Controller
         $user->last_name = $data['last_name'];
         $user->data_nascimento = $data['data_nascimento'] ?? null;
         $user->sexo = $data['sexo'] ?? null;
+        $user->naturalidade = $data['naturalidade'] ?? null;
+        $user->nacionalidade = $data['nacionalidade'] ?? null;
         $user->name = trim($data['first_name'] . ' ' . ($data['middle_name'] ?? '') . ' ' . $data['last_name']);
         $user->email = $data['email'];
         $user->phone = $data['phone'] ?? null;
@@ -187,6 +191,8 @@ class ProfessionalController extends Controller
             'last_name' => 'required',
             'data_nascimento' => 'nullable|date',
             'sexo' => 'nullable|in:M,F',
+            'naturalidade' => 'nullable|string',
+            'nacionalidade' => 'nullable|string',
             'email' => 'required|email|unique:users,email,' . $profissional->id,
             'phone' => 'nullable',
             'password' => 'nullable|string|min:8|confirmed',
@@ -224,6 +230,8 @@ class ProfessionalController extends Controller
         $profissional->last_name = $data['last_name'];
         $profissional->data_nascimento = $data['data_nascimento'] ?? null;
         $profissional->sexo = $data['sexo'] ?? null;
+        $profissional->naturalidade = $data['naturalidade'] ?? null;
+        $profissional->nacionalidade = $data['nacionalidade'] ?? null;
         $profissional->name = trim($data['first_name'] . ' ' . ($data['middle_name'] ?? '') . ' ' . $data['last_name']);
         $profissional->email = $data['email'];
         $profissional->phone = $data['phone'] ?? null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,8 @@ class User extends Authenticatable
         'last_name',
         'data_nascimento',
         'sexo',
+        'naturalidade',
+        'nacionalidade',
         'email',
         'phone',
         'logradouro',

--- a/database/migrations/2025_08_21_000000_add_naturalidade_nacionalidade_to_users_table.php
+++ b/database/migrations/2025_08_21_000000_add_naturalidade_nacionalidade_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('naturalidade')->nullable()->after('sexo');
+            $table->string('nacionalidade')->nullable()->after('naturalidade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['naturalidade', 'nacionalidade']);
+        });
+    }
+};

--- a/resources/views/admin/professionals/create.blade.php
+++ b/resources/views/admin/professionals/create.blade.php
@@ -58,6 +58,14 @@
                     </select>
                 </div>
                 <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Naturalidade</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="naturalidade" value="{{ old('naturalidade') }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Nacionalidade</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nacionalidade" value="{{ old('nacionalidade') }}" />
+                </div>
+                <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">CPF</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cpf" value="{{ old('cpf') }}" />
                 </div>

--- a/resources/views/admin/professionals/edit.blade.php
+++ b/resources/views/admin/professionals/edit.blade.php
@@ -59,6 +59,14 @@
                     </select>
                 </div>
                 <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Naturalidade</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="naturalidade" value="{{ old('naturalidade', $profissional->naturalidade) }}" />
+                </div>
+                <div>
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Nacionalidade</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nacionalidade" value="{{ old('nacionalidade', $profissional->nacionalidade) }}" />
+                </div>
+                <div>
                     <label class="mb-2 block text-sm font-medium text-gray-700">CPF</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cpf" value="{{ old('cpf', $profissional->cpf) }}" />
                 </div>

--- a/resources/views/admin/profissionais/show.blade.php
+++ b/resources/views/admin/profissionais/show.blade.php
@@ -91,6 +91,8 @@
                 <div><span class="font-medium">Nome do meio</span><p>{{ $profissional->middle_name ?: '-' }}</p></div>
                 <div><span class="font-medium">Último nome</span><p>{{ $profissional->last_name }}</p></div>
                 <div><span class="font-medium">Data de nascimento</span><p>{{ $profissional->data_nascimento?->format('d/m/Y') ?: '-' }}</p></div>
+                <div><span class="font-medium">Naturalidade</span><p>{{ $profissional->naturalidade ?: '-' }}</p></div>
+                <div><span class="font-medium">Nacionalidade</span><p>{{ $profissional->nacionalidade ?: '-' }}</p></div>
                 <div><span class="font-medium">CPF</span><p>{{ $profissional->cpf ?: '-' }}</p></div>
                 <div class="sm:col-span-2">
                     <span class="font-medium block">Foto</span>


### PR DESCRIPTION
## Summary
- add `naturalidade` and `nacionalidade` columns to users
- store and update these fields for professionals
- allow editing and creating these fields on professional forms
- display new fields on professional details page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880f77a529c832aa98df8c009c3ae77