### PR TITLE
Add English relationship aliases to Profissional model

### DIFF
--- a/app/Models/Profissional.php
+++ b/app/Models/Profissional.php
@@ -66,6 +66,16 @@ class Profissional extends Model
         return $this->belongsTo(Usuario::class);
     }
 
+    public function person()
+    {
+        return $this->pessoa();
+    }
+
+    public function user()
+    {
+        return $this->usuario();
+    }
+
     public function horariosTrabalho()
     {
         return $this->hasMany(ProfissionalHorario::class);


### PR DESCRIPTION
## Summary
- map `user` and `person` relationships in `Profissional` to match controller expectations

## Testing
- `composer install` *(fails: curl error 56 while downloading packages: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689237a6566c832a892cb61f9f461605