### PR TITLE
Fix week day mapping for dynamic schedule

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -47,8 +47,16 @@ class AgendaController extends Controller
             return response()->json(['closed' => true]);
         }
 
-        $dias = ['segunda', 'terca', 'quarta', 'quinta', 'sexta', 'sabado', 'domingo'];
-        $dia = $dias[$date->dayOfWeekIso - 1];
+        $dias = [
+            1 => 'segunda',
+            2 => 'terca',
+            3 => 'quarta',
+            4 => 'quinta',
+            5 => 'sexta',
+            6 => 'sabado',
+            0 => 'domingo',
+        ];
+        $dia = $dias[$date->dayOfWeek];
 
         $intervalos = \App\Models\Horario::where('clinic_id', $clinicId)
             ->where('dia_semana', $dia)


### PR DESCRIPTION
## Summary
- adjust day-of-week mapping in `AgendaController@horarios`
- use `dayOfWeek` to correctly read clinic hours

## Testing
- `php -l app/Http/Controllers/Admin/AgendaController.php`
- `php artisan test` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_688629cff958832ab5e2051df15d53a6