### PR TITLE
Improve work schedule validation

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -235,6 +235,32 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    document.querySelectorAll('.work-schedule').forEach(section => {
+        section.querySelectorAll('tr[data-dia]').forEach(row => {
+            const inicio = row.querySelector('input[data-role="inicio"]');
+            const fim = row.querySelector('input[data-role="fim"]');
+            if (!inicio || !fim) return;
+            const min = inicio.getAttribute('min');
+            const max = inicio.getAttribute('max');
+            const validate = () => {
+                inicio.setCustomValidity('');
+                fim.setCustomValidity('');
+                if (inicio.value && min && inicio.value < min) {
+                    inicio.setCustomValidity('Início antes da abertura');
+                }
+                if (fim.value && max && fim.value > max) {
+                    fim.setCustomValidity('Fim após o fechamento');
+                }
+                if (inicio.value && fim.value && fim.value <= inicio.value) {
+                    fim.setCustomValidity('Fim deve ser após o início');
+                }
+            };
+            inicio.addEventListener('input', validate);
+            fim.addEventListener('input', validate);
+            validate();
+        });
+    });
+
 
     const charts = [
         {

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -241,7 +241,7 @@
                 ];
             @endphp
             @foreach($clinics as $clinic)
-                <div class="mb-4">
+                <div class="mb-4 work-schedule">
                     @if($clinics->count() > 1)
                         <h3 class="mb-2 text-sm font-medium text-gray-700">{{ $clinic->nome }}</h3>
                     @endif
@@ -258,13 +258,13 @@
                                 @php
                                     $ref = $clinic->horarios->firstWhere('dia_semana', $diaKey);
                                 @endphp
-                                <tr>
+                                <tr data-dia="{{ $diaKey }}">
                                     <td class="py-1">{{ $diaLabel }}</td>
                                     <td>
-                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio') }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                        <input type="time" data-role="inicio" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio') }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
                                     </td>
                                     <td>
-                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim') }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                        <input type="time" data-role="fim" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim') }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
                                     </td>
                                 </tr>
                             @endforeach

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -245,7 +245,7 @@
                 @php
                     $vals = $horarios[$clinic->id] ?? [];
                 @endphp
-                <div class="mb-4">
+                <div class="mb-4 work-schedule">
                     @if($clinics->count() > 1)
                         <h3 class="mb-2 text-sm font-medium text-gray-700">{{ $clinic->nome }}</h3>
                     @endif
@@ -264,13 +264,13 @@
                                     $ini = old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio', $vals[$diaKey]['inicio'] ?? '');
                                     $fim = old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim', $vals[$diaKey]['fim'] ?? '');
                                 @endphp
-                                <tr>
+                                <tr data-dia="{{ $diaKey }}">
                                     <td class="py-1">{{ $diaLabel }}</td>
                                     <td>
-                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ $ini }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                        <input type="time" data-role="inicio" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ $ini }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
                                     </td>
                                     <td>
-                                        <input type="time" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ $fim }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
+                                        <input type="time" data-role="fim" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ $fim }}" @if($ref) min="{{ $ref->hora_inicio }}" max="{{ $ref->hora_fim }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
                                     </td>
                                 </tr>
                             @endforeach

--- a/resources/views/profissionais/show.blade.php
+++ b/resources/views/profissionais/show.blade.php
@@ -103,7 +103,7 @@
             @endphp
             @foreach($clinics as $clinic)
                 @php $vals = $horarios[$clinic->id] ?? []; @endphp
-                <div class="mb-4">
+                <div class="mb-4 work-schedule">
                     @if($clinics->count() > 1)
                         <h3 class="mb-2 text-sm font-medium text-gray-700">{{ $clinic->nome }}</h3>
                     @endif


### PR DESCRIPTION
## Summary
- add `work-schedule` containers with data attributes in professional forms
- validate work schedule times on the frontend

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68826748f6c0832aa10ffae06fc8ab4c