### PR TITLE
Handle super admins in organization scope

### DIFF
--- a/app/Traits/BelongsToOrganization.php
+++ b/app/Traits/BelongsToOrganization.php
@@ -9,7 +9,7 @@ trait BelongsToOrganization
 {
     protected static function bootBelongsToOrganization()
     {
-        if (! auth()->check() || is_null(auth()->user()->organization_id)) {
+        if (! auth()->check() || is_null(auth()->user()->organization_id) || auth()->user()->isSuperAdmin()) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- allow models using `BelongsToOrganization` trait to skip the organization scope when the user is a super admin

## Testing
- `php -l app/Traits/BelongsToOrganization.php`
- `composer test` *(fails: Command "test" is not defined)*
- `php artisan test` *(fails: vendor autoload not found)*


------
https://chatgpt.com/codex/tasks/task_e_688206b12584832ab240e4f2830f7257