### PR TITLE
Add clinic assignment to professionals

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -84,6 +84,8 @@ class ProfessionalController extends Controller
             'user_id' => $user?->id,
         ], $this->extractProfessionalData($data)));
 
+        $profissional->clinics()->sync($request->input('clinics', []));
+
         $this->saveWorkSchedules($profissional, $request->input('horarios_trabalho', []));
 
         return redirect()->route('profissionais.index')->with('success', 'Profissional salvo com sucesso.');
@@ -121,6 +123,7 @@ class ProfessionalController extends Controller
         $profissional->person->update($personData);
 
         $profissional->update($this->extractProfessionalData($data));
+        $profissional->clinics()->sync($request->input('clinics', []));
         $this->saveWorkSchedules($profissional, $request->input('horarios_trabalho', []), true);
         return redirect()->route('profissionais.index')->with('success', 'Profissional atualizado com sucesso.');
     }
@@ -160,7 +163,6 @@ class ProfessionalController extends Controller
             'tipo_contrato' => 'nullable',
             'data_inicio_contrato' => 'nullable|date',
             'data_fim_contrato' => 'nullable|date',
-            'carga_horaria' => 'nullable|integer',
             'total_horas_semanais' => 'nullable|integer',
             'regime_trabalho' => 'nullable',
             'funcao' => 'nullable',
@@ -180,6 +182,8 @@ class ProfessionalController extends Controller
             'comissoes' => 'array',
             'comissoes.*.comissao' => 'nullable|numeric|between:0,100',
             'comissoes.*.protese' => 'nullable|numeric|between:0,100',
+            'clinics' => 'array',
+            'clinics.*' => 'exists:clinics,id',
         ];
 
         $validator = Validator::make($request->all(), $rules);
@@ -253,7 +257,6 @@ class ProfessionalController extends Controller
             'tipo_contrato' => $data['tipo_contrato'] ?? null,
             'data_inicio_contrato' => $data['data_inicio_contrato'] ?? null,
             'data_fim_contrato' => $data['data_fim_contrato'] ?? null,
-            'carga_horaria' => $data['carga_horaria'] ?? null,
             'total_horas_semanais' => $data['total_horas_semanais'] ?? null,
             'regime_trabalho' => $data['regime_trabalho'] ?? null,
             'funcao' => $data['funcao'] ?? null,

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -8,6 +8,7 @@ use App\Models\Cadeira;
 use App\Traits\BelongsToOrganization;
 use App\Models\Organization;
 use App\Models\ClinicUser;
+use App\Models\Profissional;
 
 class Clinic extends Model
 {
@@ -54,5 +55,10 @@ class Clinic extends Model
             ->using(ClinicUser::class)
             ->withPivot('profile_id')
             ->withTimestamps();
+    }
+
+    public function profissionais()
+    {
+        return $this->belongsToMany(Profissional::class, 'clinic_profissional')->withTimestamps();
     }
 }

--- a/app/Models/Profissional.php
+++ b/app/Models/Profissional.php
@@ -27,7 +27,6 @@ class Profissional extends Model
         'tipo_contrato',
         'data_inicio_contrato',
         'data_fim_contrato',
-        'carga_horaria',
         'total_horas_semanais',
         'regime_trabalho',
         'funcao',
@@ -46,7 +45,6 @@ class Profissional extends Model
         'data_demissao' => 'date',
         'data_inicio_contrato' => 'date',
         'data_fim_contrato' => 'date',
-        'carga_horaria' => 'integer',
         'total_horas_semanais' => 'integer',
         'salario_fixo' => 'decimal:2',
         'comissoes' => 'array',
@@ -71,5 +69,10 @@ class Profissional extends Model
     public function horariosTrabalho()
     {
         return $this->hasMany(ProfissionalHorario::class);
+    }
+
+    public function clinics()
+    {
+        return $this->belongsToMany(Clinic::class, 'clinic_profissional')->withTimestamps();
     }
 }

--- a/database/migrations/2025_10_03_000000_create_clinic_profissional_table.php
+++ b/database/migrations/2025_10_03_000000_create_clinic_profissional_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('clinic_profissional', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinic_id')->constrained('clinics');
+            $table->foreignId('profissional_id')->constrained('profissionais');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clinic_profissional');
+    }
+};

--- a/database/migrations/2025_10_03_000001_drop_carga_horaria_from_profissionais_table.php
+++ b/database/migrations/2025_10_03_000001_drop_carga_horaria_from_profissionais_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('profissionais', function (Blueprint $table) {
+            if (Schema::hasColumn('profissionais', 'carga_horaria')) {
+                $table->dropColumn('carga_horaria');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('profissionais', function (Blueprint $table) {
+            $table->integer('carga_horaria')->nullable()->after('data_fim_contrato');
+        });
+    }
+};

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -170,12 +170,19 @@
                     <input type="date" name="data_fim_contrato" value="{{ old('data_fim_contrato') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Carga horária semanal</label>
-                    <input type="number" name="carga_horaria" value="{{ old('carga_horaria') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
-                </div>
-                <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Total de horas semanais</label>
                     <input type="number" name="total_horas_semanais" value="{{ old('total_horas_semanais') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                </div>
+                <div class="sm:col-span-2">
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">Clínicas</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        @foreach($clinics as $clinic)
+                            <label class="flex items-center space-x-2">
+                                <input type="checkbox" name="clinics[]" value="{{ $clinic->id }}" @checked(in_array($clinic->id, old('clinics', []))) class="rounded border-stroke" />
+                                <span>{{ $clinic->nome }}</span>
+                            </label>
+                        @endforeach
+                    </div>
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Regime de trabalho</label>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -171,12 +171,19 @@
                     <input type="date" name="data_fim_contrato" value="{{ old('data_fim_contrato', optional($profissional->data_fim_contrato)->format('Y-m-d')) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Carga horária semanal</label>
-                    <input type="number" name="carga_horaria" value="{{ old('carga_horaria', $profissional->carga_horaria ?? '') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
-                </div>
-                <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Total de horas semanais</label>
                     <input type="number" name="total_horas_semanais" value="{{ old('total_horas_semanais', $profissional->total_horas_semanais ?? '') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                </div>
+                <div class="sm:col-span-2">
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">Clínicas</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        @foreach($clinics as $clinic)
+                            <label class="flex items-center space-x-2">
+                                <input type="checkbox" name="clinics[]" value="{{ $clinic->id }}" @checked(in_array($clinic->id, old('clinics', $profissional->clinics->pluck('id')->toArray()))) class="rounded border-stroke" />
+                                <span>{{ $clinic->nome }}</span>
+                            </label>
+                        @endforeach
+                    </div>
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Regime de trabalho</label>


### PR DESCRIPTION
## Summary
- allow linking professionals to multiple clinics
- remove weekly workload field from professionals
- show clinic checkboxes in professional forms
- drop `carga_horaria` field from DB and create pivot table for clinics

## Testing
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68828abf4ac4832a96373022fc07f82b