### PR TITLE
Fix Sunday schedule handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,7 @@ If migrations are failing or producing unexpected results, try the steps below:
 2. **Verify which migrations have already run**
    - Look at the `migrations` table in your database or run
      `php artisan migrate:status` to see a list of executed migrations.
+
+## Testando o controlador de horários
+
+Execute `php scripts/test_horarios.php <data>` para verificar os horários retornados pelo endpoint `agendamentos/horarios`. Substitua `<data>` por uma data no formato `AAAA-MM-DD` (por exemplo, `2025-07-27`). O script retorna o JSON produzido pelo controlador, permitindo confirmar se o dia está mapeado corretamente.

--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -52,16 +52,20 @@ class AgendaController extends Controller
             return response()->json(['closed' => true]);
         }
 
-        $dias = [
-            Carbon::MONDAY    => 'segunda',
-            Carbon::TUESDAY   => 'terca',
-            Carbon::WEDNESDAY => 'quarta',
-            Carbon::THURSDAY  => 'quinta',
-            Carbon::FRIDAY    => 'sexta',
-            Carbon::SATURDAY  => 'sabado',
-            Carbon::SUNDAY    => 'domingo',
+        $diasIso = [
+            1 => 'segunda',
+            2 => 'terca',
+            3 => 'quarta',
+            4 => 'quinta',
+            5 => 'sexta',
+            6 => 'sabado',
+            7 => 'domingo',
         ];
-        $dia = $dias[$date->dayOfWeekIso];
+        $dia = $diasIso[$date->dayOfWeekIso] ?? null;
+
+        if ($dia === null) {
+            return response()->json(['closed' => true]);
+        }
 
         $intervalos = \App\Models\Horario::withoutGlobalScopes()
             ->where('clinic_id', $clinicId)

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -100,8 +100,6 @@ window.agendaCalendar = function agendaCalendar() {
                         if (data.intervals && data.intervals.length) {
                             const list = data.intervals.map(i => `${i.inicio}-${i.fim}`).join(', ');
                             dbg.textContent = `Horários de funcionamento: ${list}`;
-                        } else if (data.closed) {
-                            dbg.textContent = 'Horários de funcionamento: fechado';
                         } else {
                             dbg.textContent = '';
                         }

--- a/scripts/test_horarios.php
+++ b/scripts/test_horarios.php
@@ -1,0 +1,13 @@
+<?php
+require __DIR__.'/../vendor/autoload.php';
+$app = require __DIR__.'/../bootstrap/app.php';
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Admin\AgendaController;
+
+$date = $argv[1] ?? date('Y-m-d');
+$request = Request::create('/admin/agendamentos/horarios', 'GET', ['date' => $date]);
+$response = app(AgendaController::class)->horarios($request);
+
+echo $response->getContent() . PHP_EOL;


### PR DESCRIPTION
## Summary
- fix schedule day lookup to use ISO weekday indexes
- fall back to "closed" on unexpected day index
- remove debug text when schedule is closed
- add a helper script for testing schedule output

## Testing
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_688645ca87e8832a995a9568a34f3e0e