### PR TITLE
Fix modal centering

### DIFF
--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -53,7 +53,7 @@
         </tbody>
     </table>
 </div>
-<div id="escala-modal" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">
+<div id="escala-modal" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
     <div class="bg-white rounded p-4 w-80">
         <form method="POST" action="{{ route('escalas.store') }}" class="space-y-4">
             @csrf


### PR DESCRIPTION
## Summary
- ensure lightbox overlay acts as a flex container so the modal centers correctly

## Testing
- `php --version`

------
https://chatgpt.com/codex/tasks/task_e_688490e80a90832aa618839b6f1e9758