### PR TITLE
Fix super admin profile permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,13 @@ composer dump-autoload
 
 Isso recriará o autoloader do Composer e permitirá que a classe seja encontrada.
 
-Ele gerará a conta `admin@example.com` com a senha `password`. Acesse com essas
-credenciais e, se desejar, altere a senha após o login.
-
-Esse seeder também cria o perfil **Administrador** com todas as permissões e o
-associa automaticamente a esse usuário para que você já possa gerenciar novos
-perfis e usuários.
+Ele gerará ou atualizará a conta `admin@example.com` com a senha `password`.
+Esse usuário pertence à organização padrão "Default Organization" e recebe
+exclusivamente o perfil **Super Administrador**. Sempre que o seeder for
+executado, perfis anteriores desse usuário são removidos, garantindo que ele
+tenha acesso apenas ao módulo **Backend** e à seção de **Usuários Admin**, onde
+é possível definir novas senhas para os responsáveis pelas organizações.
+Após o login com as credenciais padrão, altere a senha conforme necessário.
 
 ## Deploy no Render
 

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -14,13 +14,10 @@ class AdminUserSeeder extends Seeder
 {
     public function run(): void
     {
-        $organization = Organization::first();
-        if (! $organization) {
-            $organization = Organization::create([
-                'nome_fantasia' => 'Default Organization',
-                'cnpj' => '00000000000000',
-            ]);
-        }
+        $organization = Organization::firstOrCreate(
+            ['cnpj' => '00000000000000'],
+            ['nome_fantasia' => 'Default Organization']
+        );
 
         $person = Person::firstOrCreate(
             [
@@ -66,6 +63,7 @@ class AdminUserSeeder extends Seeder
             );
         }
 
-        $user->profiles()->syncWithoutDetaching([$profile->id => ['clinic_id' => null]]);
+        // Ensure the admin user only has the Super Administrador profile
+        $user->profiles()->sync([$profile->id => ['clinic_id' => null]]);
     }
 }


### PR DESCRIPTION
## Summary
- ensure AdminUserSeeder removes other profiles before attaching Super Administrador
- document that the seeder updates the admin user and restricts its profile

## Testing
- `composer validate --no-check-all`
- `php -v | head -n 1`
- `php artisan --version` *(fails: missing vendor)*
- `composer install` *(fails: network 403)*

------
https://chatgpt.com/codex/tasks/task_e_6881f7aad09c832ab9ca2e56ad4dea0d