### PR TITLE
Use Str::contains for dentist matching

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -9,6 +9,7 @@ use App\Models\EscalaTrabalho;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
 
 class AgendamentoController extends Controller
 {
@@ -66,11 +67,11 @@ class AgendamentoController extends Controller
 
         return $escalas->pluck('profissional')
             ->filter(function ($prof) {
-                $funcao = strtolower($prof->funcao ?? '');
-                $cargo = strtolower($prof->cargo ?? '');
+                $funcao = $prof->funcao ?? '';
+                $cargo = $prof->cargo ?? '';
 
-                return $funcao === 'dentista'
-                    || $cargo === 'dentista'
+                return Str::contains(Str::lower($funcao), 'dentista')
+                    || Str::contains(Str::lower($cargo), 'dentista')
                     || ($prof->user && $prof->user->especialidade);
             })
             ->unique('id')

--- a/tests/Unit/AgendamentoControllerTest.php
+++ b/tests/Unit/AgendamentoControllerTest.php
@@ -4,9 +4,12 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Admin\AgendamentoController;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 class AgendamentoControllerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
     public function test_store_without_clinic_returns_error()
     {
         Container::setInstance(new Container());
@@ -21,5 +24,65 @@ class AgendamentoControllerTest extends TestCase
         $this->assertFalse($data['success']);
         $this->assertSame('Clínica não selecionada.', $data['message']);
         $this->assertSame('/admin/clinicas', $data['redirect']);
+    }
+
+    public function test_professionals_for_date_detects_dentist_variations()
+    {
+        $clinicId = 1;
+        $date = '2024-05-20';
+
+        $collection = collect([
+            (object) ['profissional' => (object) [
+                'id' => 1,
+                'funcao' => 'Dentista(a)',
+                'cargo' => null,
+                'user' => null,
+                'pessoa' => (object) ['primeiro_nome' => 'Ana', 'sexo' => 'Feminino'],
+            ]],
+            (object) ['profissional' => (object) [
+                'id' => 2,
+                'funcao' => 'Dentista Clínico',
+                'cargo' => null,
+                'user' => null,
+                'pessoa' => (object) ['primeiro_nome' => 'Bruno', 'sexo' => 'Masculino'],
+            ]],
+            (object) ['profissional' => (object) [
+                'id' => 3,
+                'funcao' => null,
+                'cargo' => 'Dentista(a)',
+                'user' => null,
+                'pessoa' => (object) ['primeiro_nome' => 'Clara', 'sexo' => 'Feminino'],
+            ]],
+            (object) ['profissional' => (object) [
+                'id' => 4,
+                'funcao' => null,
+                'cargo' => 'Dentista Clínico',
+                'user' => null,
+                'pessoa' => (object) ['primeiro_nome' => 'Diego', 'sexo' => 'Masculino'],
+            ]],
+            (object) ['profissional' => (object) [
+                'id' => 5,
+                'funcao' => 'Auxiliar',
+                'cargo' => 'Recepcionista',
+                'user' => null,
+                'pessoa' => (object) ['primeiro_nome' => 'Eva', 'sexo' => 'Feminino'],
+            ]],
+        ]);
+
+        $mock = Mockery::mock('alias:App\Models\EscalaTrabalho');
+        $mock->shouldReceive('with')->andReturnSelf();
+        $mock->shouldReceive('where')->andReturnSelf();
+        $mock->shouldReceive('get')->andReturn($collection);
+
+        $controller = new AgendamentoController();
+        $reflection = new \ReflectionClass($controller);
+        $method = $reflection->getMethod('professionalsForDate');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($controller, $clinicId, $date);
+        $ids = array_column($result, 'id');
+        sort($ids);
+
+        $this->assertSame([1, 2, 3, 4], $ids);
     }
 }


### PR DESCRIPTION
## Summary
- allow more flexible dentist detection in `professionalsForDate`
- cover dentist title variations in tests

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6893837f428c832a8cec7c1cb64e30d3