### PR TITLE
Reset financial charts before reinitialization

### DIFF
--- a/resources/views/financeiro/index.blade.php
+++ b/resources/views/financeiro/index.blade.php
@@ -110,13 +110,18 @@
 <script>
     document.addEventListener('DOMContentLoaded', function () {
         const createChart = (id, store, config) => {
-            const el = document.getElementById(id);
+            let el = document.getElementById(id);
             if (!el || !window.Chart) return;
 
             // Destroy any existing chart instance attached to this element
-            const existing = window[store] || Chart.getChart(el);
+            const existing = window[store] || (Chart.getChart ? Chart.getChart(el) : null);
             if (existing) {
                 existing.destroy();
+
+                // Replace canvas with a fresh one to prevent size accumulation
+                const fresh = el.cloneNode(true);
+                el.replaceWith(fresh);
+                el = fresh;
             }
 
             window[store] = new Chart(el, config);


### PR DESCRIPTION
## Summary
- prevent repeated Chart.js canvases from expanding on the financial dashboard by destroying any existing chart and replacing the canvas before creating a new one

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689358cf39e4832aafdf62c47ec0457a