### PR TITLE
Show full admin user name on backend list

### DIFF
--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -13,7 +13,7 @@ class AdminUserController extends Controller
     {
         $admins = Usuario::whereHas('perfis', function ($q) {
             $q->whereIn('nome', ['Administrador', 'Super Administrador']);
-        })->with('organization')->get();
+        })->with(['organization', 'pessoa'])->get();
 
         return view('backend.usuarios-admin.index', compact('admins'));
     }

--- a/resources/views/backend/usuarios-admin/index.blade.php
+++ b/resources/views/backend/usuarios-admin/index.blade.php
@@ -21,7 +21,7 @@
         <tbody class="divide-y divide-gray-200">
             @forelse ($admins as $admin)
                 <tr>
-                    <td class="px-4 py-2 whitespace-nowrap">{{ $admin->name }}</td>
+                    <td class="px-4 py-2 whitespace-nowrap">{{ $admin->pessoa?->full_name ?? $admin->name }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $admin->email }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">{{ $admin->organization->nome_fantasia ?? 'N/A' }}</td>
                     <td class="px-4 py-2 whitespace-nowrap">


### PR DESCRIPTION
## Summary
- fetch related person when listing admin users
- display admin's full name in backend list using person data

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68911aacfce4832a90d85aff900aca5f