### PR TITLE
Filter professionals by schedule date and clinic

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -56,19 +56,20 @@ class AgendamentoController extends Controller
     {
         $carbon = Carbon::parse($date);
         $weekStart = $carbon->copy()->startOfWeek(Carbon::MONDAY)->toDateString();
-        $weekEnd = $carbon->copy()->endOfWeek(Carbon::SUNDAY)->toDateString();
         $day = $carbon->isoWeekday();
 
         $profissionalIds = EscalaTrabalho::where('clinica_id', $clinicId)
-            ->whereBetween('semana', [$weekStart, $weekEnd])
+            ->whereDate('semana', $weekStart)
             ->where('dia_semana', $day)
-            ->get()
+            ->distinct('profissional_id')
             ->pluck('profissional_id')
-            ->unique()
             ->toArray();
 
         $profissionais = \App\Models\Profissional::with('pessoa')
-            ->whereIn('id', $profissionalIds)
+            ->join('clinica_profissional', 'profissionais.id', '=', 'clinica_profissional.profissional_id')
+            ->where('clinica_profissional.clinica_id', $clinicId)
+            ->whereIn('profissionais.id', $profissionalIds)
+            ->distinct('profissionais.id')
             ->get();
 
         return $profissionais

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -177,10 +177,12 @@ window.renderSchedule = function(professionals, agenda, baseTimes) {
     const emptyMsg = document.getElementById('schedule-empty');
     if (bar) {
         bar.innerHTML = '';
-        bar.insertAdjacentHTML('beforeend', '<button class="px-4 py-2 rounded border text-sm whitespace-nowrap bg-primary text-white">Todos os Profissionais</button>');
-        professionals.forEach(p => {
-            bar.insertAdjacentHTML('beforeend', `<button class="px-4 py-2 rounded border text-sm whitespace-nowrap bg-white text-gray-700" data-professional="${p.id}">${p.name}</button>`);
-        });
+        if (professionals.length > 0) {
+            bar.insertAdjacentHTML('beforeend', '<button class="px-4 py-2 rounded border text-sm whitespace-nowrap bg-primary text-white">Todos os Profissionais</button>');
+            professionals.forEach(p => {
+                bar.insertAdjacentHTML('beforeend', `<button class="px-4 py-2 rounded border text-sm whitespace-nowrap bg-white text-gray-700" data-professional="${p.id}">${p.name}</button>`);
+            });
+        }
     }
     if (table) {
         const theadRow = table.querySelector('thead tr');

--- a/tests/Feature/AgendamentoTest.php
+++ b/tests/Feature/AgendamentoTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Models {
+    class Agendamento
+    {
+        public static function with($relations)
+        {
+            return new self;
+        }
+
+        public function where($field, $value)
+        {
+            return $this;
+        }
+
+        public function whereDate($field, $value)
+        {
+            return $this;
+        }
+
+        public function whereIn($field, $values)
+        {
+            return $this;
+        }
+
+        public function get()
+        {
+            return collect([]);
+        }
+    }
+}
+
+namespace Illuminate\Http {
+    class Request
+    {
+        private array $query;
+
+        public function __construct(array $query = [])
+        {
+            $this->query = $query;
+        }
+
+        public function query($key, $default = null)
+        {
+            return $this->query[$key] ?? $default;
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../Unit/stubs.php';
+    require_once __DIR__ . '/../../app/Http/Controllers/Admin/AgendamentoController.php';
+
+    use PHPUnit\Framework\TestCase;
+    use App\Http\Controllers\Admin\AgendamentoController;
+
+    if (! function_exists('app')) {
+        function app($key = null)
+        {
+            if ($key === null) {
+                return new class {
+                    public function bound($name)
+                    {
+                        return $name === 'clinic_id';
+                    }
+                };
+            }
+
+            return $key === 'clinic_id' ? 1 : null;
+        }
+    }
+
+    if (! function_exists('response')) {
+        function response()
+        {
+            return new class {
+                public function json($data)
+                {
+                    return $data;
+                }
+            };
+        }
+    }
+
+    class AgendamentoTest extends TestCase
+    {
+        public function test_professionals_route_returns_all_scheduled_professionals()
+        {
+            $escalas = collect([
+                (object) ['profissional_id' => 1, 'clinica_id' => 1, 'semana' => '2025-08-04', 'dia_semana' => 4],
+                (object) ['profissional_id' => 2, 'clinica_id' => 1, 'semana' => '2025-08-04', 'dia_semana' => 4],
+            ]);
+            \App\Models\EscalaTrabalho::setCollection($escalas);
+
+            $profissionais = collect([
+                (object) ['id' => 1, 'pessoa' => (object) ['primeiro_nome' => 'Dentista Um', 'sexo' => 'Feminino']],
+                (object) ['id' => 2, 'pessoa' => (object) ['primeiro_nome' => 'Dentista Dois', 'sexo' => 'Masculino']],
+            ]);
+            \App\Models\Profissional::setCollection($profissionais);
+
+            $controller = new AgendamentoController();
+            $request = new \Illuminate\Http\Request(['date' => '2025-08-07']);
+            $result = $controller->professionals($request);
+
+            $ids = array_column($result['professionals'], 'id');
+            sort($ids);
+
+            $this->assertSame([1, 2], $ids);
+        }
+    }
+
+    $test = new AgendamentoTest();
+    $test->test_professionals_route_returns_all_scheduled_professionals();
+    echo "Test passed\n";
+}
+

--- a/tests/Unit/stubs.php
+++ b/tests/Unit/stubs.php
@@ -165,7 +165,22 @@ namespace App\Models {
             return new self;
         }
 
+        public function join($table, $first, $operator, $second)
+        {
+            return $this;
+        }
+
+        public function where($field, $value)
+        {
+            return $this;
+        }
+
         public function whereIn($field, $values)
+        {
+            return $this;
+        }
+
+        public function distinct($field)
         {
             return $this;
         }


### PR DESCRIPTION
## Summary
- ensure agenda only lists professionals scheduled for the clinic and day
- hide "Todos os Profissionais" button when no schedules exist
- cover professionals route with feature test

## Testing
- `php tests/Unit/AgendamentoControllerTest.php`
- `php tests/Feature/AgendamentoTest.php`

------
https://chatgpt.com/codex/tasks/task_e_6893b4c87c9c832aa3ad81812629af7c