### PR TITLE
Fix monthly schedule copy target

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -332,7 +332,7 @@ class EscalaTrabalhoController extends Controller
 
             $sourceStart = $sourceMonth->copy()->startOfWeek(Carbon::MONDAY);
             $sourceEnd = $sourceMonth->copy()->endOfMonth()->endOfWeek(Carbon::SUNDAY);
-            $targetStart = $targetMonth->copy()->startOfWeek(Carbon::MONDAY);
+            $targetStart = $targetMonth->copy()->firstOfMonth(Carbon::MONDAY);
 
             $sourceEscalas = EscalaTrabalho::where('clinica_id', $clinicId)
                 ->whereBetween('semana', [$sourceStart->toDateString(), $sourceEnd->toDateString()])


### PR DESCRIPTION
## Summary
- ensure monthly schedule copy saves into the selected month

## Testing
- `php -l app/Http/Controllers/Admin/EscalaTrabalhoController.php`
- `composer install --no-interaction --prefer-dist` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68935ab33f60832aac60861babfc8ab0