### PR TITLE
fix: vertical scrolling on admin schedules page

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" x-data="{ sidebarCollapsed: JSON.parse(localStorage.getItem('sidebarCollapsed') ?? 'false') }" x-init="$watch('sidebarCollapsed', val => localStorage.setItem('sidebarCollapsed', val))" class="h-full">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" x-data="{ sidebarCollapsed: JSON.parse(localStorage.getItem('sidebarCollapsed') ?? 'false') }" x-init="$watch('sidebarCollapsed', val => localStorage.setItem('sidebarCollapsed', val))" class="min-h-full">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,7 +19,7 @@
     </script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
-<body class="flex h-full bg-gray-100">
+<body class="flex min-h-screen bg-gray-100 overflow-auto">
     @auth
         @unless(isset($hideNav) && $hideNav)
             <aside :class="sidebarCollapsed ? 'w-20' : 'w-64'" class="h-full bg-white border-r shadow transition-all duration-300">
@@ -27,13 +27,13 @@
             </aside>
         @endunless
     @endauth
-    <div class="flex flex-col flex-1 min-h-screen">
+    <div class="flex flex-col flex-1 w-full">
         @auth
             @unless(isset($hideNav) && $hideNav)
                 @include('partials.topbar')
             @endunless
         @endauth
-        <main class="flex-1 p-6 overflow-y-auto">
+        <main class="flex-1 p-6">
             @if ($errors->any() && !(isset($hideErrors) && $hideErrors))
                 @include('components.alert-error', ['slot' => $errors->first()])
             @endif


### PR DESCRIPTION
## Summary
- allow body to grow beyond viewport and scroll normally
- remove nested overflow styles from schedules layout

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68936c26c958832aa83060a0210d160c