### PR TITLE
Fix professionals lookup in agenda

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -63,8 +63,6 @@ class AgendamentoController extends Controller
         $ids = \App\Models\EscalaTrabalho::where('clinica_id', $clinicId)
             ->whereDate('semana', $weekStart)
             ->where('dia_semana', $day)
-            ->get()
-            ->filter(fn($e) => $e->semana == $weekStart && $e->dia_semana == $day)
             ->pluck('profissional_id')
             ->unique()
             ->toArray();


### PR DESCRIPTION
## Summary
- ensure professionals are returned when scheduled by removing faulty filter

## Testing
- `vendor/bin/phpunit` (fails: No such file)
- `composer install` (fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_6894e7b64858832a959650a173ee9846