### PR TITLE
Allow super admins to bypass organization status

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -24,7 +24,11 @@ class AuthenticatedSessionController extends Controller
         if (Auth::attempt($credentials)) {
             $request->session()->regenerate();
             $user = Auth::user();
-            if ($user->organization && $user->organization->status !== 'ativo') {
+            if (
+                $user->organization &&
+                $user->organization->status !== 'ativo' &&
+                ! $user->isSuperAdmin()
+            ) {
                 Auth::logout();
                 return back()->withErrors([
                     'email' => __('Organização desativada.')


### PR DESCRIPTION
## Summary
- Skip organization status check during login for super admins

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed to open required '/workspace/dentix/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68911723f994832a8ecfb320ae442f4e