### PR TITLE
Fix schedule modal date retrieval

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -522,7 +522,7 @@ document.addEventListener('DOMContentLoaded', () => {
         };
 
         const abrirModalAgendamento = () => {
-            const root = document.querySelector('[x-data]');
+            const root = scheduleModal.closest('[x-data]');
             const date = root?.__x?.$data?.selectedDate || '';
 
             // ensure times are filled – default end is start + 30min


### PR DESCRIPTION
## Summary
- Ensure schedule modal reads the selected date from its own Alpine component
- Confirm modal visibility by relying on Tailwind's `hidden` class only

## Testing
- `npm run build`
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6895d91be75c832ab5a7303415e39bb2