### PR TITLE
Make CRO mandatory for dentists

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -200,6 +200,10 @@ class ProfessionalController extends Controller
             'clinics.*' => 'exists:clinics,id',
         ];
 
+        if ($request->input('funcao') === 'Dentista') {
+            $rules['cro'] = 'required|numeric';
+        }
+
         $tipoConta = $request->input('conta.cpf_cnpj_tipo');
         if ($tipoConta === 'cpf') {
             $rules['conta.cpf_cnpj'][] = new \App\Rules\Cpf;

--- a/resources/views/components/accordion-section.blade.php
+++ b/resources/views/components/accordion-section.blade.php
@@ -1,7 +1,7 @@
-@props(['title', 'open' => false])
+@props(['title', 'open' => false, 'titleHtml' => null])
 <div x-data="{ open: @json($open) }" class="rounded-sm border border-stroke bg-gray-50">
     <button type="button" @click="open = !open" class="w-full flex justify-between items-center p-4">
-        <span class="text-sm font-medium text-gray-700">{{ $title }}</span>
+        <span class="text-sm font-medium text-gray-700">{!! $titleHtml ?? e($title) !!}</span>
         <svg class="w-4 h-4 transform transition-transform" :class="{ 'rotate-180': open }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
         </svg>

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -202,11 +202,14 @@
                 </div>
             </div>
         </x-accordion-section>
-        <x-accordion-section title="Registros" x-show="funcao === 'Dentista'" x-cloak>
+        @php
+            $registrosTitle = 'Registros <span x-show="funcao === \"Dentista\"" class="text-red-500">*</span>';
+        @endphp
+        <x-accordion-section :title-html="$registrosTitle" x-show="funcao === 'Dentista'" x-cloak>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">CRO</label>
-                    <input type="number" name="cro" value="{{ old('cro') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">CRO <span x-show="funcao === 'Dentista'" class="text-red-500">*</span></label>
+                    <input type="number" name="cro" value="{{ old('cro') }}" x-bind:required="funcao === 'Dentista'" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">UF do CRO</label>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -203,11 +203,14 @@
                 </div>
             </div>
         </x-accordion-section>
-        <x-accordion-section title="Registros" x-show="funcao === 'Dentista'" x-cloak>
+        @php
+            $registrosTitle = 'Registros <span x-show="funcao === \"Dentista\"" class="text-red-500">*</span>';
+        @endphp
+        <x-accordion-section :title-html="$registrosTitle" x-show="funcao === 'Dentista'" x-cloak>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">CRO</label>
-                    <input type="number" name="cro" value="{{ old('cro', $profissional->cro ?? '') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">CRO <span x-show="funcao === 'Dentista'" class="text-red-500">*</span></label>
+                    <input type="number" name="cro" value="{{ old('cro', $profissional->cro ?? '') }}" x-bind:required="funcao === 'Dentista'" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">UF do CRO</label>


### PR DESCRIPTION
## Summary
- enforce CRO field when the professional's function is **Dentista**
- allow accordion titles to contain HTML so star marker can be dynamic
- show `*` next to CRO label and accordion title when Dentista is selected

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688cc5e1c44c832aba097f4e7dea6481