### PR TITLE
Restrict agenda to dentists scheduled for selected day

### DIFF
--- a/tests/Feature/AgendamentoTest.php
+++ b/tests/Feature/AgendamentoTest.php
@@ -107,10 +107,34 @@ namespace {
 
             $this->assertSame([1, 2], $ids);
         }
+
+        public function test_professionals_route_excludes_unscheduled_professionals()
+        {
+            $escalas = collect([
+                (object) ['profissional_id' => 1, 'clinica_id' => 1, 'semana' => '2025-08-04', 'dia_semana' => 4],
+            ]);
+            \App\Models\EscalaTrabalho::setCollection($escalas);
+
+            $profissionais = collect([
+                (object) ['id' => 1, 'pessoa' => (object) ['primeiro_nome' => 'Dentista Um', 'sexo' => 'Feminino']],
+                (object) ['id' => 2, 'pessoa' => (object) ['primeiro_nome' => 'Dentista Dois', 'sexo' => 'Masculino']],
+            ]);
+            \App\Models\Profissional::setCollection($profissionais);
+
+            $controller = new AgendamentoController();
+            $request = new \Illuminate\Http\Request(['date' => '2025-08-07']);
+            $result = $controller->professionals($request);
+
+            $ids = array_column($result['professionals'], 'id');
+            sort($ids);
+
+            $this->assertSame([1], $ids);
+        }
     }
 
     $test = new AgendamentoTest();
     $test->test_professionals_route_returns_all_scheduled_professionals();
-    echo "Test passed\n";
+    $test->test_professionals_route_excludes_unscheduled_professionals();
+    echo "Tests passed\n";
 }
 

--- a/tests/Unit/AgendamentoControllerTest.php
+++ b/tests/Unit/AgendamentoControllerTest.php
@@ -14,8 +14,8 @@ class AgendamentoControllerTest extends TestCase
         $date = '2024-05-20';
 
         $escalas = collect([
-            (object) ['profissional_id' => 1],
-            (object) ['profissional_id' => 2],
+            (object) ['profissional_id' => 1, 'clinica_id' => 1, 'semana' => '2024-05-20', 'dia_semana' => 1],
+            (object) ['profissional_id' => 2, 'clinica_id' => 1, 'semana' => '2024-05-20', 'dia_semana' => 1],
         ]);
 
         $profissionais = collect([
@@ -43,8 +43,44 @@ class AgendamentoControllerTest extends TestCase
 
         $this->assertSame([1, 2], $ids);
     }
+
+    public function test_professionals_for_date_excludes_unscheduled_professionals()
+    {
+        $clinicId = 1;
+        $date = '2024-05-20';
+
+        $escalas = collect([
+            (object) ['profissional_id' => 1, 'clinica_id' => 1, 'semana' => '2024-05-20', 'dia_semana' => 1],
+        ]);
+
+        $profissionais = collect([
+            (object) [
+                'id' => 1,
+                'pessoa' => (object) ['primeiro_nome' => 'Ana', 'sexo' => 'Feminino'],
+            ],
+            (object) [
+                'id' => 2,
+                'pessoa' => (object) ['primeiro_nome' => 'Bruno', 'sexo' => 'Masculino'],
+            ],
+        ]);
+
+        \App\Models\EscalaTrabalho::setCollection($escalas);
+        \App\Models\Profissional::setCollection($profissionais);
+
+        $controller = new AgendamentoController();
+        $reflection = new \ReflectionClass($controller);
+        $method = $reflection->getMethod('professionalsForDate');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($controller, $clinicId, $date);
+        $ids = array_column($result, 'id');
+        sort($ids);
+
+        $this->assertSame([1], $ids);
+    }
 }
 
 $test = new AgendamentoControllerTest();
 $test->test_professionals_for_date_returns_all_scheduled_professionals();
-echo "Test passed\n";
+$test->test_professionals_for_date_excludes_unscheduled_professionals();
+echo "Tests passed\n";

--- a/tests/Unit/stubs.php
+++ b/tests/Unit/stubs.php
@@ -91,6 +91,17 @@ namespace {
             return new self($mapped);
         }
 
+        public function filter(callable $callback): self
+        {
+            $filtered = [];
+            foreach ($this->items as $item) {
+                if ($callback($item)) {
+                    $filtered[] = $item;
+                }
+            }
+            return new self($filtered);
+        }
+
         public function values(): self
         {
             return new self(array_values($this->items));


### PR DESCRIPTION
## Summary
- filter available professionals by EscalaTrabalho entries matching clinic, week and weekday
- add tests ensuring only scheduled dentists are returned
- extend stubs to support collection filtering

## Testing
- `php tests/Unit/AgendamentoControllerTest.php`
- `php tests/Feature/AgendamentoTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6894c0ede188832ab3a61bdbc81e980a