### PR TITLE
Fix clinic schedule detection

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -47,6 +47,11 @@ class AgendaController extends Controller
             return response()->json(['closed' => true]);
         }
 
+        $clinic = \App\Models\Clinic::with('horarios')->find($clinicId);
+        if (! $clinic) {
+            return response()->json(['closed' => true]);
+        }
+
         $dias = [
             1 => 'segunda',
             2 => 'terca',
@@ -58,7 +63,8 @@ class AgendaController extends Controller
         ];
         $dia = $dias[$date->dayOfWeek];
 
-        $intervalos = \App\Models\Horario::where('clinic_id', $clinicId)
+        $intervalos = $clinic->horarios()
+            ->withoutGlobalScope('organization')
             ->where('dia_semana', $dia)
             ->orderBy('hora_inicio')
             ->get();

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -66,6 +66,7 @@ class ClinicController extends Controller
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinic_id' => $clinic->id,
+                    'organization_id' => $clinic->organization_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],
@@ -137,6 +138,7 @@ class ClinicController extends Controller
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinic_id' => $clinic->id,
+                    'organization_id' => $clinic->organization_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],


### PR DESCRIPTION
## Summary
- fetch clinic info before building schedule times
- include organization in clinic operating hours records

## Testing
- `php -l app/Http/Controllers/Admin/ClinicController.php`
- `php -l app/Http/Controllers/Admin/AgendaController.php`
- ❌ `php artisan --version` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_68862dfcd51c832a9f78dbe0af5783ed