### PR TITLE
Handle super admins in organization scope

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -34,6 +34,10 @@ class AuthenticatedSessionController extends Controller
                 return redirect()->intended('/portal');
             }
 
+            if ($user->isSuperAdmin()) {
+                return redirect()->intended('/backend');
+            }
+
             return redirect()->intended(RouteServiceProvider::HOME);
         }
 

--- a/app/Traits/BelongsToOrganization.php
+++ b/app/Traits/BelongsToOrganization.php
@@ -9,7 +9,7 @@ trait BelongsToOrganization
 {
     protected static function bootBelongsToOrganization()
     {
-        if (! auth()->check() || is_null(auth()->user()->organization_id)) {
+        if (! auth()->check() || is_null(auth()->user()->organization_id) || auth()->user()->isSuperAdmin()) {
             return;
         }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Auth;
 Route::get('/', function () {
     if (Auth::check()) {
         $user = Auth::user();
+
+        if ($user->isSuperAdmin()) {
+            return redirect()->route('backend.index');
+        }
+
         if ($user->profiles()->where('nome', 'Paciente')->exists()) {
             return redirect()->route('portal.index');
         }


### PR DESCRIPTION
## Summary
- allow models using `BelongsToOrganization` trait to skip the organization scope when the user is a super admin
- redirect super admins to the backend area after login or when visiting the home route

## Testing
- `php -l app/Traits/BelongsToOrganization.php`
- `php -l app/Http/Controllers/Auth/AuthenticatedSessionController.php`
- `php -l routes/web.php`
- `composer test` *(fails: Command "test" is not defined)*
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_688206b12584832ab240e4f2830f7257