### PR TITLE
Centraliza card na tela de login

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="flex items-center justify-center min-h-full">
+<div class="flex items-center justify-center min-h-screen">
     <div class="w-full max-w-4xl bg-white shadow-lg rounded-xl overflow-hidden flex flex-col md:flex-row">
         <div class="hidden md:flex md:w-1/2 items-center justify-center bg-gradient-to-br from-primary to-indigo-600 p-10 text-white">
             <div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -32,7 +32,7 @@
                 @include('partials.topbar')
             @endunless
         @endauth
-        <main class="flex-1 p-6 overflow-y-auto">
+        <main class="flex-1 overflow-y-auto @auth p-6 @endauth">
             @if ($errors->any() && !(isset($hideErrors) && $hideErrors))
                 @include('components.alert-error', ['slot' => $errors->first()])
             @endif


### PR DESCRIPTION
## Summary
- centraliza o card de login usando `min-h-screen`
- remove padding da área principal para usuários não autenticados

## Testing
- `php artisan test` *(falha: Failed opening required '/workspace/dentix/vendor/autoload.php')*
- `composer install` *(falha: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `npm test` *(falha: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970cc06490832aba1ea694868ea4b0