### PR TITLE
Fix sidebar height and main content scroll

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" x-data="{ sidebarCollapsed: JSON.parse(localStorage.getItem('sidebarCollapsed') ?? 'false') }" x-init="$watch('sidebarCollapsed', val => localStorage.setItem('sidebarCollapsed', val))" class="min-h-full">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" x-data="{ sidebarCollapsed: JSON.parse(localStorage.getItem('sidebarCollapsed') ?? 'false') }" x-init="$watch('sidebarCollapsed', val => localStorage.setItem('sidebarCollapsed', val))" class="h-full">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,21 +19,21 @@
     </script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
-<body class="flex min-h-screen bg-gray-100 overflow-auto">
+<body class="flex h-screen bg-gray-100 overflow-hidden">
     @auth
         @unless(isset($hideNav) && $hideNav)
-            <aside :class="sidebarCollapsed ? 'w-20' : 'w-64'" class="h-full bg-white border-r shadow transition-all duration-300">
+            <aside :class="sidebarCollapsed ? 'w-20' : 'w-64'" class="h-full bg-white border-r shadow transition-all duration-300 overflow-y-auto">
                 @include('partials.sidebar')
             </aside>
         @endunless
     @endauth
-    <div class="flex flex-col flex-1 w-full">
+    <div class="flex flex-col flex-1 w-full h-full overflow-hidden">
         @auth
             @unless(isset($hideNav) && $hideNav)
                 @include('partials.topbar')
             @endunless
         @endauth
-        <main class="flex-1 p-6">
+        <main class="flex-1 p-6 overflow-y-auto">
             @if ($errors->any() && !(isset($hideErrors) && $hideErrors))
                 @include('components.alert-error', ['slot' => $errors->first()])
             @endif


### PR DESCRIPTION
## Summary
- ensure sidebar spans full viewport height with its own scrolling
- allow main content to scroll vertically without hiding the top bar

## Testing
- `npm run build`
- `composer install` (fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_689375676f74832a819a9fb50b949472