### PR TITLE
Fix clinic schedule detection

### DIFF
--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -66,6 +66,7 @@ class ClinicController extends Controller
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinic_id' => $clinic->id,
+                    'organization_id' => $clinic->organization_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],
@@ -137,6 +138,7 @@ class ClinicController extends Controller
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinic_id' => $clinic->id,
+                    'organization_id' => $clinic->organization_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -95,6 +95,17 @@ window.agendaCalendar = function agendaCalendar() {
                         data.end,
                         data.closed
                     );
+                    const dbg = document.getElementById('clinic-hours-debug');
+                    if (dbg) {
+                        if (data.intervals && data.intervals.length) {
+                            const list = data.intervals.map(i => `${i.inicio}-${i.fim}`).join(', ');
+                            dbg.textContent = `Horários de funcionamento: ${list}`;
+                        } else if (data.closed) {
+                            dbg.textContent = 'Horários de funcionamento: fechado';
+                        } else {
+                            dbg.textContent = '';
+                        }
+                    }
                 });
         },
     };

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -124,6 +124,7 @@
         </tbody>
     </table>
 </div>
+<pre id="clinic-hours-debug" class="text-xs text-gray-500 mt-2"></pre>
 <div id="schedule-modal" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
     <div class="bg-white rounded p-4 w-80">
         <h2 class="text-lg font-semibold mb-4">Agendar Horário</h2>


### PR DESCRIPTION
## Summary
- fetch clinic info before building schedule times
- include organization in clinic operating hours records
- show clinic hours for the selected day so admins can debug schedules

## Testing
- `php -l app/Http/Controllers/Admin/ClinicController.php`
- `php -l app/Http/Controllers/Admin/AgendaController.php`
- ❌ `php artisan --version` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_68862dfcd51c832a9f78dbe0af5783ed