### PR TITLE
Ensure AgendaController parses date with timezone

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -40,7 +40,11 @@ class AgendaController extends Controller
 
     public function horarios(Request $request)
     {
-        $date = Carbon::parse($request->query('date'));
+        $date = Carbon::createFromFormat(
+            'Y-m-d',
+            $request->query('date'),
+            config('app.timezone')
+        );
 
         $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
         if (! $clinicId) {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/tests/Unit/AgendaControllerTest.php
+++ b/tests/Unit/AgendaControllerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Carbon\Carbon;
+
+class AgendaControllerTest extends TestCase
+{
+    public function test_date_parsing_with_explicit_timezone()
+    {
+        $original = date_default_timezone_get();
+        date_default_timezone_set('Asia/Tokyo');
+
+        $date = Carbon::createFromFormat('Y-m-d', '2024-05-19', config('app.timezone'));
+
+        $this->assertSame(7, $date->dayOfWeekIso);
+
+        date_default_timezone_set($original);
+    }
+}


### PR DESCRIPTION
## Summary
- parse AgendaController date using configured timezone
- add PHPUnit bootstrap and test directories
- test AgendaController date parsing in unit tests

## Testing
- `vendor/bin/phpunit tests/Unit/AgendaControllerTest.php` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_688b9af981f4832a947de640dcbf3706