### PR TITLE
Enable monthly schedule view

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -16,17 +16,10 @@ class EscalaTrabalhoController extends Controller
         $user = auth()->user();
         $clinics = $user->isOrganizationAdmin() ? Clinic::all() : $user->clinics()->get();
         $clinicId = $request->input('clinic_id', $clinics->first()->id ?? null);
-        $week = $request->input('week');
-        $week = $week ? Carbon::parse($week)->startOfWeek(Carbon::MONDAY) : Carbon::now()->startOfWeek(Carbon::MONDAY);
+        $view = $request->input('view', 'week');
 
-        $semanasDisponiveis = collect(range(-2, 5))->map(fn($i) => Carbon::now()->startOfWeek(Carbon::MONDAY)->addWeeks($i));
         $dias = ['segunda','terca','quarta','quinta','sexta','sabado','domingo'];
         $cadeiras = $clinicId ? Cadeira::where('clinic_id', $clinicId)->get() : collect();
-        $escalas = EscalaTrabalho::with(['profissional.person','profissional.user'])
-            ->where('clinic_id', $clinicId)
-            ->where('semana', $week->toDateString())
-            ->get()
-            ->groupBy(['cadeira_id','dia_semana']);
         $dentistas = Profissional::where(function($q){
                 $q->where('funcao', 'Dentista')->orWhere('cargo', 'Dentista');
             })
@@ -36,7 +29,38 @@ class EscalaTrabalhoController extends Controller
             ->with(['person'])
             ->get();
 
-        return view('escalas.index', compact('clinics','clinicId','week','dias','cadeiras','escalas','dentistas','semanasDisponiveis'));
+        if ($view === 'month') {
+            $month = $request->input('month');
+            $month = $month ? Carbon::parse($month)->startOfMonth() : Carbon::now()->startOfMonth();
+            $mesesDisponiveis = collect(range(-2, 2))->map(fn($i) => Carbon::now()->startOfMonth()->addMonths($i));
+
+            $weeks = collect();
+            $current = $month->copy()->startOfWeek(Carbon::MONDAY);
+            $last = $month->copy()->endOfMonth()->endOfWeek(Carbon::SUNDAY);
+            while ($current->lte($last)) {
+                $weeks->push($current->copy());
+                $current->addWeek();
+            }
+
+            $escalas = EscalaTrabalho::with(['profissional.person','profissional.user'])
+                ->where('clinic_id', $clinicId)
+                ->whereBetween('semana', [$weeks->first()->toDateString(), $weeks->last()->toDateString()])
+                ->get()
+                ->groupBy(['semana','cadeira_id','dia_semana']);
+
+            return view('escalas.index', compact('clinics','clinicId','view','month','weeks','dias','cadeiras','escalas','dentistas','mesesDisponiveis'));
+        }
+
+        $week = $request->input('week');
+        $week = $week ? Carbon::parse($week)->startOfWeek(Carbon::MONDAY) : Carbon::now()->startOfWeek(Carbon::MONDAY);
+        $semanasDisponiveis = collect(range(-2, 5))->map(fn($i) => Carbon::now()->startOfWeek(Carbon::MONDAY)->addWeeks($i));
+        $escalas = EscalaTrabalho::with(['profissional.person','profissional.user'])
+            ->where('clinic_id', $clinicId)
+            ->where('semana', $week->toDateString())
+            ->get()
+            ->groupBy(['cadeira_id','dia_semana']);
+
+        return view('escalas.index', compact('clinics','clinicId','view','week','dias','cadeiras','escalas','dentistas','semanasDisponiveis'));
     }
 
     public function store(Request $request)
@@ -85,7 +109,15 @@ class EscalaTrabalhoController extends Controller
             ]);
         }
 
-        return redirect()->route('escalas.index', ['clinic_id' => $data['clinic_id'], 'week' => $data['semana']])
+        $params = ['clinic_id' => $data['clinic_id'], 'week' => $data['semana']];
+        if ($request->filled('view')) {
+            $params['view'] = $request->input('view');
+        }
+        if ($request->filled('month')) {
+            $params['month'] = $request->input('month');
+        }
+
+        return redirect()->route('escalas.index', $params)
             ->with('success', 'Escala salva com sucesso.');
     }
 }

--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -24,54 +24,125 @@
         </select>
     </div>
     <div>
