### PR TITLE
Format birthdate inputs

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -7,3 +7,7 @@
 .flatpickr-input {
     background-image: none !important;
 }
+
+.flatpickr-input::-webkit-calendar-picker-indicator {
+    display: none !important;
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -158,6 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (window.flatpickr) {
         flatpickr('.datepicker', {
             altInput: true,
+            altInputClass: 'w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none',
             altFormat: 'd/m/Y',
             dateFormat: 'Y-m-d',
             locale: 'pt',

--- a/resources/views/pacientes/edit.blade.php
+++ b/resources/views/pacientes/edit.blade.php
@@ -68,7 +68,7 @@
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de nascimento <span class="text-red-500">*</span></label>
-                    <input class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="data_nascimento" value="{{ old('data_nascimento', $paciente->pessoa->data_nascimento?->format('Y-m-d')) }}" required />
+                    <input class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="data_nascimento" value="{{ old('data_nascimento', $paciente->pessoa->data_nascimento?->format('Y-m-d')) }}" placeholder="DD/MM/YYYY" required />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">CPF <span x-show="menorIdade !== 'Sim'" x-cloak class="text-red-500">*</span></label>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -45,7 +45,7 @@
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Data de nascimento <span class="text-red-500">*</span></label>
-                    <input type="text" name="data_nascimento" value="{{ old('data_nascimento', optional($profissional->pessoa->data_nascimento)->format('Y-m-d')) }}" class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" required />
+                    <input type="text" name="data_nascimento" value="{{ old('data_nascimento', optional($profissional->pessoa->data_nascimento)->format('Y-m-d')) }}" class="datepicker w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" placeholder="DD/MM/YYYY" required />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">Sexo <span class="text-red-500">*</span></label>


### PR DESCRIPTION
## Summary
- style flatpickr alt input to remove calendar icon
- hide default calendar indicator
- add DD/MM/YYYY placeholders to patient and professional birthdate fields

## Testing
- `npm run build`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892210243b4832a890a97573b5dc86e