### PR TITLE
Fix working hours accordion display

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -31,7 +31,22 @@ class ProfessionalController extends Controller
 
     public function show(Profissional $profissional)
     {
-        return view('profissionais.show', compact('profissional'));
+        $clinics = Clinic::where('organization_id', auth()->user()->organization_id)
+            ->with('horarios')
+            ->get();
+
+        $horarios = $profissional->horariosTrabalho
+            ->groupBy('clinic_id')
+            ->map(function ($items) {
+                return $items->mapWithKeys(fn($h) => [
+                    $h->dia_semana => [
+                        'inicio' => $h->hora_inicio,
+                        'fim' => $h->hora_fim,
+                    ],
+                ]);
+            })->toArray();
+
+        return view('profissionais.show', compact('profissional', 'clinics', 'horarios'));
     }
 
     public function store(Request $request)

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -255,13 +255,16 @@
                         </thead>
                         <tbody>
                             @foreach($diasSemana as $diaKey => $diaLabel)
+                                @php
+                                    $ref = $clinic->horarios->firstWhere('dia_semana', $diaKey);
+                                @endphp
                                 <tr>
                                     <td class="py-1">{{ $diaLabel }}</td>
                                     <td>
-                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio') }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
                                     </td>
                                     <td>
-                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim') }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
                                     </td>
                                 </tr>
                             @endforeach

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -260,16 +260,17 @@
                         <tbody>
                             @foreach($diasSemana as $diaKey => $diaLabel)
                                 @php
+                                    $ref = $clinic->horarios->firstWhere('dia_semana', $diaKey);
                                     $ini = old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio', $vals[$diaKey]['inicio'] ?? '');
                                     $fim = old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim', $vals[$diaKey]['fim'] ?? '');
                                 @endphp
                                 <tr>
                                     <td class="py-1">{{ $diaLabel }}</td>
                                     <td>
-                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ $ini }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ $ini }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
                                     </td>
                                     <td>
-                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ $fim }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ $fim }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
                                     </td>
                                 </tr>
                             @endforeach

--- a/resources/views/profissionais/show.blade.php
+++ b/resources/views/profissionais/show.blade.php
@@ -89,6 +89,49 @@
             </div>
         </x-accordion-section>
         @endif
+        <x-accordion-section title="Horário de trabalho">
+            @php
+                $diasSemana = [
+                    'segunda' => 'Segunda-feira',
+                    'terca' => 'Terça-feira',
+                    'quarta' => 'Quarta-feira',
+                    'quinta' => 'Quinta-feira',
+                    'sexta' => 'Sexta-feira',
+                    'sabado' => 'Sábado',
+                    'domingo' => 'Domingo',
+                ];
+            @endphp
+            @foreach($clinics as $clinic)
+                @php $vals = $horarios[$clinic->id] ?? []; @endphp
+                <div class="mb-4">
+                    @if($clinics->count() > 1)
+                        <h3 class="mb-2 text-sm font-medium text-gray-700">{{ $clinic->nome }}</h3>
+                    @endif
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr>
+                                <th class="text-left py-1">Dia</th>
+                                <th class="text-left py-1">Início</th>
+                                <th class="text-left py-1">Fim</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($diasSemana as $diaKey => $diaLabel)
+                                @php
+                                    $ini = $vals[$diaKey]['inicio'] ?? null;
+                                    $fim = $vals[$diaKey]['fim'] ?? null;
+                                @endphp
+                                <tr>
+                                    <td class="py-1">{{ $diaLabel }}</td>
+                                    <td>{{ $ini ? substr($ini,0,5) : '-' }}</td>
+                                    <td>{{ $fim ? substr($fim,0,5) : '-' }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endforeach
+        </x-accordion-section>
     </div>
 </div>
 @endsection


### PR DESCRIPTION
## Summary
- show working hours on professional details page
- restrict time inputs to clinic opening and closing

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6882654e62d0832abaf31e34c0a155db