### PR TITLE
Add clinic ID option to schedule test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,4 +183,4 @@ If migrations are failing or producing unexpected results, try the steps below:
 
 ## Testando o controlador de horários
 
-Execute `php scripts/test_horarios.php <data>` para verificar os horários retornados pelo endpoint `agendamentos/horarios`. Substitua `<data>` por uma data no formato `AAAA-MM-DD` (por exemplo, `2025-07-27`). O script retorna o JSON produzido pelo controlador, permitindo confirmar se o dia está mapeado corretamente.
+Execute `php scripts/test_horarios.php <data> [<clinica>]` para verificar os horários retornados pelo endpoint `agendamentos/horarios`. Substitua `<data>` por uma data no formato `AAAA-MM-DD` (por exemplo, `2025-07-27`). Opcionalmente informe o ID da clínica em `<clinica>` para testar o retorno dessa unidade específica. O script exibe o JSON produzido pelo controlador, permitindo confirmar se o dia está mapeado corretamente.

--- a/scripts/test_horarios.php
+++ b/scripts/test_horarios.php
@@ -7,7 +7,14 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Admin\AgendaController;
 
 $date = $argv[1] ?? date('Y-m-d');
+$clinicId = $argv[2] ?? null;
+
 $request = Request::create('/admin/agendamentos/horarios', 'GET', ['date' => $date]);
+
+if ($clinicId !== null) {
+    app()->instance('clinic_id', (int) $clinicId);
+}
+
 $response = app(AgendaController::class)->horarios($request);
 
 echo $response->getContent() . PHP_EOL;


### PR DESCRIPTION
## Summary
- add optional clinic ID to `scripts/test_horarios.php`
- bind provided clinic ID to the application container
- update README instructions for schedule testing

## Testing
- `php -l scripts/test_horarios.php`

------
https://chatgpt.com/codex/tasks/task_e_688b92ebb63c832a861ec4ee741c1313