### PR TITLE
Rename clinic_profissional pivot table to clinica_profissional

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -82,7 +82,7 @@ class EscalaTrabalhoController extends Controller
                 'profissional_id' => [
                     'required',
                     'exists:profissionais,id',
-                    Rule::exists('clinic_profissional', 'profissional_id')->where(fn($q) => $q->where('clinic_id', $request->input('clinic_id'))),
+                    Rule::exists('clinica_profissional', 'profissional_id')->where(fn($q) => $q->where('clinic_id', $request->input('clinic_id'))),
                 ],
                 'datas' => 'required|array',
                 'datas.*' => 'date',
@@ -96,7 +96,7 @@ class EscalaTrabalhoController extends Controller
                 'profissional_id' => [
                     'required',
                     'exists:profissionais,id',
-                    Rule::exists('clinic_profissional', 'profissional_id')->where(fn($q) => $q->where('clinic_id', $request->input('clinic_id'))),
+                    Rule::exists('clinica_profissional', 'profissional_id')->where(fn($q) => $q->where('clinic_id', $request->input('clinic_id'))),
                 ],
                 'semana' => 'required|date',
                 'dias' => 'required|array',

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -62,6 +62,6 @@ class Clinic extends Model
 
     public function profissionais()
     {
-        return $this->belongsToMany(Profissional::class, 'clinic_profissional')->withTimestamps();
+        return $this->belongsToMany(Profissional::class, 'clinica_profissional')->withTimestamps();
     }
 }

--- a/app/Models/Profissional.php
+++ b/app/Models/Profissional.php
@@ -73,6 +73,6 @@ class Profissional extends Model
 
     public function clinics()
     {
-        return $this->belongsToMany(Clinic::class, 'clinic_profissional')->withTimestamps();
+        return $this->belongsToMany(Clinic::class, 'clinica_profissional')->withTimestamps();
     }
 }

--- a/database/migrations/2025_10_03_000000_create_clinica_profissional_table.php
+++ b/database/migrations/2025_10_03_000000_create_clinica_profissional_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        Schema::create('clinic_profissional', function (Blueprint $table) {
+        Schema::create('clinica_profissional', function (Blueprint $table) {
             $table->id();
             $table->foreignId('clinic_id')->constrained('clinics');
             $table->foreignId('profissional_id')->constrained('profissionais');
@@ -16,6 +16,6 @@ return new class extends Migration {
 
     public function down(): void
     {
-        Schema::dropIfExists('clinic_profissional');
+        Schema::dropIfExists('clinica_profissional');
     }
 };

--- a/database/migrations/2025_10_03_000001_rename_clinic_profissional_table.php
+++ b/database/migrations/2025_10_03_000001_rename_clinic_profissional_table.php
@@ -1,0 +1,15 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::rename('clinic_profissional', 'clinica_profissional');
+    }
+
+    public function down(): void
+    {
+        Schema::rename('clinica_profissional', 'clinic_profissional');
+    }
+};


### PR DESCRIPTION
## Summary
- rename pivot table to Portuguese name `clinica_profissional`
- update models and controller rules to use new table
- add migration to rename existing table

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689068eeec38832ab5ed226a7e14c9d6