### PR TITLE
Link Financial screen in top bar menu

### DIFF
--- a/resources/views/partials/topbar.blade.php
+++ b/resources/views/partials/topbar.blade.php
@@ -38,6 +38,11 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
         </svg>
     </button>
+    <a href="{{ route('financeiro.index') }}" class="ml-4 p-2 text-gray-600 hover:text-gray-900">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 20h18M9 20V10m6 10V6m6 14V14" />
+        </svg>
+    </a>
     <div class="relative ml-4" x-data="{ userOpen: false }">
         @php
             $user = Auth::user();


### PR DESCRIPTION
## Summary
- add Financeiro link to top navigation

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688ce711ab44832aab117af07581d383