### PR TITLE
Add Laravel .htaccess rewrite rules

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,10 @@
+<IfModule mod_rewrite.c>
+    <IfModule mod_negotiation.c>
+        Options -MultiViews -Indexes
+    </IfModule>
+
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} -f
+    RewriteRule ^ - [L]
+    RewriteRule ^ index.php [L]
+</IfModule>


### PR DESCRIPTION
## Summary
- add default Laravel .htaccess to redirect requests to index.php

## Testing
- `composer install` *(fails: curl error 56, CONNECT tunnel failed)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891158fd9c8832aa4843703ff277e06