### PR TITLE
feat(schedule): allow opening modal from grid

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -514,7 +514,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return true;
         };
 
-        const openModal = () => {
+        const abrirModalAgendamento = () => {
             const root = document.querySelector('[x-data]');
             const date = root?.__x?.$data?.selectedDate || '';
 
@@ -541,6 +541,8 @@ document.addEventListener('DOMContentLoaded', () => {
             scheduleModal.dataset.time = selection.start || '';
             scheduleModal.classList.remove('hidden');
         };
+
+        window.abrirModalAgendamento = abrirModalAgendamento;
 
         const attachCellHandlers = () => {
             document.querySelectorAll('#schedule-table td[data-professional]').forEach(td => {
@@ -574,7 +576,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const end = addMinutes(start, 30);
                     if (!selectRange(prof, start, end)) return;
                     suppressClick = true;
-                    openModal();
+                    abrirModalAgendamento();
                     setTimeout(() => { suppressClick = false; }, 0);
                 });
 
@@ -604,7 +606,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             return;
                         }
                         if (!selectRange(prof, selection.start, time)) return;
-                        openModal();
+                        abrirModalAgendamento();
                         return;
                     }
 
@@ -633,7 +635,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             if (selection.start && selection.end && selection.start !== selection.end && e.target.closest('#schedule-table')) {
-                openModal();
+                abrirModalAgendamento();
             } else {
                 clearSelection();
             }


### PR DESCRIPTION
## Summary
- expose `abrirModalAgendamento` to open scheduling modal and fill fields
- trigger modal on double click or drag selection in schedule grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fdd382a0832a9a4f3182e8699250