### PR TITLE
Condição obrigatória para CPF/CNPJ

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -189,8 +189,8 @@ class ProfessionalController extends Controller
             'conta.tipo' => 'nullable',
             'conta.agencia' => 'nullable',
             'conta.numero' => 'nullable',
-            'conta.cpf_cnpj_tipo' => 'required|in:cpf,cnpj',
-            'conta.cpf_cnpj' => ['required'],
+            'conta.cpf_cnpj_tipo' => 'nullable|in:cpf,cnpj',
+            'conta.cpf_cnpj' => ['nullable'],
             'chave_pix' => 'nullable',
             'horarios_trabalho' => 'array',
             'comissoes' => 'array',
@@ -200,14 +200,22 @@ class ProfessionalController extends Controller
             'clinics.*' => 'exists:clinics,id',
         ];
 
+        $requiresCpfCnpj = $request->filled('conta.nome_banco') &&
+            $request->filled('conta.tipo') &&
+            $request->filled('conta.agencia');
+        if ($requiresCpfCnpj) {
+            $rules['conta.cpf_cnpj_tipo'] = 'required|in:cpf,cnpj';
+            $rules['conta.cpf_cnpj'] = ['required'];
+        }
+
         if ($request->input('funcao') === 'Dentista') {
             $rules['cro'] = 'required|numeric';
         }
 
         $tipoConta = $request->input('conta.cpf_cnpj_tipo');
-        if ($tipoConta === 'cpf') {
+        if ($request->filled('conta.cpf_cnpj') && $tipoConta === 'cpf') {
             $rules['conta.cpf_cnpj'][] = new \App\Rules\Cpf;
-        } elseif ($tipoConta === 'cnpj') {
+        } elseif ($request->filled('conta.cpf_cnpj') && $tipoConta === 'cnpj') {
             $rules['conta.cpf_cnpj'][] = new \App\Rules\Cnpj;
         }
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -181,6 +181,23 @@ document.addEventListener('DOMContentLoaded', () => {
         const input = group.querySelector('input[data-role="cpf_cnpj"]');
         if (!input) return;
         const radios = group.querySelectorAll('input[type="radio"]');
+        const indicator = group.querySelector('[data-required-indicator]');
+
+        const form = group.closest('form');
+        const bank = form?.querySelector('input[name="conta[nome_banco]"]');
+        const typeField = form?.querySelector('select[name="conta[tipo]"]');
+        const agency = form?.querySelector('input[name="conta[agencia]"]');
+
+        const setRequired = () => {
+            const required = bank?.value.trim() && typeField?.value.trim() && agency?.value.trim();
+            radios.forEach(r => r.required = !!required);
+            input.required = !!required;
+            if (indicator) indicator.style.display = required ? '' : 'none';
+        };
+
+        [bank, typeField, agency].forEach(el => el?.addEventListener('input', setRequired));
+        setRequired();
+
         const mask = () => {
             const type = group.querySelector('input[type="radio"]:checked')?.value || 'cpf';
             let v = input.value.replace(/\D/g, '');

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -266,7 +266,7 @@
                 @endforeach
             </div>
         </x-accordion-section>
-        <x-accordion-section title="Contas">
+        <x-accordion-section title="Dados bancários">
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Nome do banco</label>
@@ -290,10 +290,10 @@
                     <input type="text" name="conta[numero]" value="{{ old('conta.numero') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div data-cpf-cnpj-group>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">CPF/CNPJ do titular <span class="text-red-500">*</span></label>
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">CPF/CNPJ do titular <span class="text-red-500" data-required-indicator>*</span></label>
                     <div class="flex items-center space-x-4 mb-2">
                         <label class="flex items-center space-x-1">
-                            <input type="radio" name="conta[cpf_cnpj_tipo]" value="cpf" @checked(old('conta.cpf_cnpj_tipo', 'cpf')==='cpf') required />
+                            <input type="radio" name="conta[cpf_cnpj_tipo]" value="cpf" @checked(old('conta.cpf_cnpj_tipo', 'cpf')==='cpf') />
                             <span>CPF</span>
                         </label>
                         <label class="flex items-center space-x-1">
@@ -301,7 +301,7 @@
                             <span>CNPJ</span>
                         </label>
                     </div>
-                    <input type="text" data-role="cpf_cnpj" name="conta[cpf_cnpj]" value="{{ old('conta.cpf_cnpj') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none @error('conta.cpf_cnpj') border-red-500 @enderror" required />
+                    <input type="text" data-role="cpf_cnpj" name="conta[cpf_cnpj]" value="{{ old('conta.cpf_cnpj') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none @error('conta.cpf_cnpj') border-red-500 @enderror" />
                 </div>
                 <div class="sm:col-span-2">
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Chave PIX</label>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -270,7 +270,7 @@
                 @endforeach
             </div>
         </x-accordion-section>
-        <x-accordion-section title="Contas">
+        <x-accordion-section title="Dados bancários">
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Nome do banco</label>
@@ -294,10 +294,10 @@
                     <input type="text" name="conta[numero]" value="{{ old('conta.numero', $profissional->conta['numero'] ?? '') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div data-cpf-cnpj-group>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">CPF/CNPJ do titular <span class="text-red-500">*</span></label>
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">CPF/CNPJ do titular <span class="text-red-500" data-required-indicator>*</span></label>
                     <div class="flex items-center space-x-4 mb-2">
                         <label class="flex items-center space-x-1">
-                            <input type="radio" name="conta[cpf_cnpj_tipo]" value="cpf" @checked(old('conta.cpf_cnpj_tipo', $profissional->conta['cpf_cnpj_tipo'] ?? 'cpf')==='cpf') required />
+                            <input type="radio" name="conta[cpf_cnpj_tipo]" value="cpf" @checked(old('conta.cpf_cnpj_tipo', $profissional->conta['cpf_cnpj_tipo'] ?? 'cpf')==='cpf') />
                             <span>CPF</span>
                         </label>
                         <label class="flex items-center space-x-1">
@@ -305,7 +305,7 @@
                             <span>CNPJ</span>
                         </label>
                     </div>
-                    <input type="text" data-role="cpf_cnpj" name="conta[cpf_cnpj]" value="{{ old('conta.cpf_cnpj', $profissional->conta['cpf_cnpj'] ?? '') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none @error('conta.cpf_cnpj') border-red-500 @enderror" required />
+                    <input type="text" data-role="cpf_cnpj" name="conta[cpf_cnpj]" value="{{ old('conta.cpf_cnpj', $profissional->conta['cpf_cnpj'] ?? '') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none @error('conta.cpf_cnpj') border-red-500 @enderror" />
                 </div>
                 <div class="sm:col-span-2">
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Chave PIX</label>

--- a/resources/views/profissionais/show.blade.php
+++ b/resources/views/profissionais/show.blade.php
@@ -48,7 +48,7 @@
                 @endforeach
             </div>
         </x-accordion-section>
-        <x-accordion-section title="Contas">
+        <x-accordion-section title="Dados bancários">
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                     <span class="text-sm font-medium text-gray-700 mb-2 block">Nome do banco</span>


### PR DESCRIPTION
## Summary
- torna o CPF/CNPJ do titular obrigatório apenas quando banco, tipo e agência são informados
- ajusta as views de criação e edição para refletir a nova regra
- acrescenta lógica em JS para controlar atributo `required` e mostrar o asterisco apenas quando necessário
- renomeia o título do acordeão de contas para "Dados bancários"

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cee392908832a9fc8771a6a86efe2