### PR TITLE
Handle missing intl extension in PatientController normalization

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Normalizer;
 
 class PatientController extends Controller
 {
@@ -171,7 +170,12 @@ class PatientController extends Controller
 
     private function normalize(string $value): string
     {
-        $normalized = Normalizer::normalize($value, Normalizer::FORM_D);
+        if (! class_exists('Normalizer')) {
+            logger()->warning('Intl extension not loaded; using ASCII fallback for normalization.');
+            return (string) Str::of($value)->ascii()->lower();
+        }
+
+        $normalized = \Normalizer::normalize($value, \Normalizer::FORM_D);
         $withoutAccents = preg_replace('/\pM/u', '', $normalized);
         return mb_strtolower($withoutAccents);
     }


### PR DESCRIPTION
## Summary
- Use ASCII fallback when PHP intl Normalizer class is missing
- Log a warning if intl extension is unavailable during patient search normalization

## Testing
- `php -l app/Http/Controllers/Admin/PatientController.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68971fad63b8832ab5215785cd39d62d