### PR TITLE
Localize date pickers to Portuguese

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -155,6 +155,14 @@ window.updateScheduleTable = function(openTimes, start, end, closed) {
 Alpine.start();
 
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.flatpickr) {
+        flatpickr('.datepicker', {
+            altInput: true,
+            altFormat: 'd/m/Y',
+            dateFormat: 'Y-m-d',
+            locale: 'pt'
+        });
+    }
     const cnpjInput = document.querySelector('input[name="cnpj"]');
     if (cnpjInput) {
         cnpjInput.addEventListener('input', e => {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ config('app.name') }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     <script>
         document.addEventListener('alpine:init', () => {

--- a/resources/views/pacientes/create.blade.php
+++ b/resources/views/pacientes/create.blade.php
@@ -37,7 +37,7 @@
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de nascimento <span class="text-red-500">*</span></label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="data_nascimento" value="{{ old('data_nascimento') }}" required />
+                    <input class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="data_nascimento" value="{{ old('data_nascimento') }}" required />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">CPF <span x-show="menorIdade !== 'Sim'" x-cloak class="text-red-500">*</span></label>

--- a/resources/views/pacientes/edit.blade.php
+++ b/resources/views/pacientes/edit.blade.php
@@ -68,7 +68,7 @@
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de nascimento <span class="text-red-500">*</span></label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="date" name="data_nascimento" value="{{ old('data_nascimento', $paciente->pessoa->data_nascimento?->format('Y-m-d')) }}" required />
+                    <input class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="data_nascimento" value="{{ old('data_nascimento', $paciente->pessoa->data_nascimento?->format('Y-m-d')) }}" required />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">CPF <span x-show="menorIdade !== 'Sim'" x-cloak class="text-red-500">*</span></label>

--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -44,7 +44,7 @@
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de nascimento <span class="text-red-500">*</span></label>
-                    <input type="date" name="data_nascimento" value="{{ old('data_nascimento') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
+                    <input type="text" name="data_nascimento" value="{{ old('data_nascimento') }}" class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Sexo</label>
@@ -156,11 +156,11 @@
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de início do contrato <span class="text-red-500">*</span></label>
-                    <input type="date" name="data_inicio_contrato" value="{{ old('data_inicio_contrato') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
+                    <input type="text" name="data_inicio_contrato" value="{{ old('data_inicio_contrato') }}" class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
                 </div>
                 <div x-show="tipo_contrato && tipo_contrato !== 'CLT'" x-cloak>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de término do contrato</label>
-                    <input type="date" name="data_fim_contrato" value="{{ old('data_fim_contrato') }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    <input type="text" name="data_fim_contrato" value="{{ old('data_fim_contrato') }}" class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Total de horas semanais</label>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -45,7 +45,7 @@
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de nascimento <span class="text-red-500">*</span></label>
-                    <input type="date" name="data_nascimento" value="{{ old('data_nascimento', optional($profissional->pessoa->data_nascimento)->format('Y-m-d')) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
+                    <input type="text" name="data_nascimento" value="{{ old('data_nascimento', optional($profissional->pessoa->data_nascimento)->format('Y-m-d')) }}" class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Sexo</label>
@@ -157,11 +157,11 @@
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de início do contrato <span class="text-red-500">*</span></label>
-                    <input type="date" name="data_inicio_contrato" value="{{ old('data_inicio_contrato', optional($profissional->data_inicio_contrato)->format('Y-m-d')) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
+                    <input type="text" name="data_inicio_contrato" value="{{ old('data_inicio_contrato', optional($profissional->data_inicio_contrato)->format('Y-m-d')) }}" class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
                 </div>
                 <div x-show="tipo_contrato && tipo_contrato !== 'CLT'" x-cloak>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de término do contrato</label>
-                    <input type="date" name="data_fim_contrato" value="{{ old('data_fim_contrato', optional($profissional->data_fim_contrato)->format('Y-m-d')) }}" class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
+                    <input type="text" name="data_fim_contrato" value="{{ old('data_fim_contrato', optional($profissional->data_fim_contrato)->format('Y-m-d')) }}" class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Total de horas semanais</label>


### PR DESCRIPTION
## Summary
- add flatpickr via CDN and initialize with Brazilian locale
- switch professional and patient date fields to use the new picker

## Testing
- `npm run build`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689215ee6328832ab048cd5b35b81ff3