### PR TITLE
Implementa aviso de validação

### DIFF
--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -24,7 +24,7 @@
             </ul>
         </div>
     @endif
-    <div data-validation-alert class="hidden mb-4 flex items-center rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+    <div data-validation-alert class="mb-4 flex items-center rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 {{ $errors->any() ? '' : 'hidden' }}">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M4.93 4.93l1.42 1.42A9 9 0 1121 12h0a9 9 0 11-7.07-7.07L4.93 4.93z" />
         </svg>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -24,7 +24,7 @@
             </ul>
         </div>
     @endif
-    <div data-validation-alert class="hidden mb-4 flex items-center rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+    <div data-validation-alert class="mb-4 flex items-center rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 {{ $errors->any() ? '' : 'hidden' }}">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M4.93 4.93l1.42 1.42A9 9 0 1121 12h0a9 9 0 11-7.07-7.07L4.93 4.93z" />
         </svg>


### PR DESCRIPTION
## Summary
- exibe a barra de alerta de validação automaticamente quando existem erros na criação e edição de profissionais

## Testing
- `php vendor/bin/phpunit --configuration phpunit.xml` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_688c90e902d0832aa18e5cf76d43dbcf