### PR TITLE
Trigger patient creation modal from schedule search

### DIFF
--- a/resources/js/__tests__/schedule.test.js
+++ b/resources/js/__tests__/schedule.test.js
@@ -116,5 +116,21 @@ describe('schedule selection', () => {
     expect(document.getElementById('schedule-paciente-id').value).toBe('1');
     vi.useRealTimers();
   });
+
+  it('calls abrirModalPaciente when clicking create new', async () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn(window, 'abrirModalPaciente');
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve([]) })
+    );
+    const input = document.getElementById('schedule-paciente');
+    input.value = 'Jo';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await vi.runAllTimersAsync();
+    const btn = document.getElementById('create-paciente-btn');
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(spy).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
 });
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -356,6 +356,15 @@ const abrirModalAgendamento = () => {
 };
 window.abrirModalAgendamento = abrirModalAgendamento;
 
+const abrirModalPaciente = () => {
+    const modal = document.getElementById('paciente-modal');
+    if (modal) {
+        modal.classList.remove('hidden');
+    }
+    window.dispatchEvent(new CustomEvent('abrirModalPaciente'));
+};
+window.abrirModalPaciente = abrirModalPaciente;
+
 const openScheduleModal = (prof, start, end, date) => {
     if (!selectRange(date, prof, start, end)) return;
 
@@ -766,7 +775,14 @@ document.addEventListener('DOMContentLoaded', () => {
                                 pacienteList.innerHTML = `<li class="px-2 py-1 text-sm text-gray-600">Nenhum paciente encontrado. <button type="button" id="create-paciente-btn" class="text-primary underline">Criar novo?</button></li>`;
                                 pacienteList.classList.remove('hidden');
                                 const btn = document.getElementById('create-paciente-btn');
-                                if (btn) btn.addEventListener('click', () => { if (createUrl) window.location.href = createUrl; });
+                                if (btn) btn.addEventListener('click', () => {
+                                    pacienteList.classList.add('hidden');
+                                    if (typeof window.abrirModalPaciente === 'function') {
+                                        window.abrirModalPaciente();
+                                    } else {
+                                        window.dispatchEvent(new CustomEvent('abrirModalPaciente'));
+                                    }
+                                });
                                 return;
                             }
                             data.slice(0, 10).forEach(p => {


### PR DESCRIPTION
## Summary
- expose global `abrirModalPaciente` helper to show patient creation modal
- call patient creation modal instead of redirect when no search results
- cover `Criar novo?` button with a unit test

## Testing
- `npm test`
- `composer install --no-interaction --no-progress` *(fails: curl error 56: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68971896f660832aba10a7f41dc2e7d2