### PR TITLE
Remove console logging in layout

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,10 +7,10 @@
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     <script>
         document.addEventListener('alpine:init', () => {
-            console.log('Alpine carregado!');
+
         });
         document.addEventListener('DOMContentLoaded', () => {
-            console.log('DOM pronto');
+
         });
     </script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- clean up console logs in `app.blade.php`

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688d01ad6a40832a9a53c20ba5c04111