### PR TITLE
Normalize salary parsing to handle thousand separators

### DIFF
--- a/app/Http/Controllers/Admin/ProfessionalController.php
+++ b/app/Http/Controllers/Admin/ProfessionalController.php
@@ -294,7 +294,9 @@ class ProfessionalController extends Controller
             'cargo' => $data['cargo'] ?? null,
             'cro' => $data['cro'] ?? null,
             'cro_uf' => $data['cro_uf'] ?? null,
-            'salario_fixo' => isset($data['salario_fixo']) ? str_replace(',', '.', str_replace('.', '', $data['salario_fixo'])) : null,
+            'salario_fixo' => isset($data['salario_fixo'])
+                ? str_replace(',', '.', preg_replace('/(?<=\\d)\.(?=\d{3}(?:\D|$))/', '', $data['salario_fixo']))
+                : null,
             'salario_periodo' => $data['salario_periodo'] ?? null,
             'comissoes' => $data['comissoes'] ?? null,
             'conta' => $data['conta'] ?? null,

--- a/tests/Unit/ProfessionalControllerTest.php
+++ b/tests/Unit/ProfessionalControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+require_once __DIR__.'/stubs.php';
+require_once __DIR__.'/../../app/Http/Controllers/Admin/ProfessionalController.php';
+
+use PHPUnit\Framework\TestCase;
+use App\Http\Controllers\Admin\ProfessionalController;
+
+class ProfessionalControllerTest extends TestCase
+{
+    private function extract(array $data): array
+    {
+        $controller = new ProfessionalController();
+        $reflection = new \ReflectionClass($controller);
+        $method = $reflection->getMethod('extractProfessionalData');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $data);
+    }
+
+    public function test_salary_without_thousands()
+    {
+        $result = $this->extract(['salario_fixo' => '1234,56']);
+        $this->assertSame('1234.56', $result['salario_fixo']);
+    }
+
+    public function test_salary_with_thousands()
+    {
+        $result = $this->extract(['salario_fixo' => '1.234,56']);
+        $this->assertSame('1234.56', $result['salario_fixo']);
+    }
+
+    public function test_salary_with_multiple_thousands()
+    {
+        $result = $this->extract(['salario_fixo' => '1.234.567,89']);
+        $this->assertSame('1234567.89', $result['salario_fixo']);
+    }
+}
+
+$test = new ProfessionalControllerTest();
+$test->test_salary_without_thousands();
+$test->test_salary_with_thousands();
+$test->test_salary_with_multiple_thousands();
+echo "Test passed\n";


### PR DESCRIPTION
## Summary
- ensure salary parsing removes only thousand separators and converts decimal comma to point
- add unit tests for salary parsing with and without thousands

## Testing
- `php tests/Unit/ProfessionalControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6894bc64c204832aad8b78691856afae