### PR TITLE
fix: handle renamed organizations table in pessoas migration

### DIFF
--- a/database/migrations/2025_09_01_000000_create_pessoas_table.php
+++ b/database/migrations/2025_09_01_000000_create_pessoas_table.php
@@ -8,7 +8,8 @@ return new class extends Migration {
     {
         Schema::create('pessoas', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizations');
+            $organizationTable = Schema::hasTable('organizacoes') ? 'organizacoes' : 'organizations';
+            $table->foreignId('organization_id')->constrained($organizationTable);
             $table->string('first_name');
             $table->string('middle_name')->nullable();
             $table->string('last_name');


### PR DESCRIPTION
## Summary
- handle organizations table being renamed to `organizacoes` before creating `pessoas`

## Testing
- `composer install` (fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_688fd9ff3da8832a9763026040081ead