### PR TITLE
Rename clinic_id foreign keys to clinica_id

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -77,7 +77,7 @@ class AgendaController extends Controller
         // active. This prevents pulling schedules from other organizations
         // while still allowing queries for the selected clinic.
         $intervalos = \App\Models\Horario::withoutGlobalScope('clinic')
-            ->where('clinic_id', $clinicId)
+            ->where('clinica_id', $clinicId)
             ->where('dia_semana', $dia)
             ->orderBy('hora_inicio')
             ->get();

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -89,7 +89,7 @@ class ClinicController extends Controller
         foreach ($horarios as $dia => $horario) {
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
-                    'clinic_id' => $clinic->id,
+                    'clinica_id' => $clinic->id,
                     'organizacao_id' => $clinic->organizacao_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],
@@ -185,7 +185,7 @@ class ClinicController extends Controller
         foreach ($horarios as $dia => $horario) {
             if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
-                    'clinic_id' => $clinic->id,
+                    'clinica_id' => $clinic->id,
                     'organizacao_id' => $clinic->organizacao_id,
                     'dia_semana' => $dia,
                     'hora_inicio' => $horario['abertura'],

--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -50,7 +50,7 @@ class EscalaTrabalhoController extends Controller
             }
 
             $escalas = EscalaTrabalho::with(['profissional.person','profissional.user'])
-                ->where('clinic_id', $clinicId)
+                ->where('clinica_id', $clinicId)
                 ->whereBetween('semana', [$weeks->first()->toDateString(), $weeks->last()->toDateString()])
                 ->get()
                 ->groupBy([fn($e) => $e->semana->toDateString(), 'cadeira_id', 'dia_semana']);
@@ -62,7 +62,7 @@ class EscalaTrabalhoController extends Controller
         $week = $week ? Carbon::parse($week)->startOfWeek(Carbon::MONDAY) : Carbon::now()->startOfWeek(Carbon::MONDAY);
         $semanasDisponiveis = collect(range(-2, 5))->map(fn($i) => Carbon::now()->startOfWeek(Carbon::MONDAY)->addWeeks($i));
         $escalas = EscalaTrabalho::with(['profissional.person','profissional.user'])
