### PR TITLE
Ensure schedule click suppression resets immediately

### DIFF
--- a/resources/js/__tests__/schedule.test.js
+++ b/resources/js/__tests__/schedule.test.js
@@ -51,12 +51,11 @@ describe('schedule selection', () => {
     expect(document.getElementById('schedule-end').value).toBe('09:30');
   });
 
-  it('opens modal with correct start and end after two clicks', async () => {
+  it('opens modal with correct start and end after two clicks', () => {
     const first = document.querySelector('#schedule-table td[data-professional="1"][data-time="09:00"]');
     first.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     first.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    await new Promise(r => setTimeout(r, 0));
 
     const second = document.querySelector('#schedule-table td[data-professional="1"][data-time="10:00"]');
     second.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -412,7 +412,21 @@ function attachCellHandlers() {
 
     handleClick = e => {
         const cell = e.target.closest('#schedule-table td[data-professional]');
-        if (suppressClick || (e.detail > 1 && cell === lastClickedCell)) {
+
+        if (suppressClick) {
+            // Skip the suppressed click (typically the first cell click)
+            // but immediately clear the flag so the next click is handled.
+            suppressClick = false;
+            lastClickedCell = cell;
+            if (selection.start && !e.target.closest('#schedule-table')) {
+                if (!scheduleModal || !scheduleModal.contains(e.target)) {
+                    clearSelection(true);
+                }
+            }
+            return;
+        }
+
+        if (e.detail > 1 && cell === lastClickedCell) {
             if (selection.start && !e.target.closest('#schedule-table')) {
                 if (!scheduleModal || !scheduleModal.contains(e.target)) {
                     clearSelection(true);
@@ -481,7 +495,9 @@ function attachCellHandlers() {
             clearSelection();
         }
 
-        setTimeout(() => { suppressClick = false; }, 0);
+        // Do not rely on a delayed reset; handleClick will clear the
+        // suppression on the next click so that subsequent clicks are
+        // processed immediately.
     };
 
     document.addEventListener('mousedown', handleMouseDown);


### PR DESCRIPTION
## Summary
- Reset `suppressClick` at the start of `handleClick` so second cell clicks open scheduling modal with stored start time
- Drop asynchronous `suppressClick` reset in `handleMouseUp`
- Streamline schedule selection test to verify consecutive clicks without delay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965de0d81c832a93513747b5f55e03