### PR TITLE
Add separators between professional columns in schedule

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -216,7 +216,7 @@ window.renderSchedule = function (professionals, agenda, baseTimes) {
             professionals.forEach(p => {
                 theadRow.insertAdjacentHTML(
                     'beforeend',
-                    `<th class="p-2 bg-gray-50 text-left whitespace-nowrap">${p.name}</th>`
+                    `<th class="p-2 bg-gray-50 text-left whitespace-nowrap border-l">${p.name}</th>`
                 );
             });
         }
@@ -225,7 +225,7 @@ window.renderSchedule = function (professionals, agenda, baseTimes) {
             baseTimes.forEach(hora => {
                 let row = `<tr class="border-t" data-row="${hora}"><td class="bg-gray-50 w-24 min-w-[6rem] h-16 align-middle" data-slot="${hora}" data-hora="${hora}"><div class="h-full flex items-center justify-end px-2 text-xs text-gray-500 whitespace-nowrap">${hora}</div></td>`;
                 professionals.forEach(p => {
-                    row += `<td class="h-16 cursor-pointer" data-professional="${p.id}" data-time="${hora}" data-hora="${hora}">`;
+                    row += `<td class="h-16 cursor-pointer border-l" data-professional="${p.id}" data-time="${hora}" data-hora="${hora}">`;
                     const item = agenda[p.id] && agenda[p.id][hora];
                     if (item) {
                         let color = 'bg-gray-100 text-gray-700';

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -65,7 +65,7 @@
             <tr>
                 <th class="p-2 bg-gray-50 w-24 min-w-[6rem]"></th>
                 @foreach($professionals as $prof)
-                    <th class="p-2 bg-gray-50 text-left whitespace-nowrap">{{ $prof['name'] }}</th>
+                    <th class="p-2 bg-gray-50 text-left whitespace-nowrap border-l">{{ $prof['name'] }}</th>
                 @endforeach
             </tr>
         </thead>
@@ -74,7 +74,7 @@
                 <tr class="border-t" data-row="{{ $hora }}">
                     <td class="bg-gray-50 w-24 min-w-[6rem] h-16 align-middle" data-slot="{{ $hora }}" data-hora="{{ $hora }}"><x-agenda.horario :time="$hora" /></td>
                     @foreach($professionals as $prof)
-                        <td class="h-16 cursor-pointer" data-professional="{{ $prof['id'] }}" data-time="{{ $hora }}" data-hora="{{ $hora }}">
+                        <td class="h-16 cursor-pointer border-l" data-professional="{{ $prof['id'] }}" data-time="{{ $hora }}" data-hora="{{ $hora }}">
                             @isset($agenda[$prof['id']][$hora])
                                 @php $item = $agenda[$prof['id']][$hora]; @endphp
                                 <x-agenda.agendamento :paciente="$item['paciente']" :tipo="$item['tipo']" :contato="$item['contato']" :status="$item['status']" />

--- a/resources/views/portal/agendamentos.blade.php
+++ b/resources/views/portal/agendamentos.blade.php
@@ -90,7 +90,7 @@
             <tr>
                 <th class="p-2 bg-gray-50 w-20"></th>
                 @foreach($professionals as $prof)
-                    <th class="p-2 bg-gray-50 text-left whitespace-nowrap">{{ $prof['name'] }}</th>
+                    <th class="p-2 bg-gray-50 text-left whitespace-nowrap border-l">{{ $prof['name'] }}</th>
                 @endforeach
             </tr>
         </thead>
@@ -99,7 +99,7 @@
                 <tr class="border-t">
                     <td class="bg-gray-50 w-20"><x-agenda.horario :time="$hora"/></td>
                     @foreach($professionals as $prof)
-                        <td class="w-40 h-16">
+                        <td class="w-40 h-16 border-l">
                             @isset($agenda[$prof['id']][$hora])
                                 @php $item = $agenda[$prof['id']][$hora]; @endphp
                                 <x-agenda.agendamento :paciente="$item['paciente']" :tipo="$item['tipo']" :contato="$item['contato']" :status="$item['status']" />


### PR DESCRIPTION
## Summary
- add left border to schedule columns so multiple professionals are visually separated
- apply same styling in dynamic JS renderer for agenda tables

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed to open required '/workspace/dentix/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6894ec208f94832a8b7d082b77612cdb