### PR TITLE
Add basic scheduling with DB storage

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Agendamento;
+use App\Models\Clinic;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class AgendamentoController extends Controller
+{
+    public function index(Request $request)
+    {
+        $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
+        $professionals = [];
+        if ($clinicId) {
+            $clinic = Clinic::with(['profissionais.person'])->find($clinicId);
+            if ($clinic) {
+                $professionals = $clinic->profissionais->map(function ($prof) {
+                    $gender = $prof->person->sexo ?? null;
+                    $prefix = $gender === 'Masculino' ? 'Dr. ' : ($gender === 'Feminino' ? 'Dra. ' : '');
+                    return [
+                        'id' => $prof->id,
+                        'name' => $prefix . ($prof->person->first_name ?? ''),
+                    ];
+                })->toArray();
+            }
+        }
+
+        $horarios = [];
+        $startTime = Carbon::createFromTime(0, 0);
+        $endTime = Carbon::createFromTime(23, 30);
+        for ($time = $startTime->copy(); $time <= $endTime; $time->addMinutes(30)) {
+            $horarios[] = $time->format('H:i');
+        }
+
+        $date = $request->query('date', Carbon::today()->format('Y-m-d'));
+        $agenda = [];
+        if ($clinicId) {
+            $agendamentos = Agendamento::where('clinic_id', $clinicId)
+                ->whereDate('data', $date)
+                ->get();
+            foreach ($agendamentos as $ag) {
+                $agenda[$ag->profissional_id][$ag->hora_inicio] = [
+                    'paciente' => $ag->paciente,
+                    'tipo' => $ag->tipo ?? '',
+                    'contato' => $ag->contato ?? '',
+                    'status' => $ag->status ?? 'confirmado',
+                ];
+            }
+        }
+
+        return view('agendamentos.index', compact('professionals', 'horarios', 'agenda'));
+    }
+
+    public function store(Request $request)
+    {
+        $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
+        if (! $clinicId) {
+            return response()->json(['success' => false], 400);
+        }
+
+        $data = $request->validate([
+            'profissional_id' => 'required|exists:profissionais,id',
+            'paciente' => 'required|string',
+            'data' => 'required|date',
+            'hora_inicio' => 'required',
+            'hora_fim' => 'required',
+            'observacao' => 'nullable|string',
+        ]);
+
+        $data['clinic_id'] = $clinicId;
+        $data['status'] = 'confirmado';
+
+        Agendamento::create($data);
+
+        return response()->json(['success' => true]);
+    }
+}

--- a/app/Models/Agendamento.php
+++ b/app/Models/Agendamento.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Agendamento extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'clinic_id',
+        'profissional_id',
+        'paciente',
+        'tipo',
+        'contato',
+        'status',
+        'data',
+        'hora_inicio',
+        'hora_fim',
+        'observacao',
+    ];
+
+    protected $casts = [
+        'data' => 'date',
+    ];
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class);
+    }
+
+    public function profissional()
+    {
+        return $this->belongsTo(Profissional::class);
+    }
+}

--- a/database/migrations/2025_10_23_000000_create_agendamentos_table.php
+++ b/database/migrations/2025_10_23_000000_create_agendamentos_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agendamentos', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinic_id')->constrained('clinics');
+            $table->foreignId('profissional_id')->constrained('profissionais');
+            $table->string('paciente');
+            $table->string('tipo')->nullable();
+            $table->string('contato')->nullable();
+            $table->enum('status', ['confirmado', 'cancelado', 'vago'])->default('confirmado');
+            $table->date('data');
+            $table->time('hora_inicio');
+            $table->time('hora_fim');
+            $table->text('observacao')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agendamentos');
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -450,6 +450,26 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (saveBtn) {
             saveBtn.addEventListener('click', () => {
+                const root = document.querySelector('[x-data]');
+                const date = root?.__x?.$data?.selectedDate;
+                const url = saveBtn.dataset.storeUrl;
+                const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+                fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': token,
+                    },
+                    body: JSON.stringify({
+                        data: date,
+                        hora_inicio: startInput.value,
+                        hora_fim: endInput.value,
+                        paciente: patientInput.value,
+                        observacao: document.getElementById('schedule-observacao')?.value || '',
+                        profissional_id: selection.professional,
+                    }),
+                }).then(() => window.location.reload());
+
                 scheduleModal.classList.add('hidden');
                 clearSelection();
             });

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -11,56 +11,7 @@
     <p class="text-gray-600">Agenda semanal por profissional</p>
 </div>
 @php
