### PR TITLE
Fix patient search field

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -114,7 +114,8 @@ class PatientController extends Controller
             ->limit(10)
             ->get()
             ->map(function ($p) {
-                return $p->person->first_name;
+                $person = $p->person;
+                return trim(($person->first_name ?? '') . ' ' . ($person->last_name ?? ''));
             })
             ->values();
 


### PR DESCRIPTION
## Summary
- Return full patient names (first and last) in patient search API to improve matching in scheduling modal

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f72d08fac832a906fa93b279dfd76