### PR TITLE
Fix schedule display and conflict checks for multiple dentists

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -53,8 +53,9 @@ class EscalaTrabalhoController extends Controller
             $escalas = EscalaTrabalho::with(['profissional.person','profissional.user'])
                 ->where('clinica_id', $clinicId)
                 ->whereBetween('semana', [$weeks->first()->toDateString(), $weeks->last()->toDateString()])
+                ->orderBy('hora_inicio')
                 ->get()
-                ->groupBy([fn($e) => $e->semana->toDateString(), 'cadeira_id', 'dia_semana']);
+                ->groupBy([fn($e) => $e->semana->toDateString(), 'cadeira_id', 'dia_semana'], preserveKeys: true);
 
             return view('escalas.index', compact('clinics','clinicId','view','month','weeks','dias','cadeiras','escalas','dentistas','mesesDisponiveis'));
         }
@@ -68,8 +69,9 @@ class EscalaTrabalhoController extends Controller
                 $week->toDateString(),
                 $week->copy()->addDays(6)->toDateString(),
             ])
+            ->orderBy('hora_inicio')
             ->get()
-            ->groupBy(['cadeira_id','dia_semana']);
+            ->groupBy(['cadeira_id','dia_semana'], preserveKeys: true);
 
         return view('escalas.index', compact('clinics','clinicId','view','week','dias','cadeiras','escalas','dentistas','semanasDisponiveis'));
     }
@@ -122,7 +124,8 @@ class EscalaTrabalhoController extends Controller
                     return back()->with('error', 'Horário fora do expediente da clínica.');
                 }
 
-                $conflict = EscalaTrabalho::where('cadeira_id', $data['cadeira_id'])
+                $conflict = EscalaTrabalho::where('clinica_id', $data['clinic_id'])
+                    ->where('cadeira_id', $data['cadeira_id'])
                     ->where('semana', $weekStart)
                     ->where('dia_semana', $dia)
                     ->where(function ($q) use ($data) {
@@ -130,7 +133,8 @@ class EscalaTrabalhoController extends Controller
                           ->where('hora_fim', '>', $data['hora_inicio']);
                     })->exists();
 
-                $conflictProf = EscalaTrabalho::where('profissional_id', $data['profissional_id'])
+                $conflictProf = EscalaTrabalho::where('clinica_id', $data['clinic_id'])
+                    ->where('profissional_id', $data['profissional_id'])
                     ->where('semana', $weekStart)
                     ->where('dia_semana', $dia)
                     ->where(function ($q) use ($data) {
@@ -166,7 +170,8 @@ class EscalaTrabalhoController extends Controller
                     return back()->with('error', 'Horário fora do expediente da clínica.');
                 }
 
-                $conflict = EscalaTrabalho::where('cadeira_id', $data['cadeira_id'])
+                $conflict = EscalaTrabalho::where('clinica_id', $data['clinic_id'])
+                    ->where('cadeira_id', $data['cadeira_id'])
                     ->where('semana', $data['semana'])
                     ->where('dia_semana', $dia)
                     ->where(function ($q) use ($data) {
@@ -174,7 +179,8 @@ class EscalaTrabalhoController extends Controller
                           ->where('hora_fim', '>', $data['hora_inicio']);
                     })->exists();
 
-                $conflictProf = EscalaTrabalho::where('profissional_id', $data['profissional_id'])
+                $conflictProf = EscalaTrabalho::where('clinica_id', $data['clinic_id'])
+                    ->where('profissional_id', $data['profissional_id'])
                     ->where('semana', $data['semana'])
                     ->where('dia_semana', $dia)
                     ->where(function ($q) use ($data) {

--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -72,7 +72,9 @@
                         <tr>
                             <td class="w-32 px-2 py-1 font-semibold bg-gray-50 border border-gray-200">{{ $cadeira->nome }}</td>
                             @foreach($dias as $d)
-                                @php $items = $escalas[$w->toDateString()][$cadeira->id][$d->value] ?? collect(); @endphp
+                                @php
+                                    $items = data_get($escalas, $w->toDateString().'.'.$cadeira->id.'.'.$d->value, collect())->sortBy('hora_inicio');
+                                @endphp
                                 <td class="px-2 py-2 border border-gray-200 align-top" style="width:14.28%">
                                     @forelse($items as $it)
                                         <div class="mb-2 p-2 rounded bg-emerald-50 text-sm">
@@ -112,7 +114,9 @@
                     <tr>
                         <td class="w-32 px-2 py-1 font-semibold bg-gray-50 border border-gray-200">{{ $cadeira->nome }}</td>
                         @foreach($dias as $d)
-                            @php $items = $escalas[$cadeira->id][$d->value] ?? collect(); @endphp
+                            @php
+                                $items = data_get($escalas, $cadeira->id.'.'.$d->value, collect())->sortBy('hora_inicio');
+                            @endphp
                             <td class="px-2 py-2 border border-gray-200 align-top" style="width:14.28%">
                                 @forelse($items as $it)
                                     <div class="mb-2 p-2 rounded bg-emerald-50 text-sm">


### PR DESCRIPTION
## Summary
- keep schedule queries ordered and preserve day keys to show multiple appointments per chair
- validate chair and professional conflicts per clinic
- ensure Blade view pulls grouped schedules correctly and ordered by start time

## Testing
- `composer install --prefer-dist --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68923f75a124832a8ae635fd0d76623b