### PR TITLE
Fix weekly schedule query

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -56,7 +56,10 @@ class EscalaTrabalhoController extends Controller
         $semanasDisponiveis = collect(range(-2, 5))->map(fn($i) => Carbon::now()->startOfWeek(Carbon::MONDAY)->addWeeks($i));
         $escalas = EscalaTrabalho::with(['profissional.person','profissional.user'])
             ->where('clinic_id', $clinicId)
-            ->where('semana', $week->toDateString())
+            ->whereBetween('semana', [
+                $week->toDateString(),
+                $week->copy()->addDays(6)->toDateString(),
+            ])
             ->get()
             ->groupBy(['cadeira_id','dia_semana']);
 


### PR DESCRIPTION
## Summary
- fix weekly schedules query range

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `vendor/bin/phpunit --verbose` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688bc3844844832ab01b6cb4acc10e5f