### PR TITLE
Defer schedule handler setup until DOM ready

### DIFF
--- a/resources/js/__tests__/schedule.test.js
+++ b/resources/js/__tests__/schedule.test.js
@@ -34,6 +34,7 @@ describe('schedule selection', () => {
     buildDom();
     global.alert = vi.fn();
     await import('../app.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
   });
 
   it('opens modal with 30min duration on double click', () => {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -489,7 +489,7 @@ function attachCellHandlers() {
 }
 
 window.attachCellHandlers = attachCellHandlers;
-attachCellHandlers();
+document.addEventListener('DOMContentLoaded', attachCellHandlers);
 document.addEventListener('schedule:rendered', attachCellHandlers);
 
 Alpine.start();

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,25 +1,24 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" x-data="{ sidebarCollapsed: JSON.parse(localStorage.getItem('sidebarCollapsed') ?? 'false') }" x-init="$watch('sidebarCollapsed', val => localStorage.setItem('sidebarCollapsed', val))" class="h-full">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>{{ config('app.name') }}</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-    <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-    <script>
-        document.addEventListener('alpine:init', () => {
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+        <title>{{ config('app.name') }}</title>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+        <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+        <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
+        <script>
+            document.addEventListener('alpine:init', () => {
 
         });
         document.addEventListener('DOMContentLoaded', () => {
 
         });
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head>
-<body class="flex h-screen bg-gray-100">
+        </script>
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    </head>
+    <body class="flex h-screen bg-gray-100">
     @auth
         @unless(isset($hideNav) && $hideNav)
             <aside :class="sidebarCollapsed ? 'w-20' : 'w-64'" class="h-screen bg-white border-r shadow transition-all duration-300 overflow-y-auto">
@@ -43,6 +42,7 @@
             @yield('content')
         </main>
     </div>
-    @stack('scripts')
-</body>
-</html>
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @stack('scripts')
+    </body>
+    </html>


### PR DESCRIPTION
## Summary
- Delay attaching schedule cell handlers until `DOMContentLoaded` and re-bind on `schedule:rendered`
- Dispatch DOMContentLoaded in tests after importing script
- Load Vite assets at end of layout body to avoid early execution

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68962a2b46ac832a8c10e5b79d0904f4