### PR TITLE
Expand scheduling modal width

### DIFF
--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -135,7 +135,7 @@
     </table>
 </div>
 <div id="schedule-modal" data-time="" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
-    <div class="bg-white rounded p-4 w-96">
+    <div class="bg-white rounded p-4 w-[32rem]">
         <h2 class="text-lg font-semibold mb-2">Agendar Horário</h2>
         <div id="schedule-time" class="text-sm text-gray-600 mb-4"></div>
         <label class="block mb-4">


### PR DESCRIPTION
## Summary
- enlarge scheduling modal for easier patient search

## Testing
- `npm run build`
- `php artisan test` *(fails: Failed opening required vendor/autoload.php)*
- `composer install` *(fails: curl error 56 while downloading packages.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d03f67428832ab7d211a27abc3aec