### PR TITLE
Add Portuguese validation messages

### DIFF
--- a/resources/lang/pt_BR/validation.php
+++ b/resources/lang/pt_BR/validation.php
@@ -1,0 +1,23 @@
+<?php
+return [
+    'required' => 'O campo :attribute é obrigatório.',
+    'email' => 'O campo :attribute deve ser um e-mail válido.',
+    'numeric' => 'O campo :attribute deve ser numérico.',
+    'date' => 'O campo :attribute não é uma data válida.',
+    'image' => 'O arquivo :attribute deve ser uma imagem.',
+    'digits_between' => 'O campo :attribute deve ter entre :min e :max dígitos.',
+    'array' => 'O campo :attribute deve ser uma lista.',
+
+    'attributes' => [
+        'first_name' => 'nome',
+        'middle_name' => 'nome do meio',
+        'last_name' => 'sobrenome',
+        'data_nascimento' => 'data de nascimento',
+        'cpf' => 'cpf',
+        'data_inicio_contrato' => 'data de início do contrato',
+        'regime_trabalho' => 'regime de trabalho',
+        'funcao' => 'função',
+        'cargo' => 'cargo',
+        'conta.cpf_cnpj' => 'cpf/cnpj',
+    ],
+];


### PR DESCRIPTION
## Summary
- add `pt_BR` validation file so required field errors display in Portuguese

## Testing
- `php -l resources/lang/pt_BR/validation.php`
- `php -l artisan`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688cdae898bc832aac08c6b9404938b0