### PR TITLE
Remove work schedule accordion

### DIFF
--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -223,53 +223,6 @@
                 </div>
             </div>
         </x-accordion-section>
-        <x-accordion-section title="Horário de trabalho">
-            @php
-                $diasSemana = [
-                    'segunda' => 'Segunda-feira',
-                    'terca' => 'Terça-feira',
-                    'quarta' => 'Quarta-feira',
-                    'quinta' => 'Quinta-feira',
-                    'sexta' => 'Sexta-feira',
-                    'sabado' => 'Sábado',
-                    'domingo' => 'Domingo',
-                ];
-            @endphp
-            @foreach($clinics as $clinic)
-                <div class="mb-4 work-schedule">
-                    @if($clinics->count() > 1)
-                        <h3 class="mb-2 text-sm font-medium text-gray-700">{{ $clinic->nome }}</h3>
-                    @endif
-                    <table class="w-full text-sm">
-                        <thead>
-                            <tr>
-                                <th class="text-left py-1">Dia</th>
-                                <th class="text-left py-1">Início</th>
-                                <th class="text-left py-1">Fim</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach($diasSemana as $diaKey => $diaLabel)
-                                @php
-                                    $ref = $clinic->horarios->firstWhere('dia_semana', $diaKey);
-                                    $min = $ref ? substr($ref->hora_inicio, 0, 5) : null;
-                                    $max = $ref ? substr($ref->hora_fim, 0, 5) : null;
-                                @endphp
-                                <tr data-dia="{{ $diaKey }}">
-                                    <td class="py-1">{{ $diaLabel }}</td>
-                                    <td>
-                                        <input type="time" data-role="inicio" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio') }}" @if($ref) min="{{ $min }}" max="{{ $max }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
-                                    </td>
-                                    <td>
-                                        <input type="time" data-role="fim" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim') }}" @if($ref) min="{{ $min }}" max="{{ $max }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
-                                    </td>
-                                </tr>
-                            @endforeach
-                        </tbody>
-                    </table>
-                </div>
-            @endforeach
-        </x-accordion-section>
     </div>
     <div x-show="activeTab === 'rem'" x-cloak class="space-y-6">
         <x-accordion-section title="Remuneração e Comissionamento" :open="true">

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -224,58 +224,6 @@
                 </div>
             </div>
         </x-accordion-section>
-        <x-accordion-section title="Horário de trabalho">
-            @php
-                $diasSemana = [
-                    'segunda' => 'Segunda-feira',
-                    'terca' => 'Terça-feira',
-                    'quarta' => 'Quarta-feira',
-                    'quinta' => 'Quinta-feira',
-                    'sexta' => 'Sexta-feira',
-                    'sabado' => 'Sábado',
-                    'domingo' => 'Domingo',
-                ];
-            @endphp
-            @foreach($clinics as $clinic)
-                @php
-                    $vals = $horarios[$clinic->id] ?? [];
-                @endphp
-                <div class="mb-4 work-schedule">
-                    @if($clinics->count() > 1)
-                        <h3 class="mb-2 text-sm font-medium text-gray-700">{{ $clinic->nome }}</h3>
-                    @endif
-                    <table class="w-full text-sm">
-                        <thead>
-                            <tr>
-                                <th class="text-left py-1">Dia</th>
-                                <th class="text-left py-1">Início</th>
-                                <th class="text-left py-1">Fim</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach($diasSemana as $diaKey => $diaLabel)
-                                @php
-                                    $ref = $clinic->horarios->firstWhere('dia_semana', $diaKey);
-                                    $min = $ref ? substr($ref->hora_inicio, 0, 5) : null;
-                                    $max = $ref ? substr($ref->hora_fim, 0, 5) : null;
-                                    $ini = old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.inicio', $vals[$diaKey]['inicio'] ?? '');
-                                    $fim = old('horarios_trabalho.' . $clinic->id . '.' . $diaKey . '.fim', $vals[$diaKey]['fim'] ?? '');
-                                @endphp
-                                <tr data-dia="{{ $diaKey }}">
-                                    <td class="py-1">{{ $diaLabel }}</td>
-                                    <td>
-                                        <input type="time" data-role="inicio" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][inicio]" value="{{ $ini }}" @if($ref) min="{{ $min }}" max="{{ $max }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
-                                    </td>
-                                    <td>
-                                        <input type="time" data-role="fim" name="horarios_trabalho[{{ $clinic->id }}][{{ $diaKey }}][fim]" value="{{ $fim }}" @if($ref) min="{{ $min }}" max="{{ $max }}" @endif class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-1 px-2 text-sm text-black focus:border-primary focus:outline-none" />
-                                    </td>
-                                </tr>
-                            @endforeach
-                        </tbody>
-                    </table>
-                </div>
-            @endforeach
-        </x-accordion-section>
     </div>
     <div x-show="activeTab === 'rem'" x-cloak class="space-y-6">
         <x-accordion-section title="Remuneração e Comissionamento" :open="true">


### PR DESCRIPTION
## Summary
- remove Horário de trabalho section from professional create/edit forms

## Testing
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882748f99ec832aadf0372c6b0cbe0c