### PR TITLE
Avoid clearing selection when clicking inside schedule modal

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -407,13 +407,25 @@ function attachCellHandlers() {
     handleClick = e => {
         if (suppressClick || e.detail > 1) {
             if (selection.start && !e.target.closest('#schedule-table')) {
-                clearSelection();
+                if (!scheduleModal || !scheduleModal.contains(e.target)) {
+                    const profVal = professionalInput?.value;
+                    const summaryText = summary?.textContent;
+                    clearSelection();
+                    if (professionalInput) professionalInput.value = profVal;
+                    if (summary) summary.textContent = summaryText;
+                }
             }
             return;
         }
         const cell = e.target.closest('#schedule-table td[data-professional]');
         if (!cell) {
-            if (selection.start) clearSelection();
+            if (selection.start && (!scheduleModal || !scheduleModal.contains(e.target))) {
+                const profVal = professionalInput?.value;
+                const summaryText = summary?.textContent;
+                clearSelection();
+                if (professionalInput) professionalInput.value = profVal;
+                if (summary) summary.textContent = summaryText;
+            }
             return;
         }
         const time = cell.dataset.time;


### PR DESCRIPTION
## Summary
- Only clear schedule selection when clicks are outside both the table and modal
- Preserve professional and summary inputs when selection is cleared

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68961e13169c832a907147551db73d45