### PR TITLE
Restrict super admin access

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,5 +54,6 @@ class Kernel extends HttpKernel
         'forcepasswordchange' => \App\Http\Middleware\ForcePasswordChange::class,
         'superadmin' => \App\Http\Middleware\EnsureSuperAdmin::class,
         'paciente' => \App\Http\Middleware\EnsurePatientProfile::class,
+        'deny_superadmin' => \App\Http\Middleware\DenySuperAdmin::class,
     ];
 }

--- a/app/Http/Middleware/DenySuperAdmin.php
+++ b/app/Http/Middleware/DenySuperAdmin.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class DenySuperAdmin
+{
+    public function handle($request, Closure $next)
+    {
+        if (Auth::check() && Auth::user()->isSuperAdmin()) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -87,9 +87,6 @@ class User extends Authenticatable
 
     public function hasAnyModulePermission(string $module): bool
     {
-        if ($this->isSuperAdmin()) {
-            return true;
-        }
 
         $profileQuery = $this->profiles();
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
             ->group(base_path('routes/web.php'));
 
         Route::prefix('admin')
-            ->middleware(['web', 'auth', 'forcepasswordchange'])
+            ->middleware(['web', 'auth', 'forcepasswordchange', 'deny_superadmin'])
             ->group(base_path('routes/admin.php'));
 
         Route::prefix('backend')


### PR DESCRIPTION
## Summary
- block super admin users from admin routes
- remove unrestricted access for super admin when checking module permissions
- deny admin access via new middleware

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_688201e6b328832a8f48c5d18a486cbc