### PR TITLE
Fix schedule modal triggering on double click

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -607,11 +607,18 @@ document.addEventListener('DOMContentLoaded', () => {
         document.addEventListener('mouseup', e => {
             if (!dragging) return;
             dragging = false;
-            if (selection.start && selection.end && e.target.closest('#schedule-table')) {
+
+            if (suppressClick && selection.start === selection.end) {
+                setTimeout(() => { suppressClick = false; }, 0);
+                return;
+            }
+
+            if (selection.start && selection.end && selection.start !== selection.end && e.target.closest('#schedule-table')) {
                 openModal();
             } else {
                 clearSelection();
             }
+
             setTimeout(() => { suppressClick = false; }, 0);
         });
 


### PR DESCRIPTION
## Summary
- prevent mouseup from opening the schedule modal when a double click is in progress
- only open the modal after a valid drag selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6894f83afe14832ab3e34fb9303c4440