### PR TITLE
Fix currency input formatting

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -258,9 +258,9 @@ document.addEventListener('DOMContentLoaded', () => {
             input.value = format(input.value);
         }
 
-        input.addEventListener('input', e => {
+        // Format value only after the user finishes typing to avoid cursor issues
+        input.addEventListener('blur', e => {
             e.target.value = format(e.target.value);
-            e.target.setSelectionRange(e.target.value.length, e.target.value.length);
         });
 
         if (form) {


### PR DESCRIPTION
## Summary
- avoid formatting currency on each keystroke to keep focus

## Testing
- `npm run build`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688cd42c208c832aafbe2fdf1f08a57c