### PR TITLE
Renomeia organization_id para organizacao_id

### DIFF
--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -81,7 +81,7 @@ class ClinicController extends Controller
 
         unset($data['horarios']);
 
-        $data['organizacao_id'] = auth()->user()->organization_id;
+        $data['organizacao_id'] = auth()->user()->organizacao_id;
         $data['timezone'] = auth()->user()->organization->timezone;
 
         $clinic = Clinic::create($data);
@@ -90,7 +90,7 @@ class ClinicController extends Controller
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinic_id' => $clinic->id,
-                    'organization_id' => $clinic->organizacao_id,
+                    'organizacao_id' => $clinic->organizacao_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],
@@ -98,7 +98,7 @@ class ClinicController extends Controller
             }
         }
 
-        $adminPerfil = \App\Models\Perfil::where('organization_id', $clinic->organizacao_id)
+        $adminPerfil = \App\Models\Perfil::where('organizacao_id', $clinic->organizacao_id)
             ->where('nome', 'Administrador')
             ->first();
         if ($adminPerfil) {
@@ -186,7 +186,7 @@ class ClinicController extends Controller
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinic_id' => $clinic->id,
-                    'organization_id' => $clinic->organizacao_id,
+                    'organizacao_id' => $clinic->organizacao_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],

--- a/app/Http/Controllers/Admin/OrganizationController.php
+++ b/app/Http/Controllers/Admin/OrganizationController.php
@@ -72,7 +72,7 @@ class OrganizationController extends Controller
         ]);
      
         $perfil = Perfil::create([
-            'organization_id' => $organization->id,
+            'organizacao_id' => $organization->id,
             'nome' => 'Administrador',
         ]);
 