-    use Illuminate\Support\Carbon;
-    $months = [1=>'Janeiro',2=>'Fevereiro',3=>'Mar\xC3\xA7o',4=>'Abril',5=>'Maio',6=>'Junho',7=>'Julho',8=>'Agosto',9=>'Setembro',10=>'Outubro',11=>'Novembro',12=>'Dezembro'];
-    $week = ['SEG','TER','QUA','QUI','SEX','SAB','DOM'];
-    $start = Carbon::now()->startOfWeek(Carbon::MONDAY);
-    $days = [];
-    for($i=0;$i<7;$i++){
-        $d = $start->copy()->addDays($i);
-        $days[] = [
-            'label'=>$week[$i],
-            'number'=>$d->day,
-            'month'=>$months[$d->month],
-            'active'=>$d->isToday(),
-            'past'=>$d->lt(Carbon::today()),
-        ];
-    }
-    $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;
-    $professionals = [];
-    if ($clinicId) {
-        $clinic = \App\Models\Clinic::with(['profissionais.person'])->find($clinicId);
-        if ($clinic) {
-            $professionals = $clinic->profissionais->map(function ($prof) {
-                $gender = $prof->person->sexo ?? null;
-                $prefix = $gender === 'Masculino' ? 'Dr. ' : ($gender === 'Feminino' ? 'Dra. ' : '');
-                return [
-                    'id' => $prof->id,
-                    'name' => $prefix . ($prof->person->first_name ?? ''),
-                ];
-            })->toArray();
-        }
-    }
-    $patients = ['João','Maria','Pedro','Ana','Carlos'];
-    $horarios = [];
-    $startTime = Carbon::createFromTime(0, 0);
-    $endTime = Carbon::createFromTime(23, 30);
-    for ($time = $startTime->copy(); $time <= $endTime; $time->addMinutes(30)) {
-        $horarios[] = $time->format('H:i');
-    }
-    $agenda = [
-        1 => [
-            '08:00' => ['paciente'=>'Maria','tipo'=>'Consulta','contato'=>'(11) 91234-5678','status'=>'confirmado'],
-            '15:00' => ['paciente'=>'Raony','tipo'=>'Retorno','contato'=>'(11) 99876-5432','status'=>'cancelado'],
-        ],
-        2 => [
-            '09:00' => ['paciente'=>'Ana','tipo'=>'Consulta','contato'=>'(11) 95555-4444','status'=>'confirmado'],
-            '16:00' => ['paciente'=>'Luis','tipo'=>'Consulta','contato'=>'(11) 97777-2222','status'=>'vago'],
-        ],
-        3 => [
-            '10:00' => ['paciente'=>'Pedro','tipo'=>'Consulta','contato'=>'(11) 94444-3333','status'=>'confirmado'],
-        ],
-    ];
+    // Dados de agenda são fornecidos pelo controlador
 @endphp
 <div x-data="agendaCalendar()" x-init="init()" data-horarios-url="{{ route('agendamentos.horarios') }}">
     <div class="flex justify-end mb-2 relative">
@@ -160,7 +111,7 @@
         </label>
         <div class="flex justify-end gap-2">
             <button id="schedule-cancel" class="px-3 py-1 border rounded">Cancelar</button>
-            <button id="schedule-save" class="px-3 py-1 bg-primary text-white rounded">Salvar</button>
+            <button id="schedule-save" data-store-url="{{ route('agendamentos.store') }}" class="px-3 py-1 bg-primary text-white rounded">Salvar</button>
         </div>
         </div>
 </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ config('app.name') }}</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     <script>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Admin\FormularioController;
 use App\Http\Controllers\Admin\PatientController;
 use App\Http\Controllers\Admin\ProfessionalController;
 use App\Http\Controllers\Admin\AgendaController;
+use App\Http\Controllers\Admin\AgendamentoController;
 use App\Http\Controllers\Admin\ClinicContextController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\EscalaTrabalhoController;
@@ -18,7 +19,8 @@ use App\Http\Controllers\Admin\EstoqueController;
 Route::get('/', [DashboardController::class, 'index'])->name('admin.index');
 
 Route::get('agenda', [AgendaController::class, 'index'])->name('agenda.index');
-Route::view('agendamentos', 'agendamentos.index')->name('agendamentos.index');
+Route::get('agendamentos', [AgendamentoController::class, 'index'])->name('agendamentos.index');
+Route::post('agendamentos', [AgendamentoController::class, 'store'])->name('agendamentos.store');
 Route::get('agendamentos/horarios', [AgendaController::class, 'horarios'])->name('agendamentos.horarios');
 
 


### PR DESCRIPTION
## Summary
- enable agendamento pages to persist appointments via new `Agendamento` model and controller
- expose new routes and JS to post appointments with CSRF protection
- add migration for `agendamentos` table and render saved items in agenda view

## Testing
- `npm run build`
- `composer install` (failed: curl error 56 connecting to packagist)
- `php artisan test` (failed: vendor/autoload.php missing)


------
https://chatgpt.com/codex/tasks/task_e_688f74929e5c832a81e4db4a484829cb