### PR TITLE
Make clinica association optional

### DIFF
--- a/database/migrations/2024_01_01_000400_create_usuarios_table.php
+++ b/database/migrations/2024_01_01_000400_create_usuarios_table.php
@@ -26,7 +26,7 @@ return new class extends Migration {
 
         Schema::create('clinica_usuario', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('clinica_id')->constrained('clinicas');
+            $table->foreignId('clinica_id')->nullable()->constrained('clinicas');
             $table->foreignId('usuario_id')->constrained('usuarios');
             $table->foreignId('perfil_id')->nullable()->constrained('perfis');
             $table->timestamps();

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -9,6 +9,7 @@ use App\Models\Perfil;
 use App\Models\Permissao;
 use App\Models\Pessoa;
 use App\Models\Organization;
+use App\Models\Clinic;
 
 class AdminUserSeeder extends Seeder
 {
@@ -18,6 +19,16 @@ class AdminUserSeeder extends Seeder
             ['cnpj' => '00000000000000'],
             [
                 'nome_fantasia' => 'Default Organization',
+                'timezone' => config('app.timezone'),
+            ]
+        );
+
+        $clinic = Clinic::firstOrCreate(
+            [
+                'organizacao_id' => $organization->id,
+                'nome' => 'Default Clinic',
+            ],
+            [
                 'timezone' => config('app.timezone'),
             ]
         );
@@ -69,6 +80,6 @@ class AdminUserSeeder extends Seeder
         }
 
         // Ensure the admin user only has the Super Administrador perfil
-        $usuario->perfis()->sync([$perfil->id => ['clinica_id' => null]]);
+        $usuario->perfis()->sync([$perfil->id => ['clinica_id' => $clinic->id]]);
     }
 }


### PR DESCRIPTION
## Summary
- create default clinic in AdminUserSeeder and attach admin profile to it
- allow clinica_usuario.clinica_id to be nullable

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan migrate:fresh --seed --database=sqlite` *(fails: Failed opening required 'vendor/autoload.php')*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68909d0a794c832a998157a1beb66f2b