### PR TITLE
Fix missing appointment type when saving schedule

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -141,11 +141,15 @@ class AgendamentoController extends Controller
             'data' => 'required|date',
             'hora_inicio' => 'required',
             'hora_fim' => 'required',
+            'tipo' => 'nullable|string',
+            'contato' => 'nullable|string',
             'observacao' => 'nullable|string',
         ]);
 
         $data['clinica_id'] = $clinicId;
         $data['status'] = 'confirmado';
+        $data['tipo'] = $data['tipo'] ?? 'Consulta';
+        $data['contato'] = $data['contato'] ?? '';
 
         Agendamento::create($data);
         $cacheKey = "agendamentos_{$clinicId}_" . Carbon::parse($data['data'])->format('Y-m-d');


### PR DESCRIPTION
## Summary
- default appointment type and contact when saving a schedule

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689634974eb0832aabaa1c5a9bb1c8b0