### PR TITLE
Fix clinic schedule detection

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -47,6 +47,11 @@ class AgendaController extends Controller
             return response()->json(['closed' => true]);
         }
 
+        $clinic = \App\Models\Clinic::find($clinicId);
+        if (! $clinic) {
+            return response()->json(['closed' => true]);
+        }
+
         $dias = [
             1 => 'segunda',
             2 => 'terca',
@@ -58,7 +63,8 @@ class AgendaController extends Controller
         ];
         $dia = $dias[$date->dayOfWeek];
 
-        $intervalos = \App\Models\Horario::where('clinic_id', $clinicId)
+        $intervalos = \App\Models\Horario::withoutGlobalScopes()
+            ->where('clinic_id', $clinicId)
             ->where('dia_semana', $dia)
             ->orderBy('hora_inicio')
             ->get();
@@ -70,6 +76,7 @@ class AgendaController extends Controller
         $horarios = [];
         $startTimes = [];
         $endTimes = [];
+        $debugIntervals = [];
         foreach ($intervalos as $int) {
             if (!$int->hora_inicio || !$int->hora_fim) {
                 continue;
@@ -78,6 +85,10 @@ class AgendaController extends Controller
             $end = Carbon::createFromTimeString($int->hora_fim);
             $startTimes[] = $start->format('H:i');
             $endTimes[] = $end->format('H:i');
+            $debugIntervals[] = [
+                'inicio' => $start->format('H:i'),
+                'fim' => $end->format('H:i'),
+            ];
             for ($time = $start->copy(); $time <= $end; $time->addMinutes(30)) {
                 $horarios[] = $time->format('H:i');
             }
@@ -89,11 +100,15 @@ class AgendaController extends Controller
         $startTime = min($startTimes);
         $endTime = max($endTimes);
 
+        // Uncomment the line below for raw dump of schedule intervals during debugging
+        // dd($debugIntervals);
+
         return response()->json([
             'closed' => false,
             'horarios' => $horarios,
             'start' => $startTime,
             'end' => $endTime,
+            'intervals' => $debugIntervals,
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -66,6 +66,7 @@ class ClinicController extends Controller
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinic_id' => $clinic->id,
+                    'organization_id' => $clinic->organization_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],
@@ -137,6 +138,7 @@ class ClinicController extends Controller
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinic_id' => $clinic->id,
+                    'organization_id' => $clinic->organization_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -95,6 +95,17 @@ window.agendaCalendar = function agendaCalendar() {
                         data.end,
                         data.closed
                     );
+                    const dbg = document.getElementById('clinic-hours-debug');
+                    if (dbg) {
+                        if (data.intervals && data.intervals.length) {
+                            const list = data.intervals.map(i => `${i.inicio}-${i.fim}`).join(', ');
+                            dbg.textContent = `Horários de funcionamento: ${list}`;
+                        } else if (data.closed) {
+                            dbg.textContent = 'Horários de funcionamento: fechado';
+                        } else {
+                            dbg.textContent = '';
+                        }
+                    }
                 });
         },
     };

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -124,6 +124,7 @@
         </tbody>
     </table>
 </div>
+<pre id="clinic-hours-debug" class="text-xs text-gray-500 mt-2"></pre>
 <div id="schedule-modal" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
     <div class="bg-white rounded p-4 w-80">
         <h2 class="text-lg font-semibold mb-4">Agendar Horário</h2>


### PR DESCRIPTION
## Summary
- remove global scopes when retrieving clinic operating hours
- keep debug info for selected day

## Testing
- `php -l app/Http/Controllers/Admin/AgendaController.php`
- `php -l app/Http/Controllers/Admin/ClinicController.php`
- ❌ `php artisan --version` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_68862dfcd51c832a9f78dbe0af5783ed