### PR TITLE
Fix commission fields visibility in professional forms

### DIFF
--- a/resources/views/profissionais/create.blade.php
+++ b/resources/views/profissionais/create.blade.php
@@ -250,7 +250,7 @@
             </div>
             <div class="space-y-4 mt-4">
                 @foreach($clinics as $clinic)
-                    <div class="p-4 bg-gray-50 border rounded" x-show="selectedClinics.includes({{ $clinic->id }})" x-cloak>
+                    <div class="p-4 bg-gray-50 border rounded" x-show="selectedClinics.includes('{{ $clinic->id }}')" x-cloak>
                         <h4 class="text-sm font-medium text-gray-700 mb-2">{{ $clinic->nome }}</h4>
                         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                             <div>

--- a/resources/views/profissionais/edit.blade.php
+++ b/resources/views/profissionais/edit.blade.php
@@ -254,7 +254,7 @@
                     @php
                         $vals = $profissional->comissoes[$clinic->id] ?? [];
                     @endphp
-                    <div class="p-4 bg-gray-50 border rounded" x-show="selectedClinics.includes({{ $clinic->id }})" x-cloak>
+                    <div class="p-4 bg-gray-50 border rounded" x-show="selectedClinics.includes('{{ $clinic->id }}')" x-cloak>
                         <h4 class="text-sm font-medium text-gray-700 mb-2">{{ $clinic->nome }}</h4>
                         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                             <div>


### PR DESCRIPTION
## Summary
- Ensure commission percentage inputs appear when a clinic is selected on professional create/edit forms by comparing clinic IDs as strings

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68923b5fac0c832a8746d43e0f00df02