### PR TITLE
fix: center login without overflow

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="flex items-center justify-center min-h-screen py-10">
+<div class="flex items-center justify-center min-h-full">
     <div class="w-full max-w-4xl bg-white shadow-lg rounded-xl overflow-hidden flex flex-col md:flex-row">
         <div class="hidden md:flex md:w-1/2 items-center justify-center bg-gradient-to-br from-primary to-indigo-600 p-10 text-white">
             <div>


### PR DESCRIPTION
## Summary
- avoid scroll on login by using `min-h-full`

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68965f141e9c832a8b21eec34f4e9bfb