### PR TITLE
Require guardian last name for minors

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -153,6 +153,7 @@ class PatientController extends Controller
 
         if ($request->menor_idade === 'Sim') {
             $rules['responsavel_first_name'] = 'required';
+            $rules['responsavel_last_name'] = 'required';
             $rules['responsavel_cpf'] = 'required';
             $rules['cpf'] = 'nullable';
         } else {

--- a/resources/views/pacientes/create.blade.php
+++ b/resources/views/pacientes/create.blade.php
@@ -73,8 +73,8 @@
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_middle_name" value="{{ old('responsavel_middle_name') }}" />
                 </div>
                 <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Último nome</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_last_name" value="{{ old('responsavel_last_name') }}" />
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">Último nome <span x-show="menorIdade === 'Sim'" x-cloak class="text-red-500">*</span></label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_last_name" value="{{ old('responsavel_last_name') }}" x-bind:required="menorIdade === 'Sim'" />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">CPF do responsável <span x-show="menorIdade === 'Sim'" x-cloak class="text-red-500">*</span></label>

--- a/resources/views/pacientes/edit.blade.php
+++ b/resources/views/pacientes/edit.blade.php
@@ -104,8 +104,8 @@
                     <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_middle_name" value="{{ old('responsavel_middle_name', $paciente->responsavel_middle_name) }}" />
                 </div>
                 <div>
-                    <label class="text-sm font-medium text-gray-700 mb-2 block">Último nome</label>
-                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_last_name" value="{{ old('responsavel_last_name', $paciente->responsavel_last_name) }}" />
+                    <label class="text-sm font-medium text-gray-700 mb-2 block">Último nome <span x-show="menorIdade === 'Sim'" x-cloak class="text-red-500">*</span></label>
+                    <input class="w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black focus:border-primary focus:outline-none" type="text" name="responsavel_last_name" value="{{ old('responsavel_last_name', $paciente->responsavel_last_name) }}" x-bind:required="menorIdade === 'Sim'" />
                 </div>
                 <div>
                     <label class="text-sm font-medium text-gray-700 mb-2 block">CPF do responsável <span x-show="menorIdade === 'Sim'" x-cloak class="text-red-500">*</span></label>


### PR DESCRIPTION
## Summary
- display a red asterisk on the guardian last name field for minor patients
- enforce guardian last name as required when a patient is a minor

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892344b5920832abc85496cd1fc0d4a