### PR TITLE
Fix clinic schedule weekday storage to use numeric values

### DIFF
--- a/app/Enums/DiaSemana.php
+++ b/app/Enums/DiaSemana.php
@@ -1,0 +1,32 @@
+<?php
+namespace App\Enums;
+
+enum DiaSemana: int
+{
+    case Segunda = 1;
+    case Terca = 2;
+    case Quarta = 3;
+    case Quinta = 4;
+    case Sexta = 5;
+    case Sabado = 6;
+    case Domingo = 7;
+
+    public static function fromName(string $name): ?self
+    {
+        return match(strtolower($name)) {
+            'segunda' => self::Segunda,
+            'terca' => self::Terca,
+            'quarta' => self::Quarta,
+            'quinta' => self::Quinta,
+            'sexta' => self::Sexta,
+            'sabado' => self::Sabado,
+            'domingo' => self::Domingo,
+            default => null,
+        };
+    }
+
+    public function toName(): string
+    {
+        return strtolower($this->name);
+    }
+}

--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -58,20 +58,7 @@ class AgendaController extends Controller
 
         $date->setTimezone($clinic->timezone ?? config('app.timezone'));
 
-        $diasIso = [
-            1 => 'segunda',
-            2 => 'terca',
-            3 => 'quarta',
-            4 => 'quinta',
-            5 => 'sexta',
-            6 => 'sabado',
-            7 => 'domingo',
-        ];
-        $dia = $diasIso[$date->dayOfWeekIso] ?? null;
-
-        if ($dia === null) {
-            return response()->json(['closed' => true]);
-        }
+        $dia = $date->dayOfWeekIso;
 
         // Remove only the clinic scope so the organization scope remains
         // active. This prevents pulling schedules from other organizations

--- a/app/Http/Controllers/Admin/ClinicController.php
+++ b/app/Http/Controllers/Admin/ClinicController.php
@@ -7,6 +7,7 @@ use App\Models\Clinic;
 use App\Rules\Cnpj;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
+use App\Enums\DiaSemana;
 
 class ClinicController extends Controller
 {
@@ -87,11 +88,12 @@ class ClinicController extends Controller
         $clinic = Clinic::create($data);
 
         foreach ($horarios as $dia => $horario) {
-            if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
+            $diaNumero = DiaSemana::fromName($dia)?->value;
+            if ($diaNumero && ($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinica_id' => $clinic->id,
                     'organizacao_id' => $clinic->organizacao_id,
-                    'dia_semana' => $dia,
+                    'dia_semana' => $diaNumero,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],
                 ]);
@@ -119,8 +121,9 @@ class ClinicController extends Controller
 
         $horarios = $clinic->horarios
             ->mapWithKeys(function ($h) {
+                $diaNome = DiaSemana::from($h->dia_semana)->toName();
                 return [
-                    $h->dia_semana => [
+                    $diaNome => [
                         'abertura' => Carbon::createFromTimeString($h->hora_inicio)->format('H:i'),
                         'fechamento' => Carbon::createFromTimeString($h->hora_fim)->format('H:i'),
                     ],
@@ -183,11 +186,12 @@ class ClinicController extends Controller
         $clinic->horarios()->delete();
 
         foreach ($horarios as $dia => $horario) {
-            if (($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
+            $diaNumero = DiaSemana::fromName($dia)?->value;
+            if ($diaNumero && ($horario['abertura'] ?? false) && ($horario['fechamento'] ?? false)) {
                 $clinic->horarios()->create([
                     'clinica_id' => $clinic->id,
                     'organizacao_id' => $clinic->organizacao_id,
-                    'dia_semana' => $dia,
+                    'dia_semana' => $diaNumero,
                     'hora_inicio' => $horario['abertura'],
                     'hora_fim' => $horario['fechamento'],
                 ]);

--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -61,7 +61,7 @@
                         @php $weekStart = $w; @endphp
                         @foreach($dias as $d)
                             <th class="px-2 py-1 text-center font-semibold bg-white capitalize border border-gray-200" style="width:14.28%">
-                                {{ ucfirst($d) }}<br>
+                                {{ ucfirst($d->toName()) }}<br>
                                 <span class="text-xs text-gray-500">{{ $weekStart->copy()->addDays($loop->index)->format('d/m') }}</span>
                             </th>
                         @endforeach
@@ -72,7 +72,7 @@
                         <tr>
                             <td class="w-32 px-2 py-1 font-semibold bg-gray-50 border border-gray-200">{{ $cadeira->nome }}</td>
                             @foreach($dias as $d)
-                                @php $items = $escalas[$w->toDateString()][$cadeira->id][$d] ?? collect(); @endphp
+                                @php $items = $escalas[$w->toDateString()][$cadeira->id][$d->value] ?? collect(); @endphp
                                 <td class="px-2 py-2 border border-gray-200 align-top" style="width:14.28%">
                                     @forelse($items as $it)
                                         <div class="mb-2 p-2 rounded bg-emerald-50 text-sm">
@@ -101,7 +101,7 @@
                     @php $weekStart = $week; @endphp
                     @foreach($dias as $d)
                         <th class="px-2 py-1 text-center font-semibold bg-white capitalize border border-gray-200" style="width:14.28%">
-                            {{ ucfirst($d) }}<br>
+                            {{ ucfirst($d->toName()) }}<br>
                             <span class="text-xs text-gray-500">{{ $weekStart->copy()->addDays($loop->index)->format('d/m') }}</span>
                         </th>
                     @endforeach
@@ -112,7 +112,7 @@
                     <tr>
                         <td class="w-32 px-2 py-1 font-semibold bg-gray-50 border border-gray-200">{{ $cadeira->nome }}</td>
                         @foreach($dias as $d)
-                            @php $items = $escalas[$cadeira->id][$d] ?? collect(); @endphp
+                            @php $items = $escalas[$cadeira->id][$d->value] ?? collect(); @endphp
                             <td class="px-2 py-2 border border-gray-200 align-top" style="width:14.28%">
                                 @forelse($items as $it)
                                     <div class="mb-2 p-2 rounded bg-emerald-50 text-sm">


### PR DESCRIPTION
## Summary
- add `DiaSemana` enum to map weekday names to integer values
- convert clinic schedules to store weekday numbers and render names on edit
- align agenda and work-schedule controllers/views with numeric weekdays

## Testing
- `composer install` *(fails: curl error 56 while downloading packages.json)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689210fe3b64832ab661d2a15a420a94