### PR TITLE
Add start/end time fields to scheduling modal

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -332,7 +332,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const scheduleModal = document.getElementById('schedule-modal');
     if (scheduleModal) {
         const cancel = document.getElementById('schedule-cancel');
-        const timeLabel = document.getElementById('schedule-time');
+        const startInput = document.getElementById('schedule-start');
+        const endInput = document.getElementById('schedule-end');
         const patientInput = document.getElementById('schedule-patient');
         const patientList = document.getElementById('schedule-patient-list');
         let searchTimeout;
@@ -343,7 +344,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 selectedTime = td.dataset.time;
                 scheduleModal.dataset.time = selectedTime;
                 scheduleModal.classList.remove('hidden');
-                if (timeLabel) timeLabel.textContent = `Horário: ${selectedTime}`;
+                if (startInput) startInput.value = selectedTime;
+                if (endInput) {
+                    const [h, m] = selectedTime.split(':').map(Number);
+                    const date = new Date();
+                    date.setHours(h);
+                    date.setMinutes(m + 30);
+                    endInput.value = date.toISOString().slice(11, 16);
+                }
             });
         });
 

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -137,7 +137,16 @@
 <div id="schedule-modal" data-time="" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
     <div class="bg-white rounded p-4 w-[32rem]">
         <h2 class="text-lg font-semibold mb-2">Agendar Horário</h2>
-        <div id="schedule-time" class="text-sm text-gray-600 mb-4"></div>
+        <div class="flex gap-2 mb-4">
+            <label class="block flex-1">
+                <span class="text-sm">Início</span>
+                <input id="schedule-start" type="time" class="mt-1 w-full border rounded p-1" />
+            </label>
+            <label class="block flex-1">
+                <span class="text-sm">Fim</span>
+                <input id="schedule-end" type="time" class="mt-1 w-full border rounded p-1" />
+            </label>
+        </div>
         <label class="block mb-4">
             <span class="text-sm">Paciente</span>
             <input id="schedule-patient" type="text" list="schedule-patient-list" placeholder="Buscar..." data-search-url="{{ route('pacientes.search') }}" class="mt-1 w-full border rounded p-1" />


### PR DESCRIPTION
## Summary
- let users pick start and end times when scheduling
- prefill the start time and suggest an end time 30 minutes later

## Testing
- `npm run build`
- `phpunit` *(fails: command not found)*
- `php artisan test` *(fails: missing vendor autoload)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f68b13e78832a90d2aabfe3bcbceb