### PR TITLE
Allow optional middle name for professionals

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -153,7 +153,7 @@ class ProfessionalController extends Controller
     {
         $rules = [
             'first_name' => 'required',
-            'middle_name' => 'required',
+            'middle_name' => 'nullable',
             'last_name' => 'required',
             'data_nascimento' => 'required|date',
             'sexo' => 'nullable',

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -35,8 +35,8 @@
                     <input type="text" name="first_name" value="{{ old('first_name') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
                 </div>
                 <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Nome do meio <span class="text-red-500">*</span></label>
-                    <input type="text" name="middle_name" value="{{ old('middle_name') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">Nome do meio</label>
+                    <input type="text" name="middle_name" value="{{ old('middle_name') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Último nome <span class="text-red-500">*</span></label>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -36,8 +36,8 @@
                     <input type="text" name="first_name" value="{{ old('first_name', $profissional->person->first_name) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
                 </div>
                 <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Nome do meio <span class="text-red-500">*</span></label>
-                    <input type="text" name="middle_name" value="{{ old('middle_name', $profissional->person->middle_name) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">Nome do meio</label>
+                    <input type="text" name="middle_name" value="{{ old('middle_name', $profissional->person->middle_name) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Último nome <span class="text-red-500">*</span></label>


### PR DESCRIPTION
## Summary
- make middle name optional when validating professionals
- update professional create/edit views to remove required marker and attribute

## Testing
- `npm run build` *(fails: none)*


------
https://chatgpt.com/codex/tasks/task_e_688cead9e87c832a9ad47deca4652e6c