### PR TITLE
Fix admin seeder

### DIFF
--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -7,16 +7,29 @@ use Illuminate\Support\Facades\Hash;
 use App\Models\User;
 use App\Models\Profile;
 use App\Models\Permission;
+use App\Models\Person;
 
 class AdminUserSeeder extends Seeder
 {
     public function run(): void
     {
+        $person = Person::firstOrCreate(
+            [
+                'email' => 'admin@example.com',
+                'organization_id' => 1,
+            ],
+            [
+                'first_name' => 'Admin',
+                'last_name' => 'User',
+            ]
+        );
+
         $user = User::updateOrCreate(
             ['email' => 'admin@example.com'],
             [
-                'name' => 'Admin',
-                'password' => Hash::make('password')
+                'password' => Hash::make('password'),
+                'organization_id' => $person->organization_id,
+                'person_id' => $person->id,
             ]
         );
 


### PR DESCRIPTION
## Summary
- fix AdminUserSeeder for new `person_id` schema

## Testing
- `php -l database/seeders/AdminUserSeeder.php`
- `composer dump-autoload` *(fails: Class Illuminate\Foundation\ComposerScripts is not autoloadable)*

------
https://chatgpt.com/codex/tasks/task_e_6881f3e56194832a9de095c8ff2e3b5e