### PR TITLE
Add validation alerts for chair forms

### DIFF
--- a/resources/views/admin/cadeiras/create.blade.php
+++ b/resources/views/admin/cadeiras/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.app', ['hideErrors' => true])
 
 @section('content')
 @include('partials.breadcrumbs', ['crumbs' => [
@@ -8,10 +8,20 @@
 ]])
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Criar Cadeira</h1>
-    <form method="POST" action="{{ route('cadeiras.store') }}" class="space-y-4">
+    @if ($errors->any())
+        <x-alert-error>
+            <div>Por favor, preencha todos os campos obrigatórios (<span class="text-red-500">*</span>).</div>
+            <ul class="list-disc list-inside mt-2">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </x-alert-error>
+    @endif
+    <form method="POST" action="{{ route('cadeiras.store') }}" class="space-y-4" novalidate>
         @csrf
         <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700">Clínica</label>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Clínica <span class="text-red-500">*</span></label>
             <select name="clinic_id" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
                 <option value="">Selecione</option>
                 @foreach ($clinics as $clinic)
@@ -20,11 +30,11 @@
             </select>
         </div>
         <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Nome <span class="text-red-500">*</span></label>
             <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" required />
         </div>
         <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700">Status</label>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Status <span class="text-red-500">*</span></label>
             <select name="status" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
                 <option value="Ativa" @selected(old('status') === 'Ativa')>Ativa</option>
                 <option value="Desativa" @selected(old('status') === 'Desativa')>Desativa</option>

--- a/resources/views/admin/cadeiras/edit.blade.php
+++ b/resources/views/admin/cadeiras/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.app', ['hideErrors' => true])
 
 @section('content')
 @include('partials.breadcrumbs', ['crumbs' => [
@@ -9,19 +9,20 @@
 <div class="w-full bg-white p-6 rounded-lg shadow">
     <h1 class="text-xl font-semibold mb-4">Editar Cadeira</h1>
     @if ($errors->any())
-        <div class="mb-4">
-            <ul class="list-disc list-inside text-sm text-red-600">
+        <x-alert-error>
+            <div>Por favor, preencha todos os campos obrigatórios (<span class="text-red-500">*</span>).</div>
+            <ul class="list-disc list-inside mt-2">
                 @foreach ($errors->all() as $error)
                     <li>{{ $error }}</li>
                 @endforeach
             </ul>
-        </div>
+        </x-alert-error>
     @endif
-    <form method="POST" action="{{ route('cadeiras.update', $cadeira) }}" class="space-y-4">
+    <form method="POST" action="{{ route('cadeiras.update', $cadeira) }}" class="space-y-4" novalidate>
         @csrf
         @method('PUT')
         <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700">Clínica</label>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Clínica <span class="text-red-500">*</span></label>
             <select name="clinic_id" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
                 <option value="">Selecione</option>
                 @foreach ($clinics as $clinic)
@@ -30,11 +31,11 @@
             </select>
         </div>
         <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700">Nome</label>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Nome <span class="text-red-500">*</span></label>
             <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="nome" value="{{ old('nome', $cadeira->nome) }}" required />
         </div>
         <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700">Status</label>
+            <label class="mb-2 block text-sm font-medium text-gray-700">Status <span class="text-red-500">*</span></label>
             <select name="status" required class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none">
                 <option value="Ativa" @selected(old('status', $cadeira->status) === 'Ativa')>Ativa</option>
                 <option value="Desativa" @selected(old('status', $cadeira->status) === 'Desativa')>Desativa</option>


### PR DESCRIPTION
## Summary
- show validation warnings on chair create/edit views like professional forms
- mark required chair fields with a red asterisk

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688cdf25ad6c832a803f4efd65a3edcd