### PR TITLE
Allow nullable clinic ID in pivot migration

### DIFF
--- a/database/migrations/2024_01_01_000401_rename_clinic_user_to_clinica_usuario.php
+++ b/database/migrations/2024_01_01_000401_rename_clinic_user_to_clinica_usuario.php
@@ -15,6 +15,12 @@ return new class extends Migration {
             Schema::table('clinica_usuario', function (Blueprint $table) {
                 $table->renameColumn('clinic_id', 'clinica_id');
             });
+
+            Schema::table('clinica_usuario', function (Blueprint $table) {
+                $table->dropForeign(['clinica_id']);
+                $table->unsignedBigInteger('clinica_id')->nullable()->change();
+                $table->foreign('clinica_id')->references('id')->on('clinicas')->onDelete('cascade');
+            });
         }
     }
 
@@ -22,7 +28,10 @@ return new class extends Migration {
     {
         if (Schema::hasColumn('clinica_usuario', 'clinica_id')) {
             Schema::table('clinica_usuario', function (Blueprint $table) {
+                $table->dropForeign(['clinica_id']);
+                $table->unsignedBigInteger('clinica_id')->nullable(false)->change();
                 $table->renameColumn('clinica_id', 'clinic_id');
+                $table->foreign('clinic_id')->references('id')->on('clinicas')->onDelete('cascade');
             });
         }
 


### PR DESCRIPTION
## Summary
- ensure clinica_usuario pivot accepts null clinica_id by dropping and recreating FK as nullable

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68911ca83470832abb36fefd6b5e95cd