### PR TITLE
Reset chart canvas before reinitializing

### DIFF
--- a/resources/views/financeiro/index.blade.php
+++ b/resources/views/financeiro/index.blade.php
@@ -122,11 +122,16 @@
                 if (existing) existing.destroy();
             }
 
-            // Reset canvas dimensions so Chart.js doesn't keep expanding it
-            el.removeAttribute('width');
-            el.removeAttribute('height');
-            el.style.width = '';
-            el.style.height = '';
+            // Fully reset the canvas before creating a new chart
+            const ctx = el.getContext('2d');
+            ctx.clearRect(0, 0, el.width, el.height);
+            el.width = el.height = 0;
+            el.removeAttribute('style');
+
+            // Replace the canvas node to ensure a fresh element
+            const freshCanvas = el.cloneNode(true);
+            el.replaceWith(freshCanvas);
+            el = freshCanvas;
 
             window[store] = new Chart(el, config);
         };


### PR DESCRIPTION
## Summary
- Reset existing canvas context, dimensions, and styles before instantiating Chart.js instances
- Replace canvas elements with fresh clones to avoid size growth on repeated renders

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68926c3a0bf8832aa0c0fcef1279d16d