### PR TITLE
Show full user name in admin

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -12,7 +12,7 @@ class UserController extends Controller
 {
     public function index()
     {
-        $users = User::all();
+        $users = User::with(['person', 'clinics'])->get();
         return view('admin.users.index', compact('users'));
     }
 

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -35,4 +35,10 @@ class Person extends Model
     protected $casts = [
         'data_nascimento' => 'date',
     ];
+
+    public function getFullNameAttribute(): string
+    {
+        $middle = $this->middle_name ? $this->middle_name . ' ' : '';
+        return trim($this->first_name . ' ' . $middle . $this->last_name);
+    }
 }

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -21,7 +21,13 @@
         <tbody class="divide-y divide-gray-200">
             @forelse ($users as $user)
                 <tr>
-                    <td class="px-4 py-2 whitespace-nowrap">{{ $user->name }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">
+                        @if($user->person)
+                            {{ $user->person->full_name }}
+                        @else
+                            {{ $user->name ?? '-' }}
+                        @endif
+                    </td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $user->email }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">
                         @foreach ($user->clinics as $clinic)


### PR DESCRIPTION
## Summary
- show concatenated full name of the person in the admin user list
- eager load `person` and `clinics` for the admin user index
- add `full_name` accessor to `Person` model

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbe554838832aa2ca3edbc2875184