### PR TITLE
Add patient relation to appointments

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -115,7 +115,10 @@ class PatientController extends Controller
             ->get()
             ->map(function ($p) {
                 $person = $p->person;
-                return trim(($person->first_name ?? '') . ' ' . ($person->last_name ?? ''));
+                return [
+                    'id' => $p->id,
+                    'name' => trim(($person->first_name ?? '') . ' ' . ($person->last_name ?? '')),
+                ];
             })
             ->values();
 

--- a/app/Models/Agendamento.php
+++ b/app/Models/Agendamento.php
@@ -12,7 +12,7 @@ class Agendamento extends Model
     protected $fillable = [
         'clinic_id',
         'profissional_id',
-        'paciente',
+        'patient_id',
         'tipo',
         'contato',
         'status',
@@ -34,5 +34,10 @@ class Agendamento extends Model
     public function profissional()
     {
         return $this->belongsTo(Profissional::class);
+    }
+
+    public function patient()
+    {
+        return $this->belongsTo(Patient::class);
     }
 }

--- a/database/migrations/2025_10_24_000000_add_patient_id_to_agendamentos_table.php
+++ b/database/migrations/2025_10_24_000000_add_patient_id_to_agendamentos_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agendamentos', function (Blueprint $table) {
+            $table->foreignId('patient_id')->constrained('patients');
+            $table->dropColumn('paciente');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agendamentos', function (Blueprint $table) {
+            $table->string('paciente');
+            $table->dropConstrainedForeignId('patient_id');
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -337,6 +337,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const saveBtn = document.getElementById('schedule-save');
         const patientInput = document.getElementById('schedule-patient');
         const patientList = document.getElementById('schedule-patient-list');
+        const patientIdInput = document.getElementById('schedule-patient-id');
         let searchTimeout;
         const hiddenStart = document.getElementById('hora_inicio');
         const hiddenEnd = document.getElementById('hora_fim');
@@ -436,9 +437,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     fetch(`${url}?q=${encodeURIComponent(term)}`)
                         .then(r => r.json())
                         .then(data => {
-                            patientList.innerHTML = data.map(n => `<option value="${n}"></option>`).join('');
+                            patientList.innerHTML = data.map(n => `<option data-id="${n.id}" value="${n.name}"></option>`).join('');
                         });
                 }, 300);
+            });
+            patientInput.addEventListener('change', () => {
+                const option = Array.from(patientList.options).find(o => o.value === patientInput.value);
+                if (patientIdInput) patientIdInput.value = option?.dataset.id || '';
             });
         }
 
@@ -464,7 +469,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         data: date,
                         hora_inicio: startInput.value,
                         hora_fim: endInput.value,
-                        paciente: patientInput.value,
+                        patient_id: patientIdInput?.value,
                         observacao: document.getElementById('schedule-observacao')?.value || '',
                         profissional_id: selection.professional,
                     }),

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -104,6 +104,7 @@
             <span class="text-sm">Paciente</span>
             <input id="schedule-patient" type="text" list="schedule-patient-list" placeholder="Buscar..." data-search-url="{{ route('pacientes.search') }}" class="mt-1 w-full border rounded p-1" />
             <datalist id="schedule-patient-list"></datalist>
+            <input type="hidden" id="schedule-patient-id" />
         </label>
         <label class="block mb-4">
             <span class="text-sm">Observação</span>


### PR DESCRIPTION
## Summary
- link appointments to patients via `patient_id`
- expose patient relation on `Agendamento` model and controllers
- update appointment views and scripts to handle patient lookup by id

## Testing
- `npm run build`
- `php artisan migrate` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_688f7839760c832aadf9f062c6ba6c4f