### PR TITLE
Fix spacing for admission accordions

### DIFF
--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -131,7 +131,7 @@
         </div>
     </form>
     </div>
-    <div x-show="activeTab === 'adm'" x-cloak x-data="{ funcao: '{{ old('funcao') }}', tipo_contrato: '{{ old('tipo_contrato') }}' }">
+    <div x-show="activeTab === 'adm'" x-cloak x-data="{ funcao: '{{ old('funcao') }}', tipo_contrato: '{{ old('tipo_contrato') }}' }" class="space-y-6">
         <x-accordion-section title="Dados funcionais" :open="true">
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -132,7 +132,7 @@
         </div>
     </form>
     </div>
-    <div x-show="activeTab === 'adm'" x-cloak x-data="{ funcao: '{{ old('funcao', $profissional->funcao ?? '') }}', tipo_contrato: '{{ old('tipo_contrato', $profissional->tipo_contrato ?? '') }}' }">
+    <div x-show="activeTab === 'adm'" x-cloak x-data="{ funcao: '{{ old('funcao', $profissional->funcao ?? '') }}', tipo_contrato: '{{ old('tipo_contrato', $profissional->tipo_contrato ?? '') }}' }" class="space-y-6">
         <x-accordion-section title="Dados funcionais" :open="true">
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>


### PR DESCRIPTION
## Summary
- match accordion spacing between 'Dados admissionais' and 'Dados cadastrais'

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688261347d34832ab2357b30f7c27f11