-            ->where('clinic_id', $clinicId)
+            ->where('clinica_id', $clinicId)
             ->whereBetween('semana', [
                 $week->toDateString(),
                 $week->copy()->addDays(6)->toDateString(),
@@ -82,7 +82,7 @@ class EscalaTrabalhoController extends Controller
                 'profissional_id' => [
                     'required',
                     'exists:profissionais,id',
-                    Rule::exists('clinica_profissional', 'profissional_id')->where(fn($q) => $q->where('clinic_id', $request->input('clinic_id'))),
+                    Rule::exists('clinica_profissional', 'profissional_id')->where(fn($q) => $q->where('clinica_id', $request->input('clinic_id'))),
                 ],
                 'datas' => 'required|array',
                 'datas.*' => 'date',
@@ -96,7 +96,7 @@ class EscalaTrabalhoController extends Controller
                 'profissional_id' => [
                     'required',
                     'exists:profissionais,id',
-                    Rule::exists('clinica_profissional', 'profissional_id')->where(fn($q) => $q->where('clinic_id', $request->input('clinic_id'))),
+                    Rule::exists('clinica_profissional', 'profissional_id')->where(fn($q) => $q->where('clinica_id', $request->input('clinic_id'))),
                 ],
                 'semana' => 'required|date',
                 'dias' => 'required|array',
@@ -134,7 +134,7 @@ class EscalaTrabalhoController extends Controller
                 }
 
                 EscalaTrabalho::create([
-                    'clinic_id' => $data['clinic_id'],
+                    'clinica_id' => $data['clinic_id'],
                     'cadeira_id' => $data['cadeira_id'],
                     'profissional_id' => $data['profissional_id'],
                     'semana' => $weekStart,
@@ -166,7 +166,7 @@ class EscalaTrabalhoController extends Controller
                 }
 
                 EscalaTrabalho::create([
-                    'clinic_id' => $data['clinic_id'],
+                    'clinica_id' => $data['clinic_id'],
                     'cadeira_id' => $data['cadeira_id'],
                     'profissional_id' => $data['profissional_id'],
                     'semana' => $data['semana'],

--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -51,7 +51,7 @@ class ProfessionalController extends Controller
             ->get();
 
         $horarios = $profissional->horariosTrabalho
-            ->groupBy('clinic_id')
+            ->groupBy('clinica_id')
             ->map(function ($items) {
                 return $items->mapWithKeys(fn($h) => [
                     $h->dia_semana => [
@@ -113,7 +113,7 @@ class ProfessionalController extends Controller
             ->get();
 
         $horarios = $profissional->horariosTrabalho
-            ->groupBy('clinic_id')
+            ->groupBy('clinica_id')
             ->map(function ($items) {
                 return $items->mapWithKeys(fn($h) => [
                     $h->dia_semana => [
@@ -312,7 +312,7 @@ class ProfessionalController extends Controller
             foreach ($dias as $dia => $horario) {
                 if (($horario['inicio'] ?? false) && ($horario['fim'] ?? false)) {
                     $profissional->horariosTrabalho()->create([
-                        'clinic_id' => $clinicId,
+                        'clinica_id' => $clinicId,
                         'dia_semana' => $dia,
                         'hora_inicio' => $horario['inicio'],
                         'hora_fim' => $horario['fim'],

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -38,7 +38,7 @@ class Clinic extends Model
 
     public function horarios()
     {
-        return $this->hasMany(Horario::class);
+        return $this->hasMany(Horario::class, 'clinica_id');
     }
 
     public function cadeiras()
@@ -62,6 +62,6 @@ class Clinic extends Model
 
     public function profissionais()
     {
-        return $this->belongsToMany(Profissional::class, 'clinica_profissional')->withTimestamps();
+        return $this->belongsToMany(Profissional::class, 'clinica_profissional', 'clinica_id', 'profissional_id')->withTimestamps();
     }
 }

--- a/app/Models/EscalaTrabalho.php
+++ b/app/Models/EscalaTrabalho.php
@@ -13,7 +13,7 @@ class EscalaTrabalho extends Model
 
     protected $fillable = [
         'organizacao_id',
-        'clinic_id',
+        'clinica_id',
         'cadeira_id',
         'profissional_id',
         'semana',
@@ -38,6 +38,6 @@ class EscalaTrabalho extends Model
 
     public function clinic()
     {
-        return $this->belongsTo(Clinic::class);
+        return $this->belongsTo(Clinic::class, 'clinica_id');
     }
 }

--- a/app/Models/Horario.php
+++ b/app/Models/Horario.php
@@ -12,7 +12,7 @@ class Horario extends Model
     use BelongsToOrganization, BelongsToClinic;
 
     protected $fillable = [
-        'clinic_id',
+        'clinica_id',
         'organizacao_id',
         'dia_semana',
         'hora_inicio',
@@ -21,7 +21,7 @@ class Horario extends Model
 
     public function clinic()
     {
-        return $this->belongsTo(Clinic::class);
+        return $this->belongsTo(Clinic::class, 'clinica_id');
     }
 
     public function organization()

--- a/app/Models/Profissional.php
+++ b/app/Models/Profissional.php
@@ -73,6 +73,6 @@ class Profissional extends Model
 
     public function clinics()
     {
-        return $this->belongsToMany(Clinic::class, 'clinica_profissional')->withTimestamps();
+        return $this->belongsToMany(Clinic::class, 'clinica_profissional', 'profissional_id', 'clinica_id')->withTimestamps();
     }
 }

--- a/app/Models/ProfissionalHorario.php
+++ b/app/Models/ProfissionalHorario.php
@@ -11,7 +11,7 @@ class ProfissionalHorario extends Model
 
     protected $fillable = [
         'organizacao_id',
-        'clinic_id',
+        'clinica_id',
         'profissional_id',
         'dia_semana',
         'hora_inicio',
@@ -25,6 +25,6 @@ class ProfissionalHorario extends Model
 
     public function clinic()
     {
-        return $this->belongsTo(Clinic::class);
+        return $this->belongsTo(Clinic::class, 'clinica_id');
     }
 }

--- a/database/migrations/2024_01_01_000100_create_clinicas_table.php
+++ b/database/migrations/2024_01_01_000100_create_clinicas_table.php
@@ -42,7 +42,7 @@ return new class extends Migration {
         Schema::create('horarios', function (Blueprint $table) {
             $table->id();
             $table->foreignId('organizacao_id')->constrained('organizacoes');
-            $table->foreignId('clinic_id')->constrained('clinicas');
+            $table->foreignId('clinica_id')->constrained('clinicas');
             $table->unsignedTinyInteger('dia_semana');
             $table->time('hora_inicio');
             $table->time('hora_fim');

--- a/database/migrations/2024_01_01_000600_create_profissionais_table.php
+++ b/database/migrations/2024_01_01_000600_create_profissionais_table.php
@@ -36,7 +36,7 @@ return new class extends Migration {
         Schema::create('profissional_horarios', function (Blueprint $table) {
             $table->id();
             $table->foreignId('organizacao_id')->constrained('organizacoes');
-            $table->foreignId('clinic_id')->constrained('clinicas');
+            $table->foreignId('clinica_id')->constrained('clinicas');
             $table->foreignId('profissional_id')->constrained('profissionais');
             $table->unsignedTinyInteger('dia_semana');
             $table->time('hora_inicio');
@@ -46,7 +46,7 @@ return new class extends Migration {
 
         Schema::create('clinica_profissional', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('clinic_id')->constrained('clinicas');
+            $table->foreignId('clinica_id')->constrained('clinicas');
             $table->foreignId('profissional_id')->constrained('profissionais');
             $table->timestamps();
         });

--- a/database/migrations/2024_01_01_000800_create_escalas_trabalho_table.php
+++ b/database/migrations/2024_01_01_000800_create_escalas_trabalho_table.php
@@ -10,7 +10,7 @@ return new class extends Migration {
         Schema::create('escalas_trabalho', function (Blueprint $table) {
             $table->id();
             $table->foreignId('organizacao_id')->constrained('organizacoes');
-            $table->foreignId('clinic_id')->constrained('clinicas');
+            $table->foreignId('clinica_id')->constrained('clinicas');
             $table->foreignId('cadeira_id')->constrained('cadeiras');
             $table->foreignId('profissional_id')->constrained('profissionais');
             $table->date('semana');

--- a/database/migrations/2024_01_01_000901_rename_clinic_id_to_clinica_id.php
+++ b/database/migrations/2024_01_01_000901_rename_clinic_id_to_clinica_id.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $tables = [
+            'horarios',
+            'clinica_profissional',
+            'escalas_trabalho',
+            'profissional_horarios',
+        ];
+
+        foreach ($tables as $tableName) {
+            if (Schema::hasColumn($tableName, 'clinic_id')) {
+                Schema::table($tableName, function (Blueprint $table) {
+                    $table->renameColumn('clinic_id', 'clinica_id');
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        $tables = [
+            'horarios',
+            'clinica_profissional',
+            'escalas_trabalho',
+            'profissional_horarios',
+        ];
+
+        foreach ($tables as $tableName) {
+            if (Schema::hasColumn($tableName, 'clinica_id')) {
+                Schema::table($tableName, function (Blueprint $table) {
+                    $table->renameColumn('clinica_id', 'clinic_id');
+                });
+            }
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- rename `clinic_id` columns to `clinica_id` in horarios, profissional_horarios, clinica_profissional, and escalas_trabalho tables
- update models and relationships to reference `clinica_id`
- adjust controllers for scheduling logic to query and create records using the new column name

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689083343388832a8424da72b5d97668