### PR TITLE
Add work schedule section for professionals

### DIFF
--- a/app/Models/Profissional.php
+++ b/app/Models/Profissional.php
@@ -5,6 +5,7 @@ use Illuminate\Database\Eloquent\Model;
 use App\Traits\BelongsToOrganization;
 use App\Models\Person;
 use App\Models\User;
+use App\Models\ProfissionalHorario;
 
 class Profissional extends Model
 {
@@ -36,5 +37,10 @@ class Profissional extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function horariosTrabalho()
+    {
+        return $this->hasMany(ProfissionalHorario::class);
     }
 }

--- a/app/Models/ProfissionalHorario.php
+++ b/app/Models/ProfissionalHorario.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\BelongsToOrganization;
+use App\Traits\BelongsToClinic;
+
+class ProfissionalHorario extends Model
+{
+    use BelongsToOrganization, BelongsToClinic;
+
+    protected $fillable = [
+        'organization_id',
+        'clinic_id',
+        'profissional_id',
+        'dia_semana',
+        'hora_inicio',
+        'hora_fim',
+    ];
+
+    public function profissional()
+    {
+        return $this->belongsTo(Profissional::class);
+    }
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class);
+    }
+}

--- a/database/migrations/2025_10_01_000000_create_profissional_horarios_table.php
+++ b/database/migrations/2025_10_01_000000_create_profissional_horarios_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('profissional_horarios', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('profissional_id')->constrained('profissionais');
+            $table->foreignId('clinic_id')->constrained('clinics');
+            $table->foreignId('organization_id')->nullable()->constrained('organizations');
+            $table->enum('dia_semana', ['segunda','terca','quarta','quinta','sexta','sabado','domingo']);
+            $table->time('hora_inicio');
+            $table->time('hora_fim');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('profissional_horarios');
+    }
+};

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -190,6 +190,48 @@
                 </div>
             </div>
         </x-accordion-section>
+        <x-accordion-section title="Horário de trabalho">
+            @php
+                $diasSemana = [
+                    'segunda' => 'Segunda-feira',
+                    'terca' => 'Terça-feira',
+                    'quarta' => 'Quarta-feira',
+                    'quinta' => 'Quinta-feira',
+                    'sexta' => 'Sexta-feira',
+                    'sabado' => 'Sábado',
+                    'domingo' => 'Domingo',
+                ];
+            @endphp
+            @foreach($clinics as $clinic)
+                <div class="mb-4">
+                    @if($clinics->count() > 1)
+                        <h3 class="mb-2 text-sm font-medium text-gray-700">{{ $clinic->nome }}</h3>
+                    @endif
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr>
+                                <th class="text-left py-1">Dia</th>
+                                <th class="text-left py-1">Início</th>
+                                <th class="text-left py-1">Fim</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($diasSemana as $diaKey => $diaLabel)
+                                <tr>
+                                    <td class="py-1">{{ $diaLabel }}</td>
+                                    <td>
+                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                    </td>
+                                    <td>
+                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endforeach
+        </x-accordion-section>
     </div>
     <div x-show="activeTab === 'rem'" x-cloak>
         <p class="text-gray-700">Informações de remuneração.</p>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -191,6 +191,55 @@
                 </div>
             </div>
         </x-accordion-section>
+        <x-accordion-section title="Horário de trabalho">
+            @php
+                $diasSemana = [
+                    'segunda' => 'Segunda-feira',
+                    'terca' => 'Terça-feira',
+                    'quarta' => 'Quarta-feira',
+                    'quinta' => 'Quinta-feira',
+                    'sexta' => 'Sexta-feira',
+                    'sabado' => 'Sábado',
+                    'domingo' => 'Domingo',
+                ];
+            @endphp
+            @foreach($clinics as $clinic)
+                @php
+                    $vals = $horarios[$clinic->id] ?? [];
+                @endphp
+                <div class="mb-4">
+                    @if($clinics->count() > 1)
+                        <h3 class="mb-2 text-sm font-medium text-gray-700">{{ $clinic->nome }}</h3>
+                    @endif
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr>
+                                <th class="text-left py-1">Dia</th>
+                                <th class="text-left py-1">Início</th>
+                                <th class="text-left py-1">Fim</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($diasSemana as $diaKey => $diaLabel)
+                                @php
+                                    $ini = old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio', $vals[$diaKey]['inicio'] ?? '');
+                                    $fim = old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim', $vals[$diaKey]['fim'] ?? '');
+                                @endphp
+                                <tr>
+                                    <td class="py-1">{{ $diaLabel }}</td>
+                                    <td>
+                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ $ini }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                    </td>
+                                    <td>
+                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ $fim }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endforeach
+        </x-accordion-section>
     </div>
     <div x-show="activeTab === 'rem'" x-cloak>
         <p class="text-gray-700">Informações de remuneração.</p>


### PR DESCRIPTION
## Summary
- allow professionals to register work schedules per clinic
- validate schedules against clinic opening hours
- persist work schedules in new `profissional_horarios` table
- show schedules in create/edit forms

## Testing
- `php -l app/Models/ProfissionalHorario.php`
- `php -l app/Http/Controllers/Admin/ProfessionalController.php`
- `php -l app/Models/Profissional.php`
- `php -l database/migrations/2025_10_01_000000_create_profissional_horarios_table.php`


------
https://chatgpt.com/codex/tasks/task_e_68822fe2c044832a9afe5a89ea676fc8