### PR TITLE
Use Carbon constants for agenda weekdays

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -53,15 +53,15 @@ class AgendaController extends Controller
         }
 
         $dias = [
-            1 => 'segunda',
-            2 => 'terca',
-            3 => 'quarta',
-            4 => 'quinta',
-            5 => 'sexta',
-            6 => 'sabado',
-            0 => 'domingo',
+            Carbon::MONDAY    => 'segunda',
+            Carbon::TUESDAY   => 'terca',
+            Carbon::WEDNESDAY => 'quarta',
+            Carbon::THURSDAY  => 'quinta',
+            Carbon::FRIDAY    => 'sexta',
+            Carbon::SATURDAY  => 'sabado',
+            Carbon::SUNDAY    => 'domingo',
         ];
-        $dia = $dias[$date->dayOfWeek];
+        $dia = $dias[$date->dayOfWeekIso];
 
         $intervalos = \App\Models\Horario::withoutGlobalScopes()
             ->where('clinic_id', $clinicId)


### PR DESCRIPTION
## Summary
- simplify day-of-week mapping

## Testing
- `php -l app/Http/Controllers/Admin/AgendaController.php`
- `composer install` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68863bef4cdc832a8ea4a27190398d60