### PR TITLE
Fix clinic schedule query

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -67,7 +67,10 @@ class AgendaController extends Controller
             return response()->json(['closed' => true]);
         }
 
-        $intervalos = \App\Models\Horario::withoutGlobalScopes()
+        // Remove only the clinic scope so the organization scope remains
+        // active. This prevents pulling schedules from other organizations
+        // while still allowing queries for the selected clinic.
+        $intervalos = \App\Models\Horario::withoutGlobalScope('clinic')
             ->where('clinic_id', $clinicId)
             ->where('dia_semana', $dia)
             ->orderBy('hora_inicio')


### PR DESCRIPTION
## Summary
- scope agenda `horarios` lookup to exclude only the clinic global scope
- prevent cross-organization schedule leakage

## Testing
- `phpunit` *(fails: PHPUnit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688b8815bd84832aa3300f82e423d5e4