### PR TITLE
Fix duplicate clinic checkbox fields

### DIFF
--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -199,17 +199,6 @@
                         <option value="Híbrido" @selected(old('regime_trabalho')==='Híbrido')>Híbrido</option>
                     </select>
                 </div>
-                <div class="sm:col-span-2">
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Clínicas</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                        @foreach($clinics as $clinic)
-                            <label class="flex items-center space-x-2">
-                                <input type="checkbox" name="clinics[]" value="{{ $clinic->id }}" @checked(in_array($clinic->id, old('clinics', []))) class="rounded border-stroke" />
-                                <span>{{ $clinic->nome }}</span>
-                            </label>
-                        @endforeach
-                    </div>
-                </div>
             </div>
         </x-accordion-section>
         <x-accordion-section title="Atribuição">

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -200,17 +200,6 @@
                         <option value="Híbrido" @selected(old('regime_trabalho', $profissional->regime_trabalho ?? '')==='Híbrido')>Híbrido</option>
                     </select>
                 </div>
-                <div class="sm:col-span-2">
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Clínicas</label>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                        @foreach($clinics as $clinic)
-                            <label class="flex items-center space-x-2">
-                                <input type="checkbox" name="clinics[]" value="{{ $clinic->id }}" @checked(in_array($clinic->id, old('clinics', $profissional->clinics->pluck('id')->toArray()))) class="rounded border-stroke" />
-                                <span>{{ $clinic->nome }}</span>
-                            </label>
-                        @endforeach
-                    </div>
-                </div>
             </div>
         </x-accordion-section>
         <x-accordion-section title="Atribuição">


### PR DESCRIPTION
## Summary
- remove duplicate clinics checkbox group in Professional create/edit forms

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688492b9504c832a8af7770680806125