### PR TITLE
fix: correctly detect schedule time conflicts

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -116,17 +116,17 @@ class EscalaTrabalhoController extends Controller
                 $conflict = EscalaTrabalho::where('cadeira_id', $data['cadeira_id'])
                     ->where('semana', $weekStart)
                     ->where('dia_semana', $dia)
-                    ->where(function($q) use ($data) {
-                        $q->whereBetween('hora_inicio', [$data['hora_inicio'], $data['hora_fim']])
-                          ->orWhereBetween('hora_fim', [$data['hora_inicio'], $data['hora_fim']]);
+                    ->where(function ($q) use ($data) {
+                        $q->where('hora_inicio', '<', $data['hora_fim'])
+                          ->where('hora_fim', '>', $data['hora_inicio']);
                     })->exists();
 
                 $conflictProf = EscalaTrabalho::where('profissional_id', $data['profissional_id'])
                     ->where('semana', $weekStart)
                     ->where('dia_semana', $dia)
-                    ->where(function($q) use ($data) {
-                        $q->whereBetween('hora_inicio', [$data['hora_inicio'], $data['hora_fim']])
-                          ->orWhereBetween('hora_fim', [$data['hora_inicio'], $data['hora_fim']]);
+                    ->where(function ($q) use ($data) {
+                        $q->where('hora_inicio', '<', $data['hora_fim'])
+                          ->where('hora_fim', '>', $data['hora_inicio']);
                     })->exists();
 
                 if ($conflict || $conflictProf) {
@@ -152,17 +152,17 @@ class EscalaTrabalhoController extends Controller
                 $conflict = EscalaTrabalho::where('cadeira_id', $data['cadeira_id'])
                     ->where('semana', $data['semana'])
                     ->where('dia_semana', $dia)
-                    ->where(function($q) use ($data) {
-                        $q->whereBetween('hora_inicio', [$data['hora_inicio'], $data['hora_fim']])
-                          ->orWhereBetween('hora_fim', [$data['hora_inicio'], $data['hora_fim']]);
+                    ->where(function ($q) use ($data) {
+                        $q->where('hora_inicio', '<', $data['hora_fim'])
+                          ->where('hora_fim', '>', $data['hora_inicio']);
                     })->exists();
 
                 $conflictProf = EscalaTrabalho::where('profissional_id', $data['profissional_id'])
                     ->where('semana', $data['semana'])
                     ->where('dia_semana', $dia)
-                    ->where(function($q) use ($data) {
-                        $q->whereBetween('hora_inicio', [$data['hora_inicio'], $data['hora_fim']])
-                          ->orWhereBetween('hora_fim', [$data['hora_inicio'], $data['hora_fim']]);
+                    ->where(function ($q) use ($data) {
+                        $q->where('hora_inicio', '<', $data['hora_fim'])
+                          ->where('hora_fim', '>', $data['hora_inicio']);
                     })->exists();
 
                 if ($conflict || $conflictProf) {

--- a/tests/Unit/EscalaTrabalhoControllerTest.php
+++ b/tests/Unit/EscalaTrabalhoControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Carbon\Carbon;
+
+class EscalaTrabalhoControllerTest extends TestCase
+{
+    private function overlaps($existingStart, $existingEnd, $newStart, $newEnd)
+    {
+        return Carbon::parse($existingStart) < Carbon::parse($newEnd)
+            && Carbon::parse($existingEnd) > Carbon::parse($newStart);
+    }
+
+    public function test_allows_adjacent_times()
+    {
+        $this->assertFalse(
+            $this->overlaps('08:00', '09:00', '09:00', '10:00')
+        );
+    }
+
+    public function test_detects_overlapping_times()
+    {
+        $this->assertTrue(
+            $this->overlaps('08:00', '10:00', '09:00', '11:00')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- detect overlapping times using open intervals to allow back-to-back dentists on the same chair
- add unit tests for schedule overlap logic

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68923c279b8c832ab2f6ac077a67e794