### PR TITLE
Fix Sunday schedule handling

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -52,16 +52,20 @@ class AgendaController extends Controller
             return response()->json(['closed' => true]);
         }
 
-        $dias = [
-            Carbon::MONDAY    => 'segunda',
-            Carbon::TUESDAY   => 'terca',
-            Carbon::WEDNESDAY => 'quarta',
-            Carbon::THURSDAY  => 'quinta',
-            Carbon::FRIDAY    => 'sexta',
-            Carbon::SATURDAY  => 'sabado',
-            Carbon::SUNDAY    => 'domingo',
+        $diasIso = [
+            1 => 'segunda',
+            2 => 'terca',
+            3 => 'quarta',
+            4 => 'quinta',
+            5 => 'sexta',
+            6 => 'sabado',
+            7 => 'domingo',
         ];
-        $dia = $dias[$date->dayOfWeekIso];
+        $dia = $diasIso[$date->dayOfWeekIso] ?? null;
+
+        if ($dia === null) {
+            return response()->json(['closed' => true]);
+        }
 
         $intervalos = \App\Models\Horario::withoutGlobalScopes()
             ->where('clinic_id', $clinicId)


### PR DESCRIPTION
## Summary
- fix schedule day lookup to use ISO weekday indexes
- fall back to "closed" on unexpected day index

## Testing
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_688645ca87e8832a995a9568a34f3e0e