### PR TITLE
Enforce clinic schedule validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ If migrations are failing or producing unexpected results, try the steps below:
    - Look at the `migrations` table in your database or run
      `php artisan migrate:status` to see a list of executed migrations.
 
+### Horários de Funcionamento
+
+Ao cadastrar ou editar uma clínica, informe para cada dia da semana os campos
+**abertura** e **fechamento** no formato `HH:MM`. Se ambos forem preenchidos e o
+horário de abertura for igual ou posterior ao de fechamento, o formulário será
+devolvido com uma mensagem de erro e os dados não serão salvos.
+
 ## Testando o controlador de horários
 
 Execute `php scripts/test_horarios.php <data>` para verificar os horários retornados pelo endpoint `agendamentos/horarios`. Substitua `<data>` por uma data no formato `AAAA-MM-DD` (por exemplo, `2025-07-27`). O script retorna o JSON produzido pelo controlador, permitindo confirmar se o dia está mapeado corretamente.

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Clinic;
 use App\Rules\Cnpj;
 use Illuminate\Http\Request;
+use Carbon\Carbon;
 
 class ClinicController extends Controller
 {
@@ -53,9 +54,28 @@ class ClinicController extends Controller
             'telefone' => 'required',
             'email' => 'required|email',
             'horarios' => 'required|array',
+            'horarios.*.abertura' => 'nullable|date_format:H:i',
+            'horarios.*.fechamento' => 'nullable|date_format:H:i',
         ]);
 
         $horarios = $data['horarios'];
+
+        $errors = [];
+        foreach ($horarios as $dia => $horario) {
+            $abertura = $horario['abertura'] ?? null;
+            $fechamento = $horario['fechamento'] ?? null;
+            if ($abertura && $fechamento) {
+                $start = Carbon::createFromFormat('H:i', $abertura);
+                $end = Carbon::createFromFormat('H:i', $fechamento);
+                if ($start->gte($end)) {
+                    $errors["horarios.$dia.fechamento"] = 'Fechamento deve ser depois da abertura';
+                }
+            }
+        }
+        if ($errors) {
+            return back()->withErrors($errors)->withInput();
+        }
+
         unset($data['horarios']);
 
         $data['organization_id'] = auth()->user()->organization_id;
@@ -126,9 +146,28 @@ class ClinicController extends Controller
             'telefone' => 'required',
             'email' => 'required|email',
             'horarios' => 'required|array',
+            'horarios.*.abertura' => 'nullable|date_format:H:i',
+            'horarios.*.fechamento' => 'nullable|date_format:H:i',
         ]);
 
         $horarios = $data['horarios'];
+
+        $errors = [];
+        foreach ($horarios as $dia => $horario) {
+            $abertura = $horario['abertura'] ?? null;
+            $fechamento = $horario['fechamento'] ?? null;
+            if ($abertura && $fechamento) {
+                $start = Carbon::createFromFormat('H:i', $abertura);
+                $end = Carbon::createFromFormat('H:i', $fechamento);
+                if ($start->gte($end)) {
+                    $errors["horarios.$dia.fechamento"] = 'Fechamento deve ser depois da abertura';
+                }
+            }
+        }
+        if ($errors) {
+            return back()->withErrors($errors)->withInput();
+        }
+
         unset($data['horarios']);
 
         $clinic->update($data);


### PR DESCRIPTION
## Summary
- add strict validation for opening hours in ClinicController
- error when closing time is not after opening time
- document clinic scheduling rules in README

## Testing
- `php -l app/Http/Controllers/Admin/ClinicController.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688b92e25680832aa226f087a71a251b