@@ -101,7 +101,7 @@ class OrganizationController extends Controller
         $password = $data['password'] ?? Str::random(10);
 
         $pessoa = Pessoa::create([
-            'organization_id' => $organization->id,
+            'organizacao_id' => $organization->id,
             'first_name' => $data['first_name'],
             'middle_name' => $data['middle_name'] ?? null,
             'last_name' => $data['last_name'],
@@ -110,7 +110,7 @@ class OrganizationController extends Controller
 
         $usuario = Usuario::create([
             'email' => $data['email'],
-            'organization_id' => $organization->id,
+            'organizacao_id' => $organization->id,
             'password' => Hash::make($password),
             'must_change_password' => true,
             'pessoa_id' => $pessoa->id,
@@ -173,7 +173,7 @@ class OrganizationController extends Controller
             'timezone' => $data['timezone'],
         ]);
 
-        $usuario = Usuario::where('organization_id', $organization->id)->first();
+        $usuario = Usuario::where('organizacao_id', $organization->id)->first();
         if ($usuario) {
             if ($request->filled('first_name') || $request->filled('middle_name') || $request->filled('last_name')) {
                 $usuario->pessoa?->update([

--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -34,11 +34,11 @@ class PatientController extends Controller
     {
         $data = $this->validateData($request);
         $pessoa = Pessoa::create(array_merge(
-            ['organization_id' => auth()->user()->organization_id],
+            ['organizacao_id' => auth()->user()->organizacao_id],
             $this->extractPessoaData($data)
         ));
         $patientData = [
-            'organization_id' => auth()->user()->organization_id,
+            'organizacao_id' => auth()->user()->organizacao_id,
             'pessoa_id' => $pessoa->id,
             'menor_idade' => $request->menor_idade === 'Sim',
             'responsavel_first_name' => $data['responsavel_first_name'] ?? null,
@@ -52,14 +52,14 @@ class PatientController extends Controller
         if ($request->boolean('create_user') && $paciente->email) {
             $perfil = Perfil::firstOrCreate([
                 'nome' => 'Paciente',
-                'organization_id' => auth()->user()->organization_id,
+                'organizacao_id' => auth()->user()->organizacao_id,
             ]);
 
             $password = Str::random(8);
             $usuario = Usuario::create([
                 'name' => $paciente->pessoa->first_name.' '.$paciente->pessoa->last_name,
                 'email' => $paciente->email,
-                'organization_id' => auth()->user()->organization_id,
+                'organizacao_id' => auth()->user()->organizacao_id,
                 'password' => Hash::make($password),
                 'must_change_password' => true,
             ]);

--- a/app/Http/Controllers/Admin/PerfilController.php
+++ b/app/Http/Controllers/Admin/PerfilController.php
@@ -29,7 +29,7 @@ class PerfilController extends Controller
 
         $perfil = Perfil::create([
             'nome' => $data['nome'],
-            'organization_id' => auth()->user()->organization_id,
+            'organizacao_id' => auth()->user()->organizacao_id,
         ]);
 
         $this->syncPermissions($perfil, $data['permissions'] ?? []);

--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -37,7 +37,7 @@ class ProfessionalController extends Controller
 
     public function create()
     {
-        $clinics = Clinic::where('organizacao_id', auth()->user()->organization_id)
+        $clinics = Clinic::where('organizacao_id', auth()->user()->organizacao_id)
             ->with('horarios')
             ->get();
 
@@ -46,7 +46,7 @@ class ProfessionalController extends Controller
 
     public function show(Profissional $profissional)
     {
-        $clinics = Clinic::where('organizacao_id', auth()->user()->organization_id)
+        $clinics = Clinic::where('organizacao_id', auth()->user()->organizacao_id)
             ->with('horarios')
             ->get();
 
@@ -73,7 +73,7 @@ class ProfessionalController extends Controller
             $pessoaData['photo_path'] = $request->file('foto')->store('profissionais', 'public');
         }
         $pessoa = Pessoa::create(array_merge([
-            'organization_id' => auth()->user()->organization_id
+            'organizacao_id' => auth()->user()->organizacao_id
         ], $pessoaData));
 
         $usuario = null;
@@ -82,7 +82,7 @@ class ProfessionalController extends Controller
             if (!$usuario) {
                 $usuario = Usuario::create([
                     'email' => $pessoa->email,
-                    'organization_id' => auth()->user()->organization_id,
+                    'organizacao_id' => auth()->user()->organizacao_id,
                     'password' => Hash::make(Str::random(8)),
                     'must_change_password' => true,
                     'pessoa_id' => $pessoa->id,
@@ -94,7 +94,7 @@ class ProfessionalController extends Controller
 
 
         $profissional = Profissional::create(array_merge([
-            'organization_id' => auth()->user()->organization_id,
+            'organizacao_id' => auth()->user()->organizacao_id,
             'pessoa_id' => $pessoa->id,
             'usuario_id' => $usuario?->id,
         ], $this->extractProfessionalData($data)));
@@ -108,7 +108,7 @@ class ProfessionalController extends Controller
 
     public function edit(Profissional $profissional)
     {
-        $clinics = Clinic::where('organizacao_id', auth()->user()->organization_id)
+        $clinics = Clinic::where('organizacao_id', auth()->user()->organizacao_id)
             ->with('horarios')
             ->get();
 
@@ -221,7 +221,7 @@ class ProfessionalController extends Controller
 
         $validator = Validator::make($request->all(), $rules);
 
-        $clinics = Clinic::where('organizacao_id', auth()->user()->organization_id)
+        $clinics = Clinic::where('organizacao_id', auth()->user()->organizacao_id)
             ->with('horarios')
             ->get()
             ->keyBy('id');

--- a/app/Models/EscalaTrabalho.php
+++ b/app/Models/EscalaTrabalho.php
@@ -12,7 +12,7 @@ class EscalaTrabalho extends Model
     protected $table = 'escalas_trabalho';
 
     protected $fillable = [
-        'organization_id',
+        'organizacao_id',
         'clinic_id',
         'cadeira_id',
         'profissional_id',

--- a/app/Models/Horario.php
+++ b/app/Models/Horario.php
@@ -13,7 +13,7 @@ class Horario extends Model
 
     protected $fillable = [
         'clinic_id',
-        'organization_id',
+        'organizacao_id',
         'dia_semana',
         'hora_inicio',
         'hora_fim',
@@ -26,6 +26,6 @@ class Horario extends Model
 
     public function organization()
     {
-        return $this->belongsTo(Organization::class);
+        return $this->belongsTo(Organization::class, 'organizacao_id');
     }
 }

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -14,7 +14,7 @@ class Patient extends Model
     protected $table = 'pacientes';
 
     protected $fillable = [
-        'organization_id',
+        'organizacao_id',
         'usuario_id',
         'pessoa_id',
         'menor_idade',
@@ -30,7 +30,7 @@ class Patient extends Model
 
     public function organization()
     {
-        return $this->belongsTo(Organization::class);
+        return $this->belongsTo(Organization::class, 'organizacao_id');
     }
 
     public function usuario()

--- a/app/Models/Perfil.php
+++ b/app/Models/Perfil.php
@@ -13,7 +13,7 @@ class Perfil extends Model
     protected $table = 'perfis';
 
     protected $fillable = [
-        'organization_id',
+        'organizacao_id',
         'nome',
     ];
 
@@ -31,6 +31,6 @@ class Perfil extends Model
 
     public function organization()
     {
-        return $this->belongsTo(Organization::class);
+        return $this->belongsTo(Organization::class, 'organizacao_id');
     }
 }

--- a/app/Models/Pessoa.php
+++ b/app/Models/Pessoa.php
@@ -9,7 +9,7 @@ class Pessoa extends Model
     use BelongsToOrganization;
 
     protected $fillable = [
-        'organization_id',
+        'organizacao_id',
         'first_name',
         'middle_name',
         'last_name',

--- a/app/Models/Profissional.php
+++ b/app/Models/Profissional.php
@@ -17,7 +17,7 @@ class Profissional extends Model
     protected $table = 'profissionais';
 
     protected $fillable = [
-        'organization_id',
+        'organizacao_id',
         'pessoa_id',
         'usuario_id',
         'numero_funcionario',
@@ -53,7 +53,7 @@ class Profissional extends Model
 
     public function organization()
     {
-        return $this->belongsTo(Organization::class);
+        return $this->belongsTo(Organization::class, 'organizacao_id');
     }
 
     public function pessoa()

--- a/app/Models/ProfissionalHorario.php
+++ b/app/Models/ProfissionalHorario.php
@@ -10,7 +10,7 @@ class ProfissionalHorario extends Model
     use BelongsToOrganization, BelongsToClinic;
 
     protected $fillable = [
-        'organization_id',
+        'organizacao_id',
         'clinic_id',
         'profissional_id',
         'dia_semana',

--- a/app/Models/Usuario.php
+++ b/app/Models/Usuario.php
@@ -23,7 +23,7 @@ class Usuario extends Authenticatable
     protected $fillable = [
         'email',
         'password',
-        'organization_id',
+        'organizacao_id',
         'dentista',
         'cro',
         'cargo',
@@ -45,7 +45,7 @@ class Usuario extends Authenticatable
 
     public function organization()
     {
-        return $this->belongsTo(Organization::class);
+        return $this->belongsTo(Organization::class, 'organizacao_id');
     }
 
     public function clinics()

--- a/app/Traits/BelongsToOrganization.php
+++ b/app/Traits/BelongsToOrganization.php
@@ -9,7 +9,8 @@ trait BelongsToOrganization
 {
     protected static function bootBelongsToOrganization()
     {
-        if (! auth()->check() || is_null(auth()->user()->organization_id) || auth()->user()->isSuperAdmin()) {
+        $orgId = auth()->check() ? (auth()->user()->organizacao_id ?? auth()->user()->organization_id) : null;
+        if (is_null($orgId) || (auth()->check() && auth()->user()->isSuperAdmin())) {
             return;
         }
 
@@ -23,13 +24,13 @@ trait BelongsToOrganization
         }
 
         if ($column) {
-            static::addGlobalScope('organization', function (Builder $builder) use ($instance, $column) {
-                $builder->where($instance->getTable() . '.' . $column, auth()->user()->organization_id);
+            static::addGlobalScope('organization', function (Builder $builder) use ($instance, $column, $orgId) {
+                $builder->where($instance->getTable() . '.' . $column, $orgId);
             });
 
-            static::creating(function ($model) use ($column) {
+            static::creating(function ($model) use ($column, $orgId) {
                 if (is_null($model->$column)) {
-                    $model->$column = auth()->user()->organization_id;
+                    $model->$column = $orgId;
                 }
             });
         }

--- a/database/migrations/2024_01_01_000100_create_clinicas_table.php
+++ b/database/migrations/2024_01_01_000100_create_clinicas_table.php
@@ -41,7 +41,7 @@ return new class extends Migration {
 
         Schema::create('horarios', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizacoes');
+            $table->foreignId('organizacao_id')->constrained('organizacoes');
             $table->foreignId('clinic_id')->constrained('clinicas');
             $table->unsignedTinyInteger('dia_semana');
             $table->time('hora_inicio');

--- a/database/migrations/2024_01_01_000200_create_perfis_permissions_table.php
+++ b/database/migrations/2024_01_01_000200_create_perfis_permissions_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('perfis', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizacoes');
+            $table->foreignId('organizacao_id')->constrained('organizacoes');
             $table->string('nome');
             $table->timestamps();
         });

--- a/database/migrations/2024_01_01_000300_create_pessoas_table.php
+++ b/database/migrations/2024_01_01_000300_create_pessoas_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('pessoas', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizacoes');
+            $table->foreignId('organizacao_id')->constrained('organizacoes');
             $table->string('first_name');
             $table->string('middle_name')->nullable();
             $table->string('last_name');

--- a/database/migrations/2024_01_01_000400_create_usuarios_table.php
+++ b/database/migrations/2024_01_01_000400_create_usuarios_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('usuarios', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizacoes');
+            $table->foreignId('organizacao_id')->constrained('organizacoes');
             $table->foreignId('pessoa_id')->nullable()->constrained('pessoas');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/database/migrations/2024_01_01_000500_create_pacientes_table.php
+++ b/database/migrations/2024_01_01_000500_create_pacientes_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('pacientes', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizacoes');
+            $table->foreignId('organizacao_id')->constrained('organizacoes');
             $table->foreignId('usuario_id')->nullable()->constrained('usuarios');
             $table->foreignId('pessoa_id')->constrained('pessoas');
             $table->boolean('menor_idade')->default(false);

--- a/database/migrations/2024_01_01_000600_create_profissionais_table.php
+++ b/database/migrations/2024_01_01_000600_create_profissionais_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('profissionais', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizacoes');
+            $table->foreignId('organizacao_id')->constrained('organizacoes');
             $table->foreignId('pessoa_id')->constrained('pessoas');
             $table->foreignId('usuario_id')->nullable()->constrained('usuarios');
             $table->string('numero_funcionario')->nullable();
@@ -35,7 +35,7 @@ return new class extends Migration {
 
         Schema::create('profissional_horarios', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizacoes');
+            $table->foreignId('organizacao_id')->constrained('organizacoes');
             $table->foreignId('clinic_id')->constrained('clinicas');
             $table->foreignId('profissional_id')->constrained('profissionais');
             $table->unsignedTinyInteger('dia_semana');

--- a/database/migrations/2024_01_01_000800_create_escalas_trabalho_table.php
+++ b/database/migrations/2024_01_01_000800_create_escalas_trabalho_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('escalas_trabalho', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('organization_id')->constrained('organizacoes');
+            $table->foreignId('organizacao_id')->constrained('organizacoes');
             $table->foreignId('clinic_id')->constrained('clinicas');
             $table->foreignId('cadeira_id')->constrained('cadeiras');
             $table->foreignId('profissional_id')->constrained('profissionais');

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -25,7 +25,7 @@ class AdminUserSeeder extends Seeder
         $pessoa = Pessoa::firstOrCreate(
             [
                 'email' => 'admin@example.com',
-                'organization_id' => $organization->id,
+                'organizacao_id' => $organization->id,
             ],
             [
                 'first_name' => 'Admin',
@@ -37,14 +37,14 @@ class AdminUserSeeder extends Seeder
             ['email' => 'admin@example.com'],
             [
                 'password' => Hash::make('password'),
-                'organization_id' => $organization->id,
+                'organizacao_id' => $organization->id,
                 'pessoa_id' => $pessoa->id,
             ]
         );
 
         $perfil = Perfil::firstOrCreate([
             'nome' => 'Super Administrador',
-            'organization_id' => null,
+            'organizacao_id' => null,
         ]);
 
         $modules = [

--- a/database/seeders/PatientProfileSeeder.php
+++ b/database/seeders/PatientProfileSeeder.php
@@ -12,7 +12,7 @@ class PatientProfileSeeder extends Seeder
     {
         $perfil = Perfil::firstOrCreate([
             'nome' => 'Paciente',
-            'organization_id' => null,
+            'organizacao_id' => null,
         ]);
 
         $modules = [


### PR DESCRIPTION
## Summary
- rename `organization_id` columns to `organizacao_id`
- update models, controllers and seeders for new foreign key
- adjust `BelongsToOrganization` trait to read `organizacao_id`

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `php -l app/Http/Controllers/Admin/ClinicController.php app/Http/Controllers/Admin/OrganizationController.php app/Http/Controllers/Admin/PatientController.php`


------
https://chatgpt.com/codex/tasks/task_e_68907fe20840832aa697ab4f4bcdb24f