### PR TITLE
Enable year and month navigation for schedules

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -35,9 +35,14 @@ class EscalaTrabalhoController extends Controller
             ->with('person')
             ->get();
 
-        $month = $request->input('month');
-        $month = $month ? Carbon::parse($month)->startOfMonth() : Carbon::now()->startOfMonth();
-        $mesesDisponiveis = collect(range(-2, 2))->map(fn($i) => Carbon::now()->startOfMonth()->addMonths($i));
+        $yearParam = $request->input('year');
+        $monthParam = $request->input('month');
+
+        $year = $yearParam ? (int)$yearParam : Carbon::now()->year;
+        $monthNumber = $monthParam ? (int)$monthParam : Carbon::now()->month;
+
+        $month = Carbon::create($year, $monthNumber, 1)->startOfMonth();
+        $mesesDisponiveis = collect(range(1, 12))->map(fn($m) => Carbon::create($year, $m, 1)->startOfMonth());
 
         $weeks = collect();
         $current = $month->copy()->startOfWeek(Carbon::MONDAY);
@@ -188,6 +193,9 @@ class EscalaTrabalhoController extends Controller
         $params = [
             'clinic_id' => $data['clinic_id'],
         ];
+        if ($request->filled('year')) {
+            $params['year'] = $request->input('year');
+        }
         if ($request->filled('month')) {
             $params['month'] = $request->input('month');
         }
@@ -258,8 +266,15 @@ class EscalaTrabalhoController extends Controller
 
         $params = [
             'clinic_id' => $escala->clinica_id,
-            'month' => $request->input('month', Carbon::parse($data['data'])->format('Y-m')),
         ];
+        if ($request->filled('year') && $request->filled('month')) {
+            $params['year'] = $request->input('year');
+            $params['month'] = $request->input('month');
+        } else {
+            $date = Carbon::parse($data['data']);
+            $params['year'] = $date->year;
+            $params['month'] = $date->month;
+        }
 
         return redirect()->route('escalas.index', $params)
             ->with('success', 'Escala atualizada com sucesso.');
@@ -272,6 +287,9 @@ class EscalaTrabalhoController extends Controller
         $params = [
             'clinic_id' => $escala->clinica_id,
         ];
+        if ($request->filled('year')) {
+            $params['year'] = $request->input('year');
+        }
         if ($request->filled('month')) {
             $params['month'] = $request->input('month');
         }
@@ -350,7 +368,8 @@ class EscalaTrabalhoController extends Controller
 
         $params = [
             'clinic_id' => $clinicId,
-            'month' => $targetMonth->format('Y-m'),
+            'year' => $targetMonth->year,
+            'month' => $targetMonth->month,
         ];
 
         return redirect()->route('escalas.index', $params)

--- a/tests/Unit/EscalaTrabalhoControllerTest.php
+++ b/tests/Unit/EscalaTrabalhoControllerTest.php
@@ -66,4 +66,28 @@ class EscalaTrabalhoControllerTest extends TestCase
 
         $this->assertSame('2025-06-02', $newWeek->toDateString());
     }
+
+    public function test_accepts_past_year_and_month()
+    {
+        $year = 1999;
+        $monthNumber = 11;
+        $selected = Carbon::create($year, $monthNumber, 1)->startOfMonth();
+        $this->assertSame('1999-11-01', $selected->toDateString());
+
+        $meses = collect(range(1, 12))->map(fn($m) => Carbon::create($year, $m, 1)->startOfMonth());
+        $this->assertCount(12, $meses);
+        $this->assertTrue($meses->first()->isSameMonth(Carbon::create($year, 1, 1)));
+        $this->assertTrue($meses->last()->isSameMonth(Carbon::create($year, 12, 1)));
+    }
+
+    public function test_accepts_future_year_and_month()
+    {
+        $year = Carbon::now()->year + 5;
+        $monthNumber = 3;
+        $selected = Carbon::create($year, $monthNumber, 1)->startOfMonth();
+        $this->assertSame($year.'-03-01', $selected->toDateString());
+
+        $meses = collect(range(1, 12))->map(fn($m) => Carbon::create($year, $m, 1)->startOfMonth());
+        $this->assertTrue($meses->contains(fn($m) => $m->isSameMonth($selected)));
+    }
 }


### PR DESCRIPTION
## Summary
- Accept separate `year` and `month` parameters for schedule index and populate a full-year month list
- Allow selecting year/month and navigating with prev/next controls in schedule view
- Cover past and future dates in unit tests

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68937a350070832ab40714f99ea3da33