### PR TITLE
Fix syntax error in AgendamentoController cache logic

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -28,12 +28,17 @@ class AgendamentoController extends Controller
             $profIds = array_column($professionals, 'id');
 
             $cacheKey = "agendamentos_{$clinicId}_{$date}";
-            $agendamentos = Cache::remember($cacheKey, 60, function () use ($clinicId, $date, $profIds) {
-@@ -36,61 +34,57 @@ class AgendamentoController extends Controller
-                    ->whereDate('data', $date)
-                    ->whereIn('profissional_id', $profIds)
-                    ->get();
-            });
+            $agendamentos = Cache::remember(
+                $cacheKey,
+                60,
+                function () use ($clinicId, $date, $profIds) {
+                    return Agendamento::with(['paciente.pessoa'])
+                        ->where('clinica_id', $clinicId)
+                        ->whereDate('data', $date)
+                        ->whereIn('profissional_id', $profIds)
+                        ->get();
+                }
+            );
 
             foreach ($agendamentos as $ag) {
                 $pessoa = optional($ag->paciente)->pessoa;


### PR DESCRIPTION
## Summary
- restore AgendamentoController::index cache callback and remove stray diff markers

## Testing
- `php -l app/Http/Controllers/Admin/AgendamentoController.php`
- `composer install` *(fails: curl error 56 while downloading packages: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894b473a73c832abfd04e73792b57fd