### PR TITLE
feat: add observation field to scheduling modal

### DIFF
--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -154,6 +154,10 @@
             <input id="schedule-patient" type="text" list="schedule-patient-list" placeholder="Buscar..." data-search-url="{{ route('pacientes.search') }}" class="mt-1 w-full border rounded p-1" />
             <datalist id="schedule-patient-list"></datalist>
         </label>
+        <label class="block mb-4">
+            <span class="text-sm">Observação</span>
+            <textarea id="schedule-observacao" class="mt-1 w-full border rounded p-1" placeholder="Digite aqui"></textarea>
+        </label>
         <div class="flex justify-end gap-2">
             <button id="schedule-cancel" class="px-3 py-1 border rounded">Cancelar</button>
             <button id="schedule-save" class="px-3 py-1 bg-primary text-white rounded">Salvar</button>


### PR DESCRIPTION
## Summary
- add observation textarea to appointment scheduling modal

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f71495a1c832abee6a10320501662