### PR TITLE
Add timezone fields for organizations and clinics

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -40,12 +40,6 @@ class AgendaController extends Controller
 
     public function horarios(Request $request)
     {
-        $date = Carbon::createFromFormat(
-            'Y-m-d',
-            $request->query('date'),
-            config('app.timezone')
-        );
-
         $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
         if (! $clinicId) {
             return response()->json(['closed' => true]);
@@ -55,6 +49,14 @@ class AgendaController extends Controller
         if (! $clinic) {
             return response()->json(['closed' => true]);
         }
+
+        $date = Carbon::createFromFormat(
+            'Y-m-d',
+            $request->query('date'),
+            $clinic->timezone ?? config('app.timezone')
+        );
+
+        $date->setTimezone($clinic->timezone ?? config('app.timezone'));
 
         $diasIso = [
             1 => 'segunda',

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -79,6 +79,7 @@ class ClinicController extends Controller
         unset($data['horarios']);
 
         $data['organization_id'] = auth()->user()->organization_id;
+        $data['timezone'] = auth()->user()->organization->timezone;
 
         $clinic = Clinic::create($data);
 

--- a/app/Http/Controllers/Admin/OrganizationController.php
+++ b/app/Http/Controllers/Admin/OrganizationController.php
@@ -44,6 +44,7 @@ class OrganizationController extends Controller
             'estado' => 'nullable',
             'logo_url' => 'nullable',
             'status' => 'in:ativo,inativo,suspenso',
+            'timezone' => 'required|timezone',
             'password' => 'nullable|string|min:8|confirmed',
         ]);
 
@@ -65,6 +66,7 @@ class OrganizationController extends Controller
             'estado' => $data['estado'] ?? null,
             'logo_url' => $data['logo_url'] ?? null,
             'status' => $data['status'] ?? 'ativo',
+            'timezone' => $data['timezone'],
         ]);
      
         $profile = Profile::create([
@@ -139,6 +141,7 @@ class OrganizationController extends Controller
             'estado' => 'nullable',
             'logo_url' => 'nullable',
             'status' => 'in:ativo,inativo,suspenso',
+            'timezone' => 'required|timezone',
             'password' => 'nullable|string|min:8|confirmed',
         ]);
 
@@ -160,6 +163,7 @@ class OrganizationController extends Controller
             'estado' => $data['estado'] ?? null,
             'logo_url' => $data['logo_url'] ?? null,
             'status' => $data['status'] ?? $organization->status,
+            'timezone' => $data['timezone'],
         ]);
 
         $usuario = User::where('organization_id', $organization->id)->first();

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -31,6 +31,7 @@ class Clinic extends Model
         'cep',
         'telefone',
         'email',
+        'timezone',
     ];
 
     public function horarios()

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -24,6 +24,7 @@ class Organization extends Model
         'estado',
         'logo_url',
         'status',
+        'timezone',
     ];
 
 

--- a/database/migrations/2025_10_21_000000_add_timezone_to_organizations_table.php
+++ b/database/migrations/2025_10_21_000000_add_timezone_to_organizations_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->string('timezone')->default(config('app.timezone'))->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropColumn('timezone');
+        });
+    }
+};

--- a/database/migrations/2025_10_21_000001_add_timezone_to_clinics_table.php
+++ b/database/migrations/2025_10_21_000001_add_timezone_to_clinics_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('clinics', function (Blueprint $table) {
+            $table->string('timezone')->default(config('app.timezone'))->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clinics', function (Blueprint $table) {
+            $table->dropColumn('timezone');
+        });
+    }
+};

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -16,7 +16,10 @@ class AdminUserSeeder extends Seeder
     {
         $organization = Organization::firstOrCreate(
             ['cnpj' => '00000000000000'],
-            ['nome_fantasia' => 'Default Organization']
+            [
+                'nome_fantasia' => 'Default Organization',
+                'timezone' => config('app.timezone'),
+            ]
         );
 
         $person = Person::firstOrCreate(

--- a/resources/views/backend/organizations/create.blade.php
+++ b/resources/views/backend/organizations/create.blade.php
@@ -109,6 +109,14 @@
             <p class="text-xs text-gray-500 mt-1">Se deixado em branco, uma senha aleatória será criada e enviada por e-mail.</p>
         </div>
         <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Timezone</label>
+            <select name="timezone" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
+                @foreach(timezone_identifiers_list() as $tz)
+                    <option value="{{ $tz }}" @selected(old('timezone', config('app.timezone')) === $tz)>{{ $tz }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Status</label>
             <select name="status" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
                 <option value="ativo" @selected(old('status') === 'ativo')>Ativa</option>

--- a/resources/views/backend/organizations/edit.blade.php
+++ b/resources/views/backend/organizations/edit.blade.php
@@ -110,6 +110,14 @@
             <p class="text-xs text-gray-500 mt-1">Se deixado em branco, a senha permanecerá inalterada.</p>
         </div>
         <div>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Timezone</label>
+            <select name="timezone" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
+                @foreach(timezone_identifiers_list() as $tz)
+                    <option value="{{ $tz }}" @selected(old('timezone', $organization->timezone ?? config('app.timezone')) === $tz)>{{ $tz }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
             <label class="mb-2 block text-sm font-medium text-gray-700">Status</label>
             <select name="status" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
                 <option value="ativo" @selected(old('status', $organization->status) === 'ativo')>Ativa</option>


### PR DESCRIPTION
## Summary
- add migrations for organization and clinic timezones
- update models and controllers to store timezone
- default clinic timezone to organization's timezone on create
- parse schedule dates using clinic timezone
- allow timezone selection in organization forms
- seed default organization with timezone

## Testing
- `php -l database/migrations/2025_10_21_000000_add_timezone_to_organizations_table.php`
- `php -l database/migrations/2025_10_21_000001_add_timezone_to_clinics_table.php`
- `php -l app/Models/Organization.php`
- `php -l app/Models/Clinic.php`
- `php -l app/Http/Controllers/Admin/OrganizationController.php`
- `php -l app/Http/Controllers/Admin/ClinicController.php`
- `php -l app/Http/Controllers/Admin/AgendaController.php`
- `php -l resources/views/backend/organizations/create.blade.php`
- `php -l resources/views/backend/organizations/edit.blade.php`
- `php -l database/seeders/AdminUserSeeder.php`
- `php scripts/test_horarios.php 2025-07-27 1` *(fails: vendor autoload missing)*
- `vendor/bin/phpunit --version` *(fails: file not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688b99796d68832a9e49a0afb9f7ae1a