### PR TITLE
Renomeia permissions para permissoes

### DIFF
--- a/app/Http/Controllers/Admin/OrganizationController.php
+++ b/app/Http/Controllers/Admin/OrganizationController.php
@@ -89,7 +89,7 @@ class OrganizationController extends Controller
         ];
 
         foreach ($modules as $module) {
-            $perfil->permissions()->create([
+            $perfil->permissoes()->create([
                 'modulo' => $module,
                 'leitura' => true,
                 'escrita' => true,

--- a/app/Http/Controllers/Admin/PerfilController.php
+++ b/app/Http/Controllers/Admin/PerfilController.php
@@ -24,7 +24,7 @@ class PerfilController extends Controller
     {
         $data = $request->validate([
             'nome' => 'required',
-            'permissions' => 'array',
+            'permissoes' => 'array',
         ]);
 
         $perfil = Perfil::create([
@@ -32,7 +32,7 @@ class PerfilController extends Controller
             'organizacao_id' => auth()->user()->organizacao_id,
         ]);
 
-        $this->syncPermissions($perfil, $data['permissions'] ?? []);
+        $this->syncPermissoes($perfil, $data['permissoes'] ?? []);
 
         return redirect()->route('perfis.index')->with('success', 'Perfil salvo com sucesso.');
     }
@@ -40,21 +40,21 @@ class PerfilController extends Controller
     public function edit(Perfil $perfil)
     {
         $modules = $this->modules();
-        $permissions = $perfil->permissions->keyBy('modulo');
-        return view('admin.perfis.edit', compact('perfil', 'modules', 'permissions'));
+        $permissoes = $perfil->permissoes->keyBy('modulo');
+        return view('admin.perfis.edit', compact('perfil', 'modules', 'permissoes'));
     }
 
     public function update(Request $request, Perfil $perfil)
     {
         $data = $request->validate([
             'nome' => 'required',
-            'permissions' => 'array',
+            'permissoes' => 'array',
         ]);
 
         $perfil->update(['nome' => $data['nome']]);
 
-        $perfil->permissions()->delete();
-        $this->syncPermissions($perfil, $data['permissions'] ?? []);
+        $perfil->permissoes()->delete();
+        $this->syncPermissoes($perfil, $data['permissoes'] ?? []);
 
         return redirect()->route('perfis.index')->with('success', 'Perfil atualizado com sucesso.');
     }
@@ -80,10 +80,10 @@ class PerfilController extends Controller
         ];
     }
 
-    private function syncPermissions(Perfil $perfil, array $permissions): void
+    private function syncPermissoes(Perfil $perfil, array $permissoes): void
     {
-        foreach ($permissions as $module => $values) {
-            $perfil->permissions()->create([
+        foreach ($permissoes as $module => $values) {
+            $perfil->permissoes()->create([
                 'modulo' => $module,
                 'leitura' => isset($values['leitura']),
                 'escrita' => isset($values['escrita']),

--- a/app/Models/Perfil.php
+++ b/app/Models/Perfil.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use App\Traits\BelongsToOrganization;
 use App\Models\Organization;
+use App\Models\Permissao;
 
 class Perfil extends Model
 {
@@ -17,9 +18,9 @@ class Perfil extends Model
         'nome',
     ];
 
-    public function permissions()
+    public function permissoes()
     {
-        return $this->hasMany(Permission::class);
+        return $this->hasMany(Permissao::class);
     }
 
     public function usuarios()

--- a/app/Models/Permissao.php
+++ b/app/Models/Permissao.php
@@ -5,8 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Perfil;
 
-class Permission extends Model
+class Permissao extends Model
 {
+    protected $table = 'permissoes';
     protected $fillable = [
         'perfil_id',
         'modulo',

--- a/app/Models/Usuario.php
+++ b/app/Models/Usuario.php
@@ -10,7 +10,7 @@ use App\Traits\BelongsToOrganization;
 use App\Models\Perfil;
 use App\Models\Organization;
 use App\Models\ClinicaUsuario;
-use App\Models\Permission;
+use App\Models\Permissao;
 use App\Models\Patient;
 use App\Models\Pessoa;
 
@@ -109,7 +109,7 @@ class Usuario extends Authenticatable
             return false;
         }
 
-        return Permission::whereIn('perfil_id', $perfilIds)
+        return Permissao::whereIn('perfil_id', $perfilIds)
             ->where('modulo', $module)
             ->where(function ($q) {
                 $q->where('leitura', true)

--- a/database/migrations/2024_05_20_000001_rename_permissions_to_permissoes.php
+++ b/database/migrations/2024_05_20_000001_rename_permissions_to_permissoes.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::rename('permissions', 'permissoes');
+    }
+
+    public function down(): void
+    {
+        Schema::rename('permissoes', 'permissions');
+    }
+};

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 use App\Models\Usuario;
 use App\Models\Perfil;
-use App\Models\Permission;
+use App\Models\Permissao;
 use App\Models\Pessoa;
 use App\Models\Organization;
 
@@ -52,7 +52,7 @@ class AdminUserSeeder extends Seeder
         ];
 
         foreach ($modules as $module) {
-            Permission::updateOrCreate(
+            Permissao::updateOrCreate(
                 [
                     'perfil_id' => $perfil->id,
                     'modulo' => $module,

--- a/database/seeders/PatientProfileSeeder.php
+++ b/database/seeders/PatientProfileSeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Perfil;
-use App\Models\Permission;
+use App\Models\Permissao;
 
 class PatientProfileSeeder extends Seeder
 {
@@ -20,7 +20,7 @@ class PatientProfileSeeder extends Seeder
         ];
 
         foreach ($modules as $module) {
-            Permission::updateOrCreate(
+            Permissao::updateOrCreate(
                 [
                     'perfil_id' => $perfil->id,
                     'modulo' => $module,

--- a/resources/views/admin/perfis/create.blade.php
+++ b/resources/views/admin/perfis/create.blade.php
@@ -29,10 +29,10 @@
                     @foreach($modules as $module)
                     <tr>
                         <td class="px-4 py-2">{{ $module }}</td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][leitura]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][escrita]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][atualizacao]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][exclusao]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissoes[{{ $module }}][leitura]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissoes[{{ $module }}][escrita]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissoes[{{ $module }}][atualizacao]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissoes[{{ $module }}][exclusao]" class="rounded border-gray-300 text-primary focus:ring-primary"></td>
                     </tr>
                     @endforeach
                 </tbody>

--- a/resources/views/admin/perfis/edit.blade.php
+++ b/resources/views/admin/perfis/edit.blade.php
@@ -30,10 +30,10 @@
                     @foreach($modules as $module)
                     <tr>
                         <td class="px-4 py-2">{{ $module }}</td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][leitura]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions->get($module))->leitura)></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][escrita]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions->get($module))->escrita)></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][atualizacao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions->get($module))->atualizacao)></td>
-                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissions[{{ $module }}][exclusao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissions->get($module))->exclusao)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissoes[{{ $module }}][leitura]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissoes->get($module))->leitura)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissoes[{{ $module }}][escrita]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissoes->get($module))->escrita)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissoes[{{ $module }}][atualizacao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissoes->get($module))->atualizacao)></td>
+                        <td class="px-4 py-2 text-center"><input type="checkbox" name="permissoes[{{ $module }}][exclusao]" class="rounded border-gray-300 text-primary focus:ring-primary" @checked(optional($permissoes->get($module))->exclusao)></td>
                     </tr>
                     @endforeach
                 </tbody>


### PR DESCRIPTION
## Summary
- adiciona migração para renomear tabela `permissions` para `permissoes`
- cria modelo `Permissao` e ajusta relação de `Perfil` e usos em controllers e seeds
- atualiza views e validações para usar campo `permissoes`

## Testing
- `composer install` *(falhou: curl error 56 while downloading packages.json: CONNECT tunnel failed)*
- `php artisan test` *(falhou: Failed opening required '/workspace/dentix/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68908b4d6df4832ab796f9336ecc5ef2