### PR TITLE
Ensure schedule modal persists during calendar updates

### DIFF
--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -86,7 +86,7 @@
         </tbody>
     </table>
 </div>
-<div id="schedule-modal" data-time="" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
+<div x-ignore id="schedule-modal" data-time="" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
     <div class="bg-white rounded p-4 w-[32rem]">
         <h2 class="text-lg font-semibold mb-2">Agendar Horário</h2>
         <p id="schedule-summary" class="text-sm text-gray-600 mb-4"></p>


### PR DESCRIPTION
## Summary
- add `x-ignore` to `#schedule-modal` so Alpine won't remove it during calendar refreshes

## Testing
- `composer install` *(fails: curl error 56; CONNECT tunnel failed)*
- `phpunit` *(fails: command not found)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `npm run build`
- Verified in Node console that `schedule-modal` remains after rendering schedule


------
https://chatgpt.com/codex/tasks/task_e_6895da10e010832a966db5a0da6b082b