### PR TITLE
Add throttling to authentication endpoints

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -18,6 +19,16 @@ class Handler extends ExceptionHandler
     {
         $this->reportable(function (Throwable $e) {
             //
+        });
+
+        $this->renderable(function (ThrottleRequestsException $e, $request) {
+            $message = 'Muitas solicitações. Tente novamente mais tarde.';
+
+            if ($request->expectsJson()) {
+                return response()->json(['message' => $message], 429);
+            }
+
+            return response($message, 429);
         });
     }
 }

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -5,9 +5,11 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
 
 Route::get('/login', [AuthenticatedSessionController::class, 'create'])
-    ->name('login');
+    ->name('login')
+    ->middleware('throttle:60,1');
 
-Route::post('/login', [AuthenticatedSessionController::class, 'store']);
+Route::post('/login', [AuthenticatedSessionController::class, 'store'])
+    ->middleware('throttle:60,1');
 
 Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
     ->name('logout');


### PR DESCRIPTION
## Summary
- rate-limit login routes to 60 requests per minute
- return a friendly message when request throttle is exceeded

## Testing
- `composer install` (fails: CONNECT tunnel failed, response 403)
- `php artisan test` (fails: vendor autoload not found)


------
https://chatgpt.com/codex/tasks/task_e_688fd63fcfc4832a844e1c12509312fe