-        <label class="block text-sm font-medium mb-1">Semana</label>
-        <select name="week" class="border rounded px-2 py-1" onchange="this.form.submit()">
-            @foreach($semanasDisponiveis as $sem)
-                <option value="{{ $sem->format('Y-m-d') }}" @selected($sem->equalTo($week))>{{ $sem->format('d/m/Y') }}</option>
-            @endforeach
+        <label class="block text-sm font-medium mb-1">Visualização</label>
+        <select name="view" class="border rounded px-2 py-1" onchange="this.form.submit()">
+            <option value="week" @selected($view==='week')>Semanal</option>
+            <option value="month" @selected($view==='month')>Mensal</option>
         </select>
     </div>
-</form>
-<div class="overflow-x-auto bg-white rounded shadow">
-    <table class="table-fixed w-full text-sm border">
-        <thead>
-            <tr>
-                <th class="w-32 px-2 py-1 bg-white font-semibold border border-gray-200">Cadeira</th>
-                @foreach($dias as $d)
-                    <th class="px-2 py-1 text-center font-semibold bg-white capitalize border border-gray-200" style="width:14.28%">{{ ucfirst($d) }}</th>
+    @if($view==='month')
+        <div>
+            <label class="block text-sm font-medium mb-1">Mês</label>
+            <select name="month" class="border rounded px-2 py-1" onchange="this.form.submit()">
+                @foreach($mesesDisponiveis as $mes)
+                    <option value="{{ $mes->format('Y-m') }}" @selected($mes->equalTo($month))>{{ $mes->translatedFormat('F Y') }}</option>
                 @endforeach
-            </tr>
-        </thead>
-        <tbody>
-            @foreach($cadeiras as $cadeira)
+            </select>
+        </div>
+    @else
+        <div>
+            <label class="block text-sm font-medium mb-1">Semana</label>
+            <select name="week" class="border rounded px-2 py-1" onchange="this.form.submit()">
+                @foreach($semanasDisponiveis as $sem)
+                    <option value="{{ $sem->format('Y-m-d') }}" @selected($sem->equalTo($week))>{{ $sem->format('d/m/Y') }}</option>
+                @endforeach
+            </select>
+        </div>
+    @endif
+</form>
+@if($view==='month')
+    @foreach($weeks as $w)
+        <h2 class="mt-6 font-semibold">Semana de {{ $w->format('d/m/Y') }}</h2>
+        <div class="overflow-x-auto bg-white rounded shadow mb-6">
+            <table class="table-fixed w-full text-sm border">
+                <thead>
+                    <tr>
+                        <th class="w-32 px-2 py-1 bg-white font-semibold border border-gray-200">Cadeira</th>
+                        @foreach($dias as $d)
+                            <th class="px-2 py-1 text-center font-semibold bg-white capitalize border border-gray-200" style="width:14.28%">{{ ucfirst($d) }}</th>
+                        @endforeach
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($cadeiras as $cadeira)
+                        <tr>
+                            <td class="w-32 px-2 py-1 font-semibold bg-gray-50 border border-gray-200">{{ $cadeira->nome }}</td>
+                            @foreach($dias as $d)
+                                @php $items = $escalas[$w->toDateString()][$cadeira->id][$d] ?? collect(); @endphp
+                                <td class="px-2 py-2 border border-gray-200 align-top" style="width:14.28%">
+                                    @forelse($items as $it)
+                                        <div class="mb-2 p-2 rounded bg-emerald-50 text-sm">
+                                            <div class="font-semibold whitespace-nowrap overflow-hidden text-ellipsis">{{ optional($it->profissional->person)->first_name }} {{ optional($it->profissional->person)->last_name }}</div>
+                                            <div>{{ $it->hora_inicio }} – {{ $it->hora_fim }}</div>
+                                            <div class="text-xs text-gray-600">{{ optional($it->profissional->user)->especialidade ?? $it->profissional->cargo }}</div>
+                                            <div class="mt-1 h-2 rounded bg-emerald-400 w-full"></div>
+                                        </div>
+                                    @empty
+                                        <span class="text-sm text-gray-400">Livre</span>
+                                    @endforelse
+                                </td>
+                            @endforeach
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endforeach
+@else
+    <div class="overflow-x-auto bg-white rounded shadow">
+        <table class="table-fixed w-full text-sm border">
+            <thead>
                 <tr>
