### PR TITLE
Fix schedule time column layout

### DIFF
--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -108,10 +108,10 @@
 </div>
 <div class="overflow-auto" id="schedule-container">
     <div id="schedule-closed" class="hidden text-center py-4 text-gray-500">A clínica está fechada neste dia.</div>
-    <table id="schedule-table" class="min-w-full text-sm">
+    <table id="schedule-table" class="min-w-full text-sm table-fixed">
         <thead>
             <tr>
-                <th class="p-2 bg-gray-50 w-20"></th>
+                <th class="p-2 bg-gray-50 w-24 min-w-[6rem]"></th>
                 @foreach($professionals as $prof)
                     <th class="p-2 bg-gray-50 text-left whitespace-nowrap">{{ $prof['name'] }}</th>
                 @endforeach
@@ -120,9 +120,9 @@
         <tbody>
             @foreach($horarios as $hora)
                 <tr class="border-t" data-row="{{ $hora }}">
-                    <td class="bg-gray-50 w-20" data-slot="{{ $hora }}" data-hora="{{ $hora }}"><x-agenda.horario :time="$hora" /></td>
+                    <td class="bg-gray-50 w-24 min-w-[6rem] h-16 align-middle" data-slot="{{ $hora }}" data-hora="{{ $hora }}"><x-agenda.horario :time="$hora" /></td>
                     @foreach($professionals as $prof)
-                        <td class="w-40 h-16 cursor-pointer" data-professional="{{ $prof['id'] }}" data-time="{{ $hora }}" data-hora="{{ $hora }}">
+                        <td class="h-16 cursor-pointer" data-professional="{{ $prof['id'] }}" data-time="{{ $hora }}" data-hora="{{ $hora }}">
                             @isset($agenda[$prof['id']][$hora])
                                 @php $item = $agenda[$prof['id']][$hora]; @endphp
                                 <x-agenda.agendamento :paciente="$item['paciente']" :tipo="$item['tipo']" :contato="$item['contato']" :status="$item['status']" />

--- a/resources/views/components/agenda/horario.blade.php
+++ b/resources/views/components/agenda/horario.blade.php
@@ -1,4 +1,4 @@
 @props(['time'])
-<div {{ $attributes->merge(['class' => 'p-2 text-right text-xs text-gray-500 whitespace-nowrap']) }}>
+<div {{ $attributes->merge(['class' => 'h-full flex items-center justify-end px-2 text-xs text-gray-500 whitespace-nowrap']) }}>
     {{ $time }}
 </div>


### PR DESCRIPTION
## Summary
- fix time column width in admin schedule and distribute professional columns
- center time labels vertically

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f6f3838d4832aa850d1fa6576c8ca