### PR TITLE
Add missing fields for professionals

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -78,11 +78,11 @@ class ProfessionalController extends Controller
         }
 
 
-        $profissional = Profissional::create([
+        $profissional = Profissional::create(array_merge([
             'organization_id' => auth()->user()->organization_id,
             'person_id' => $person->id,
             'user_id' => $user?->id,
-        ]);
+        ], $this->extractProfessionalData($data)));
 
         $this->saveWorkSchedules($profissional, $request->input('horarios_trabalho', []));
 
@@ -120,7 +120,7 @@ class ProfessionalController extends Controller
 
         $profissional->person->update($personData);
 
-        $profissional->save();
+        $profissional->update($this->extractProfessionalData($data));
         $this->saveWorkSchedules($profissional, $request->input('horarios_trabalho', []), true);
         return redirect()->route('profissionais.index')->with('success', 'Profissional atualizado com sucesso.');
     }
@@ -153,6 +153,29 @@ class ProfessionalController extends Controller
             'cidade' => 'nullable',
             'estado' => 'nullable',
             'foto' => 'nullable|image',
+            'numero_funcionario' => 'nullable',
+            'email_corporativo' => 'nullable|email',
+            'data_admissao' => 'nullable|date',
+            'data_demissao' => 'nullable|date',
+            'tipo_contrato' => 'nullable',
+            'data_inicio_contrato' => 'nullable|date',
+            'data_fim_contrato' => 'nullable|date',
+            'carga_horaria' => 'nullable|integer',
+            'total_horas_semanais' => 'nullable|integer',
+            'regime_trabalho' => 'nullable',
+            'funcao' => 'nullable',
+            'cargo' => 'nullable',
+            'cro' => 'nullable',
+            'cro_uf' => 'nullable',
+            'salario_fixo' => 'nullable|numeric',
+            'salario_periodo' => 'nullable',
+            'conta' => 'array',
+            'conta.nome_banco' => 'nullable',
+            'conta.tipo' => 'nullable',
+            'conta.agencia' => 'nullable',
+            'conta.numero' => 'nullable',
+            'conta.cpf_cnpj' => 'nullable',
+            'chave_pix' => 'nullable',
             'horarios_trabalho' => 'array',
             'comissoes' => 'array',
             'comissoes.*.comissao' => 'nullable|numeric|between:0,100',
@@ -217,6 +240,31 @@ class ProfessionalController extends Controller
             'bairro' => $data['bairro'] ?? null,
             'cidade' => $data['cidade'] ?? null,
             'estado' => $data['estado'] ?? null,
+        ];
+    }
+
+    private function extractProfessionalData(array $data): array
+    {
+        return [
+            'numero_funcionario' => $data['numero_funcionario'] ?? null,
+            'email_corporativo' => $data['email_corporativo'] ?? null,
+            'data_admissao' => $data['data_admissao'] ?? null,
+            'data_demissao' => $data['data_demissao'] ?? null,
+            'tipo_contrato' => $data['tipo_contrato'] ?? null,
+            'data_inicio_contrato' => $data['data_inicio_contrato'] ?? null,
+            'data_fim_contrato' => $data['data_fim_contrato'] ?? null,
+            'carga_horaria' => $data['carga_horaria'] ?? null,
+            'total_horas_semanais' => $data['total_horas_semanais'] ?? null,
+            'regime_trabalho' => $data['regime_trabalho'] ?? null,
+            'funcao' => $data['funcao'] ?? null,
+            'cargo' => $data['cargo'] ?? null,
+            'cro' => $data['cro'] ?? null,
+            'cro_uf' => $data['cro_uf'] ?? null,
+            'salario_fixo' => $data['salario_fixo'] ?? null,
+            'salario_periodo' => $data['salario_periodo'] ?? null,
+            'comissoes' => $data['comissoes'] ?? null,
+            'conta' => $data['conta'] ?? null,
+            'chave_pix' => $data['chave_pix'] ?? null,
         ];
     }
 

--- a/app/Models/Profissional.php
+++ b/app/Models/Profissional.php
@@ -20,9 +20,38 @@ class Profissional extends Model
         'organization_id',
         'person_id',
         'user_id',
+        'numero_funcionario',
+        'email_corporativo',
+        'data_admissao',
+        'data_demissao',
+        'tipo_contrato',
+        'data_inicio_contrato',
+        'data_fim_contrato',
+        'carga_horaria',
+        'total_horas_semanais',
+        'regime_trabalho',
+        'funcao',
+        'cargo',
+        'cro',
+        'cro_uf',
+        'salario_fixo',
+        'salario_periodo',
+        'comissoes',
+        'conta',
+        'chave_pix',
     ];
 
-    protected $casts = [];
+    protected $casts = [
+        'data_admissao' => 'date',
+        'data_demissao' => 'date',
+        'data_inicio_contrato' => 'date',
+        'data_fim_contrato' => 'date',
+        'carga_horaria' => 'integer',
+        'total_horas_semanais' => 'integer',
+        'salario_fixo' => 'decimal:2',
+        'comissoes' => 'array',
+        'conta' => 'array',
+    ];
 
     public function organization()
     {

--- a/database/migrations/2025_10_02_000000_add_extra_fields_to_profissionais_table.php
+++ b/database/migrations/2025_10_02_000000_add_extra_fields_to_profissionais_table.php
@@ -1,0 +1,43 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('profissionais', function (Blueprint $table) {
+            $table->string('numero_funcionario')->nullable()->after('user_id');
+            $table->string('email_corporativo')->nullable()->after('numero_funcionario');
+            $table->date('data_admissao')->nullable()->after('email_corporativo');
+            $table->date('data_demissao')->nullable()->after('data_admissao');
+            $table->string('tipo_contrato')->nullable()->after('data_demissao');
+            $table->date('data_inicio_contrato')->nullable()->after('tipo_contrato');
+            $table->date('data_fim_contrato')->nullable()->after('data_inicio_contrato');
+            $table->integer('carga_horaria')->nullable()->after('data_fim_contrato');
+            $table->integer('total_horas_semanais')->nullable()->after('carga_horaria');
+            $table->string('regime_trabalho')->nullable()->after('total_horas_semanais');
+            $table->string('funcao')->nullable()->after('regime_trabalho');
+            $table->string('cargo')->nullable()->after('funcao');
+            $table->string('cro')->nullable()->after('cargo');
+            $table->string('cro_uf')->nullable()->after('cro');
+            $table->decimal('salario_fixo', 10, 2)->nullable()->after('cro_uf');
+            $table->string('salario_periodo')->nullable()->after('salario_fixo');
+            $table->json('comissoes')->nullable()->after('salario_periodo');
+            $table->json('conta')->nullable()->after('comissoes');
+            $table->string('chave_pix')->nullable()->after('conta');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('profissionais', function (Blueprint $table) {
+            $table->dropColumn([
+                'numero_funcionario','email_corporativo','data_admissao','data_demissao',
+                'tipo_contrato','data_inicio_contrato','data_fim_contrato','carga_horaria',
+                'total_horas_semanais','regime_trabalho','funcao','cargo','cro','cro_uf',
+                'salario_fixo','salario_periodo','comissoes','conta','chave_pix'
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration with the remaining professional columns
- allow `Profissional` model to manage new columns
- store/update those fields in `ProfessionalController`

## Testing
- `php -l app/Models/Profissional.php`
- `php -l app/Http/Controllers/Admin/ProfessionalController.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688277e5f550832aabb5fd5b338e22c1