### PR TITLE
Fix horarios validation in clinic edit

### DIFF
--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -118,12 +118,14 @@ class ClinicController extends Controller
         }
 
         $horarios = $clinic->horarios
-            ->mapWithKeys(fn($h) => [
-                $h->dia_semana => [
-                    'abertura' => $h->hora_inicio,
-                    'fechamento' => $h->hora_fim,
-                ],
-            ])->toArray();
+            ->mapWithKeys(function ($h) {
+                return [
+                    $h->dia_semana => [
+                        'abertura' => Carbon::createFromTimeString($h->hora_inicio)->format('H:i'),
+                        'fechamento' => Carbon::createFromTimeString($h->hora_fim)->format('H:i'),
+                    ],
+                ];
+            })->toArray();
 
         return view('admin.clinics.edit', compact('clinic', 'horarios'));
     }


### PR DESCRIPTION
## Summary
- convert stored time values to `H:i` format when editing clinics so the validation passes

## Testing
- `vendor/bin/phpunit -c phpunit.xml --dont-report-useless-tests` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cd1e67ec0832a863a63b59a8ca2f9