### PR TITLE
Use double click to open scheduling modal

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -340,7 +340,7 @@ document.addEventListener('DOMContentLoaded', () => {
         let selectedTime = '';
 
         document.querySelectorAll('#schedule-table td[data-professional]').forEach(td => {
-            td.addEventListener('click', () => {
+            td.addEventListener('dblclick', () => {
                 selectedTime = td.dataset.time;
                 scheduleModal.dataset.time = selectedTime;
                 scheduleModal.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- trigger schedule modal with double-click on slots

## Testing
- `npm run build`
- `composer install` *(fails: curl error 56: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f69dc1334832a859a26b305a674f3