### PR TITLE
feat: enable editing and deletion of dentist schedules

### DIFF
--- a/resources/views/escalas/partials/card.blade.php
+++ b/resources/views/escalas/partials/card.blade.php
@@ -12,7 +12,7 @@
     $duracao = $inicio->diffInMinutes($fim);
     $percentual = $totalMinutos > 0 ? ($duracao / $totalMinutos) * 100 : 0;
 @endphp
-<div class="mb-2 p-2 rounded bg-emerald-50 text-sm">
+<div class="mb-2 p-2 rounded bg-emerald-50 text-sm escala-card" data-id="{{ $it->id }}" data-profissional="{{ $it->profissional_id }}" data-hora-inicio="{{ $it->hora_inicio }}" data-hora-fim="{{ $it->hora_fim }}" data-cadeira="{{ $it->cadeira_id }}" data-date="{{ \Carbon\Carbon::parse($it->semana)->addDays($it->dia_semana - 1)->format('Y-m-d') }}">
     <div class="font-semibold whitespace-nowrap overflow-hidden text-ellipsis">
         {{ optional($it->profissional->pessoa)->primeiro_nome }} {{ optional($it->profissional->pessoa)->ultimo_nome }}
     </div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -41,7 +41,7 @@ Route::view('orcamentos/assinar', 'orcamentos.assinar')->name('orcamentos.assina
 
 Route::post('selecionar-clinica', [ClinicContextController::class, 'update'])->name('clinicas.selecionar');
 
-Route::resource('escalas', EscalaTrabalhoController::class)->only(['index','store']);
+Route::resource('escalas', EscalaTrabalhoController::class)->only(['index','store','update','destroy']);
 
 Route::get('financeiro', [FinanceiroController::class, 'index'])->name('financeiro.index');
 Route::get('estoque', [EstoqueController::class, 'index'])->name('estoque.index');


### PR DESCRIPTION
## Summary
- allow double-clicking schedule cards to edit
- support updating and deleting existing schedules
- attach metadata to schedule cards for editing

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed 403)*
- `npm test` *(fails: Missing script "test"))*


------
https://chatgpt.com/codex/tasks/task_e_6892642778f4832aa21959ee59565c24