### PR TITLE
Ajustes no modal de escalas

### DIFF
--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -133,11 +133,19 @@
     </div>
 @endif
 <div id="escala-modal" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
-    <div class="bg-white rounded p-4 w-80">
+    <div class="bg-white rounded p-4 w-96">
         <form method="POST" action="{{ route('escalas.store') }}" class="space-y-4">
             @csrf
             <input type="hidden" name="clinic_id" value="{{ $clinicId }}">
             <input type="hidden" name="view" value="{{ $view }}">
+            <div>
+                <label class="block text-sm mb-1">Profissional</label>
+                <select name="profissional_id" class="w-full border rounded px-2 py-1">
+                    @foreach($dentistas as $d)
+                        <option value="{{ $d->id }}">{{ $d->person->first_name }} {{ $d->person->last_name }}</option>
+                    @endforeach
+                </select>
+            </div>
             @if($view==='month')
                 <input type="hidden" name="month" id="calendar-month-input" value="{{ $month->format('Y-m') }}">
                 <div class="mb-2 flex items-center justify-between">
@@ -151,14 +159,6 @@
                 <input type="hidden" name="semana" value="{{ $week->format('Y-m-d') }}">
             @endif
             <div class="flex gap-2 items-end">
-                <div class="flex-1">
-                    <label class="block text-sm mb-1">Profissional</label>
-                    <select name="profissional_id" class="w-full border rounded px-2 py-1">
-                        @foreach($dentistas as $d)
-                            <option value="{{ $d->id }}">{{ $d->person->first_name }} {{ $d->person->last_name }}</option>
-                        @endforeach
-                    </select>
-                </div>
                 <div>
                     <label class="block text-sm mb-1">Início</label>
                     <input type="time" name="hora_inicio" class="border rounded px-2 py-1">


### PR DESCRIPTION
## Descrição
- coloca o campo Profissional acima do calendário
- mantém horários de início e fim abaixo do calendário, alinhados
- aumenta a largura do modal para `w-96`

## Testes
- `composer install` *(falhou: CONNECT tunnel failed)*
- `php vendor/bin/phpunit --version` *(falhou: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_688bc0be65ec832aba002e56d684e24c