### PR TITLE
Remove redundant admission date fields

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -173,8 +173,6 @@ class ProfessionalController extends Controller
             'foto' => 'nullable|image',
             'numero_funcionario' => 'nullable',
             'email_corporativo' => 'nullable|email',
-            'data_admissao' => 'required|date',
-            'data_demissao' => 'nullable|date',
             'tipo_contrato' => 'nullable',
             'data_inicio_contrato' => 'required|date',
             'data_fim_contrato' => 'nullable|date',
@@ -275,8 +273,6 @@ class ProfessionalController extends Controller
         return [
             'numero_funcionario' => $data['numero_funcionario'] ?? null,
             'email_corporativo' => $data['email_corporativo'] ?? null,
-            'data_admissao' => $data['data_admissao'] ?? null,
-            'data_demissao' => $data['data_demissao'] ?? null,
             'tipo_contrato' => $data['tipo_contrato'] ?? null,
             'data_inicio_contrato' => $data['data_inicio_contrato'] ?? null,
             'data_fim_contrato' => $data['data_fim_contrato'] ?? null,

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -130,14 +130,6 @@
                     <label class="text-sm font-medium text-gray-700 mb-2 block">E-mail corporativo</label>
                     <input type="text" name="email_corporativo" value="{{ old('email_corporativo') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
-                <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Data de admissão *</label>
-                    <input type="date" name="data_admissao" value="{{ old('data_admissao') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
-                </div>
-                <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Data de demissão</label>
-                    <input type="date" name="data_demissao" value="{{ old('data_demissao') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
-                </div>
             </div>
         </x-accordion-section>
         <x-accordion-section title="Contrato de Trabalho">

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -131,14 +131,6 @@
                     <label class="text-sm font-medium text-gray-700 mb-2 block">E-mail corporativo</label>
                     <input type="text" name="email_corporativo" value="{{ old('email_corporativo', $profissional->email_corporativo ?? '') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
-                <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Data de admissão *</label>
-                    <input type="date" name="data_admissao" value="{{ old('data_admissao', optional($profissional->data_admissao)->format('Y-m-d')) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
-                </div>
-                <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Data de demissão</label>
-                    <input type="date" name="data_demissao" value="{{ old('data_demissao', optional($profissional->data_demissao)->format('Y-m-d')) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
-                </div>
             </div>
         </x-accordion-section>
         <x-accordion-section title="Contrato de Trabalho">


### PR DESCRIPTION
## Summary
- drop admission date form inputs from professional create/edit views
- stop validating and saving admission date fields in ProfessionalController

## Testing
- `php artisan test` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_688cc50060fc832ab8e48aeca45e2298