### PR TITLE
Skip incomplete patient records during pessoas migration

### DIFF
--- a/database/migrations/2025_09_01_010000_update_patients_to_use_pessoas.php
+++ b/database/migrations/2025_09_01_010000_update_patients_to_use_pessoas.php
@@ -16,6 +16,10 @@ return new class extends Migration {
         if (Schema::hasTable('patients')) {
             $patients = DB::table('patients')->get();
             foreach ($patients as $patient) {
+                if (empty($patient->first_name) || empty($patient->last_name)) {
+                    continue;
+                }
+
                 $pessoa = Pessoa::create([
                     'organization_id' => $patient->organization_id ?? null,
                     'first_name' => $patient->first_name ?? null,


### PR DESCRIPTION
## Summary
- avoid failing `pessoas` migration by skipping patients without names

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `phpunit` *(fails: command not found: phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68906ddde3c0832a8949269347c825f7