### PR TITLE
Seed patient profile with default organization

### DIFF
--- a/database/seeders/PatientProfileSeeder.php
+++ b/database/seeders/PatientProfileSeeder.php
@@ -5,14 +5,23 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use App\Models\Perfil;
 use App\Models\Permissao;
+use App\Models\Organization;
 
 class PatientProfileSeeder extends Seeder
 {
     public function run(): void
     {
+        $organization = Organization::firstOrCreate(
+            ['cnpj' => '00000000000000'],
+            [
+                'nome_fantasia' => 'Default Organization',
+                'timezone' => config('app.timezone'),
+            ]
+        );
+
         $perfil = Perfil::firstOrCreate([
             'nome' => 'Paciente',
-            'organizacao_id' => null,
+            'organizacao_id' => $organization->id,
         ]);
 
         $modules = [


### PR DESCRIPTION
## Summary
- ensure Patient profile seeder attaches a default organization, avoiding foreign key constraint violations

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan --version` *(fails: vendor/autoload.php missing)*
- `sqlite3 database/temp.sqlite "select id, nome, organizacao_id from perfis;"`


------
https://chatgpt.com/codex/tasks/task_e_68909d0cbf38832aafaa155302446816