-                    <td class="w-32 px-2 py-1 font-semibold bg-gray-50 border border-gray-200">{{ $cadeira->nome }}</td>
+                    <th class="w-32 px-2 py-1 bg-white font-semibold border border-gray-200">Cadeira</th>
                     @foreach($dias as $d)
-                        @php $items = $escalas[$cadeira->id][$d] ?? collect(); @endphp
-                        <td class="px-2 py-2 border border-gray-200 align-top" style="width:14.28%">
-                            @forelse($items as $it)
-                                <div class="mb-2 p-2 rounded bg-emerald-50 text-sm">
-                                    <div class="font-semibold whitespace-nowrap overflow-hidden text-ellipsis">{{ optional($it->profissional->person)->first_name }} {{ optional($it->profissional->person)->last_name }}</div>
-                                    <div>{{ $it->hora_inicio }} – {{ $it->hora_fim }}</div>
-                                    <div class="text-xs text-gray-600">{{ optional($it->profissional->user)->especialidade ?? $it->profissional->cargo }}</div>
-                                    <div class="mt-1 h-2 rounded bg-emerald-400 w-full"></div>
-                                </div>
-                            @empty
-                                <span class="text-sm text-gray-400">Livre</span>
-                            @endforelse
-                        </td>
+                        <th class="px-2 py-1 text-center font-semibold bg-white capitalize border border-gray-200" style="width:14.28%">{{ ucfirst($d) }}</th>
                     @endforeach
                 </tr>
-            @endforeach
-        </tbody>
-    </table>
-</div>
+            </thead>
+            <tbody>
+                @foreach($cadeiras as $cadeira)
+                    <tr>
+                        <td class="w-32 px-2 py-1 font-semibold bg-gray-50 border border-gray-200">{{ $cadeira->nome }}</td>
+                        @foreach($dias as $d)
+                            @php $items = $escalas[$cadeira->id][$d] ?? collect(); @endphp
+                            <td class="px-2 py-2 border border-gray-200 align-top" style="width:14.28%">
+                                @forelse($items as $it)
+                                    <div class="mb-2 p-2 rounded bg-emerald-50 text-sm">
+                                        <div class="font-semibold whitespace-nowrap overflow-hidden text-ellipsis">{{ optional($it->profissional->person)->first_name }} {{ optional($it->profissional->person)->last_name }}</div>
+                                        <div>{{ $it->hora_inicio }} – {{ $it->hora_fim }}</div>
+                                        <div class="text-xs text-gray-600">{{ optional($it->profissional->user)->especialidade ?? $it->profissional->cargo }}</div>
+                                        <div class="mt-1 h-2 rounded bg-emerald-400 w-full"></div>
+                                    </div>
+                                @empty
+                                    <span class="text-sm text-gray-400">Livre</span>
+                                @endforelse
+                            </td>
+                        @endforeach
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+@endif
 <div id="escala-modal" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
     <div class="bg-white rounded p-4 w-80">
         <form method="POST" action="{{ route('escalas.store') }}" class="space-y-4">
             @csrf
             <input type="hidden" name="clinic_id" value="{{ $clinicId }}">
-            <input type="hidden" name="semana" value="{{ $week->format('Y-m-d') }}">
+            <input type="hidden" name="view" value="{{ $view }}">
+            @if($view==='month')
+                <input type="hidden" name="month" value="{{ $month->format('Y-m') }}">
+                <div>
+                    <label class="block text-sm mb-1">Semana</label>
+                    <select name="semana" class="w-full border rounded px-2 py-1">
+                        @foreach($weeks as $w)
+                            <option value="{{ $w->format('Y-m-d') }}">{{ $w->format('d/m/Y') }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            @else
+                <input type="hidden" name="semana" value="{{ $week->format('Y-m-d') }}">
+            @endif
             <div>
                 <label class="block text-sm mb-1">Profissional</label>
                 <select name="profissional_id" class="w-full border rounded px-2 py-1">


### PR DESCRIPTION
## Summary
- allow `escalas` page to display schedules by month or week
- include month/week dropdowns in the interface
- allow choosing week when adding schedule in month view

## Testing
- `php -l app/Http/Controllers/Admin/EscalaTrabalhoController.php`
- `php -l resources/views/escalas/index.blade.php`
- `php artisan test --testsuite=Unit` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_688bb684fe48832aad3843722285582b