### PR TITLE
Fix calendar month locale

### DIFF
--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -205,7 +205,7 @@
 
         function render() {
             monthInput.value = current.toISOString().slice(0,7);
-            monthLabel.textContent = current.toLocaleString('default', { month: 'long', year: 'numeric' });
+            monthLabel.textContent = current.toLocaleString('pt-BR', { month: 'long', year: 'numeric' });
 
             const first = new Date(current.getFullYear(), current.getMonth(), 1);
             const start = new Date(first);


### PR DESCRIPTION
## Summary
- localize month label in escala modal calendar

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688ce2554264832a9f4aeb7eba5b6c06