### PR TITLE
Handle responsible names separately

### DIFF
--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -42,7 +42,9 @@ class ClinicController extends Controller
         $data = $request->validate([
             'nome' => 'required',
             'cnpj' => ['required', new Cnpj],
-            'responsavel_tecnico' => 'required',
+            'responsavel_first_name' => 'required',
+            'responsavel_middle_name' => 'required',
+            'responsavel_last_name' => 'required',
             'cro' => 'required',
             'cep' => 'required',
             'logradouro' => 'required',
@@ -135,7 +137,9 @@ class ClinicController extends Controller
         $data = $request->validate([
             'nome' => 'required',
             'cnpj' => ['required', new Cnpj],
-            'responsavel_tecnico' => 'required',
+            'responsavel_first_name' => 'required',
+            'responsavel_middle_name' => 'required',
+            'responsavel_last_name' => 'required',
             'cro' => 'required',
             'cep' => 'required',
             'logradouro' => 'required',

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -17,7 +17,6 @@ class Clinic extends Model
     protected $fillable = [
         'nome',
         'cnpj',
-        'responsavel_tecnico',
         'responsavel_first_name',
         'responsavel_middle_name',
         'responsavel_last_name',

--- a/database/migrations/2025_10_22_000000_drop_responsavel_tecnico_from_clinics_table.php
+++ b/database/migrations/2025_10_22_000000_drop_responsavel_tecnico_from_clinics_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clinics', function (Blueprint $table) {
+            if (Schema::hasColumn('clinics', 'responsavel_tecnico')) {
+                $table->dropColumn('responsavel_tecnico');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clinics', function (Blueprint $table) {
+            if (!Schema::hasColumn('clinics', 'responsavel_tecnico')) {
+                $table->string('responsavel_tecnico')->nullable()->after('cnpj');
+            }
+        });
+    }
+};

--- a/resources/views/admin/clinics/create.blade.php
+++ b/resources/views/admin/clinics/create.blade.php
@@ -27,34 +27,26 @@
             </div>
         </div>
 
-        @php
-            $nomeResp = old('responsavel_tecnico');
-            $parts = $nomeResp ? preg_split('/\s+/', trim($nomeResp)) : [];
-            $respFirst = $parts[0] ?? '';
-            $respLast = count($parts) > 1 ? array_pop($parts) : '';
-            $respMiddle = $parts ? implode(' ', array_slice($parts, 1)) : '';
-        @endphp
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Responsável Técnico</h2>
             <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_first" value="{{ $respFirst }}" />
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome *</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_first_name" value="{{ old('responsavel_first_name') }}" required />
                 </div>
                 <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome do Meio</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_middle" value="{{ $respMiddle }}" />
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome do Meio *</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_middle_name" value="{{ old('responsavel_middle_name') }}" required />
                 </div>
                 <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Último</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_last" value="{{ $respLast }}" />
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Último *</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_last_name" value="{{ old('responsavel_last_name') }}" required />
                 </div>
                 <div class="sm:col-span-3">
                     <label class="mb-2 block text-sm font-medium text-gray-700">CRO *</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cro" value="{{ old('cro') }}" required />
                 </div>
             </div>
-            <input type="hidden" name="responsavel_tecnico" id="responsavel_tecnico" value="{{ old('responsavel_tecnico') }}" />
         </div>
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Endereço</h2>
@@ -133,17 +125,6 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', () => {
-        const first = document.querySelector('input[name="responsavel_first"]');
-        const middle = document.querySelector('input[name="responsavel_middle"]');
-        const last = document.querySelector('input[name="responsavel_last"]');
-        const hidden = document.getElementById('responsavel_tecnico');
-        function updateHidden() {
-            hidden.value = [first.value.trim(), middle.value.trim(), last.value.trim()]
-                .filter(Boolean)
-                .join(' ');
-        }
-        [first, middle, last].forEach(el => el.addEventListener('input', updateHidden));
-        updateHidden();
 
         const applyBtn = document.getElementById('apply-schedule-all');
         if (applyBtn) {

--- a/resources/views/admin/clinics/edit.blade.php
+++ b/resources/views/admin/clinics/edit.blade.php
@@ -28,34 +28,26 @@
             </div>
         </div>
 
-        @php
-            $nomeResp = old('responsavel_tecnico', $clinic->responsavel_tecnico);
-            $parts = $nomeResp ? preg_split('/\s+/', trim($nomeResp)) : [];
-            $respFirst = $parts[0] ?? '';
-            $respLast = count($parts) > 1 ? array_pop($parts) : '';
-            $respMiddle = $parts ? implode(' ', array_slice($parts, 1)) : '';
-        @endphp
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Responsável Técnico</h2>
             <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_first" value="{{ $respFirst }}" />
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome *</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_first_name" value="{{ old('responsavel_first_name', $clinic->responsavel_first_name) }}" required />
                 </div>
                 <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome do Meio</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_middle" value="{{ $respMiddle }}" />
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Nome do Meio *</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_middle_name" value="{{ old('responsavel_middle_name', $clinic->responsavel_middle_name) }}" required />
                 </div>
                 <div>
-                    <label class="mb-2 block text-sm font-medium text-gray-700">Último</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_last" value="{{ $respLast }}" />
+                    <label class="mb-2 block text-sm font-medium text-gray-700">Último *</label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_last_name" value="{{ old('responsavel_last_name', $clinic->responsavel_last_name) }}" required />
                 </div>
                 <div class="sm:col-span-3">
                     <label class="mb-2 block text-sm font-medium text-gray-700">CRO *</label>
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="cro" value="{{ old('cro', $clinic->cro) }}" required />
                 </div>
             </div>
-            <input type="hidden" name="responsavel_tecnico" id="responsavel_tecnico" value="{{ old('responsavel_tecnico', $clinic->responsavel_tecnico) }}" />
         </div>
         <div class="rounded-sm border border-stroke bg-gray-50 p-4">
             <h2 class="mb-4 text-sm font-medium text-gray-700">Endereço</h2>
@@ -141,17 +133,6 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', () => {
-        const first = document.querySelector('input[name="responsavel_first"]');
-        const middle = document.querySelector('input[name="responsavel_middle"]');
-        const last = document.querySelector('input[name="responsavel_last"]');
-        const hidden = document.getElementById('responsavel_tecnico');
-        function updateHidden() {
-            hidden.value = [first.value.trim(), middle.value.trim(), last.value.trim()]
-                .filter(Boolean)
-                .join(' ');
-        }
-        [first, middle, last].forEach(el => el.addEventListener('input', updateHidden));
-        updateHidden();
 
         const applyBtn = document.getElementById('apply-schedule-all');
         if (applyBtn) {

--- a/resources/views/admin/clinics/index.blade.php
+++ b/resources/views/admin/clinics/index.blade.php
@@ -27,7 +27,7 @@
                 <tr>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $clinic->nome }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $clinic->cnpj }}</td>
-                    <td class="px-4 py-2 whitespace-nowrap">{{ $clinic->responsavel_tecnico }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ trim($clinic->responsavel_first_name . ' ' . $clinic->responsavel_middle_name . ' ' . $clinic->responsavel_last_name) }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $clinic->cro }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $clinic->telefone }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $clinic->email }}</td>


### PR DESCRIPTION
## Summary
- drop obsolete `responsavel_tecnico` column
- require and persist responsible first, middle and last names
- update clinic views to mark responsible fields required and show full name

## Testing
- `php artisan test` *(fails: missing composer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688cc470dcac832a83181d0403bcd76b