### PR TITLE
Renomeia tabela patients para pacientes

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -69,7 +69,7 @@ class AgendamentoController extends Controller
 
         $data = $request->validate([
             'profissional_id' => 'required|exists:profissionais,id',
-            'patient_id' => 'required|exists:patients,id',
+            'patient_id' => 'required|exists:pacientes,id',
             'data' => 'required|date',
             'hora_inicio' => 'required',
             'hora_fim' => 'required',

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -11,6 +11,8 @@ class Patient extends Model
 {
     use BelongsToOrganization;
 
+    protected $table = 'pacientes';
+
     protected $fillable = [
         'organization_id',
         'user_id',

--- a/database/migrations/2025_10_27_000000_rename_patients_to_pacientes_table.php
+++ b/database/migrations/2025_10_27_000000_rename_patients_to_pacientes_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::rename('patients', 'pacientes');
+    }
+
+    public function down(): void
+    {
+        Schema::rename('pacientes', 'patients');
+    }
+};


### PR DESCRIPTION
## Summary
- rename table `patients` to `pacientes`
- point `Patient` model to new table
- adjust agendamento validation to reference `pacientes`

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688fd2ea87c0832abee23a5fda8e919e