### PR TITLE
Fix patient search route precedence

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -33,9 +33,9 @@ Route::resource('profissionais', ProfessionalController::class)
     ->parameters(['profissionais' => 'profissional']);
 
 Route::resource('formularios', FormularioController::class);
+Route::get('pacientes/buscar', [PatientController::class, 'search'])->name('pacientes.search');
 Route::resource('pacientes', PatientController::class)
     ->parameters(['pacientes' => 'paciente']);
-Route::get('pacientes/buscar', [PatientController::class, 'search'])->name('pacientes.search');
 
 Route::view('orcamentos/assinar', 'orcamentos.assinar')->name('orcamentos.assinar');
 


### PR DESCRIPTION
## Summary
- Move patient search route before resource definition so `/pacientes/buscar` is resolved before `/pacientes/{paciente}`

## Testing
- `php -l routes/admin.php`
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f8b916218832aab1634e65b488cb1