### PR TITLE
Refine patient search with database query

### DIFF
--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use App\Traits\BelongsToOrganization;
 use App\Models\Usuario;
 use App\Models\Pessoa;
+use App\Models\Clinic;
 
 class Patient extends Model
 {
@@ -41,5 +42,10 @@ class Patient extends Model
     public function pessoa()
     {
         return $this->belongsTo(Pessoa::class);
+    }
+
+    public function clinicas()
+    {
+        return $this->belongsToMany(Clinic::class, 'clinica_paciente', 'paciente_id', 'clinica_id')->withTimestamps();
     }
 }


### PR DESCRIPTION
## Summary
- Replace in-memory patient filtering with SQL query using normalized name, email, phone, and CPF fields
- Limit results to the active clinic and order by relevance, returning at most ten entries
- Add `clinicas` relationship on Patient model for clinic scoping

## Testing
- `composer install --no-progress --no-interaction` (failed: CONNECT tunnel failed, response 403)
- `php tests/Feature/PatientSearchTest.php` (failed: Call to undefined method App\Models\Patient::query())

------
https://chatgpt.com/codex/tasks/task_e_689712c6400c832a9edfa5037d9d74b5