### PR TITLE
Handle missing patient columns in migration

### DIFF
--- a/database/migrations/2025_09_01_010000_update_patients_to_use_pessoas.php
+++ b/database/migrations/2025_09_01_010000_update_patients_to_use_pessoas.php
@@ -45,11 +45,18 @@ return new class extends Migration {
             }
         }
 
-        Schema::table('patients', function (Blueprint $table) {
-            $table->dropColumn([
-                'first_name','middle_name','last_name','data_nascimento','cpf','telefone','whatsapp','email','cep','logradouro','numero','complemento','bairro','cidade','estado'
-            ]);
-        });
+        $columns = [
+            'first_name', 'middle_name', 'last_name', 'data_nascimento', 'cpf', 'telefone',
+            'whatsapp', 'email', 'cep', 'logradouro', 'numero', 'complemento',
+            'bairro', 'cidade', 'estado',
+        ];
+        $existingColumns = array_filter($columns, fn ($col) => Schema::hasColumn('patients', $col));
+
+        if (!empty($existingColumns)) {
+            Schema::table('patients', function (Blueprint $table) use ($existingColumns) {
+                $table->dropColumn($existingColumns);
+            });
+        }
     }
 
     public function down(): void


### PR DESCRIPTION
## Summary
- safeguard patient migration to drop columns only when present

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68906f091760832a85df8ecefbf60e04