### PR TITLE
refactor: add data attributes for schedule

### DIFF
--- a/resources/js/__tests__/schedule.test.js
+++ b/resources/js/__tests__/schedule.test.js
@@ -6,7 +6,7 @@ vi.mock('@alpinejs/collapse', () => ({ default: {} }));
 
 const buildDom = () => {
   document.body.innerHTML = `
-    <div id="schedule-modal" class="hidden">
+    <div id="schedule-modal" class="hidden" data-hora="" data-date="">
       <input id="schedule-start" />
       <input id="schedule-end" />
       <input id="schedule-professional" />
@@ -22,12 +22,12 @@ const buildDom = () => {
     </div>
     <table id="schedule-table">
       <thead>
-        <tr><th data-professional="1">Prof 1</th></tr>
+        <tr><th data-professional-id="1">Prof 1</th></tr>
       </thead>
       <tbody>
-        <tr data-row="09:00"><td data-slot="09:00"></td><td data-professional="1" data-time="09:00" data-hora="09:00"></td></tr>
-        <tr data-row="09:30"><td data-slot="09:30"></td><td data-professional="1" data-time="09:30" data-hora="09:30"></td></tr>
-        <tr data-row="10:00"><td data-slot="10:00"></td><td data-professional="1" data-time="10:00" data-hora="10:00"></td></tr>
+        <tr data-row="09:00"><td data-slot="09:00"></td><td data-professional-id="1" data-hora="09:00" data-date="2024-01-01"></td></tr>
+        <tr data-row="09:30"><td data-slot="09:30"></td><td data-professional-id="1" data-hora="09:30" data-date="2024-01-01"></td></tr>
+        <tr data-row="10:00"><td data-slot="10:00"></td><td data-professional-id="1" data-hora="10:00" data-date="2024-01-01"></td></tr>
       </tbody>
     </table>
   `;
@@ -43,7 +43,7 @@ describe('schedule selection', () => {
   });
 
   it('opens modal with 30min duration on double click', () => {
-    const cell = document.querySelector('#schedule-table td[data-professional="1"][data-time="09:00"]');
+    const cell = document.querySelector('#schedule-table td[data-professional-id="1"][data-hora="09:00"]');
     cell.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
     const modal = document.getElementById('schedule-modal');
     expect(modal.classList.contains('hidden')).toBe(false);
@@ -52,12 +52,12 @@ describe('schedule selection', () => {
   });
 
   it('opens modal with correct start and end after two clicks', () => {
-    const first = document.querySelector('#schedule-table td[data-professional="1"][data-time="09:00"]');
+    const first = document.querySelector('#schedule-table td[data-professional-id="1"][data-hora="09:00"]');
     first.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     first.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
-    const second = document.querySelector('#schedule-table td[data-professional="1"][data-time="10:00"]');
+    const second = document.querySelector('#schedule-table td[data-professional-id="1"][data-hora="10:00"]');
     second.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     second.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     second.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -69,7 +69,7 @@ describe('schedule selection', () => {
   });
 
   it('keeps professional info after interacting with modal fields', () => {
-    const cell = document.querySelector('#schedule-table td[data-professional="1"][data-time="09:00"]');
+    const cell = document.querySelector('#schedule-table td[data-professional-id="1"][data-hora="09:00"]');
     cell.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
 
     const profInput = document.getElementById('schedule-professional');

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -65,7 +65,7 @@
             <tr>
                 <th class="p-2 bg-gray-50 w-24 min-w-[6rem]"></th>
                 @foreach($professionals as $prof)
-                    <th class="p-2 bg-gray-50 text-left whitespace-nowrap border-l" data-professional="{{ $prof['id'] }}">{{ $prof['name'] }}</th>
+                    <th class="p-2 bg-gray-50 text-left whitespace-nowrap border-l" data-professional-id="{{ $prof['id'] }}">{{ $prof['name'] }}</th>
                 @endforeach
             </tr>
         </thead>
@@ -74,7 +74,7 @@
                 <tr class="border-t" data-row="{{ $hora }}">
                     <td class="bg-gray-50 w-24 min-w-[6rem] h-16 align-middle" data-slot="{{ $hora }}" data-hora="{{ $hora }}"><x-agenda.horario :time="$hora" /></td>
                     @foreach($professionals as $prof)
-                        <td class="h-16 cursor-pointer border-l" data-professional="{{ $prof['id'] }}" data-time="{{ $hora }}" data-hora="{{ $hora }}">
+                        <td class="h-16 cursor-pointer border-l" data-professional-id="{{ $prof['id'] }}" data-hora="{{ $hora }}" data-date="{{ $date }}">
                             @isset($agenda[$prof['id']][$hora])
                                 @php $item = $agenda[$prof['id']][$hora]; @endphp
                                 <x-agenda.agendamento :paciente="$item['paciente']" :tipo="$item['tipo']" :contato="$item['contato']" :status="$item['status']" />
@@ -86,7 +86,7 @@
         </tbody>
     </table>
 </div>
-<div x-ignore id="schedule-modal" data-time="" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
+<div x-ignore id="schedule-modal" data-hora="" data-date="" class="fixed inset-0 bg-black/50 hidden flex items-center justify-center z-50">
     <div class="bg-white rounded p-4 w-[32rem]">
         <h2 class="text-lg font-semibold mb-2">Agendar Horário</h2>
         <p id="schedule-summary" class="text-sm text-gray-600 mb-4"></p>


### PR DESCRIPTION
## Summary
- include `data-date` and `data-professional-id` attributes in schedule view
- use `dataset.date`, `dataset.hora`, and `dataset.professionalId` in calendar scripts
- update schedule tests for new data attributes

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68965f38d8dc832a840b0f63ce0dd2d1