### PR TITLE
Fix dentists filter for work schedule

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -25,9 +25,12 @@ class EscalaTrabalhoController extends Controller
             ->where('semana', $week->toDateString())
             ->get()
             ->groupBy(['cadeira_id','dia_semana']);
-        $dentistas = Profissional::where('cargo', 'like', '%dent%')
-            ->orWhere('cargo', 'like', '%odont%')
-            ->get();
+        $dentistas = Profissional::where(function ($q) {
+            $q->where('cargo', 'like', '%dent%')
+              ->orWhere('cargo', 'like', '%odont%')
+              ->orWhere('funcao', 'like', '%dent%')
+              ->orWhere('funcao', 'like', '%odont%');
+        })->get();
         return view('escalas.index', compact('clinics','clinicId','week','dias','cadeiras','schedules','dentistas'));
     }
 


### PR DESCRIPTION
## Summary
- include `funcao` column when filtering professionals for work schedule

## Testing
- `php -l app/Http/Controllers/Admin/EscalaTrabalhoController.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688492787668832aac896d151087cb8c