### PR TITLE
Fix month view query parameter

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -31,6 +31,9 @@ class EscalaTrabalhoController extends Controller
 
         if ($view === 'month') {
             $month = $request->input('month');
+            if (! $month && $request->filled('week')) {
+                $month = Carbon::parse($request->input('week'))->startOfMonth()->format('Y-m');
+            }
             $month = $month ? Carbon::parse($month)->startOfMonth() : Carbon::now()->startOfMonth();
             $mesesDisponiveis = collect(range(-2, 2))->map(fn($i) => Carbon::now()->startOfMonth()->addMonths($i));
 


### PR DESCRIPTION
## Summary
- derive the month parameter from `week` if the request uses `view=month`

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688bd99923d4832a97fa64e1f318209e