### PR TITLE
Normalize schedule selection end slot

### DIFF
--- a/resources/js/__tests__/schedule.test.js
+++ b/resources/js/__tests__/schedule.test.js
@@ -81,7 +81,24 @@ describe('schedule selection', () => {
     const modal = document.getElementById('schedule-modal');
     expect(modal.classList.contains('hidden')).toBe(false);
     expect(document.getElementById('schedule-start').value).toBe('09:00');
-    expect(document.getElementById('schedule-end').value).toBe('10:00');
+    expect(document.getElementById('schedule-end').value).toBe('10:30');
+  });
+
+  it('normalizes selection when clicks are in reverse order', () => {
+    const first = document.querySelector('#schedule-table td[data-professional-id="1"][data-hora="10:00"]');
+    first.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    first.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const second = document.querySelector('#schedule-table td[data-professional-id="1"][data-hora="09:00"]');
+    second.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    second.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    second.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const modal = document.getElementById('schedule-modal');
+    expect(modal.classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('schedule-start').value).toBe('09:00');
+    expect(document.getElementById('schedule-end').value).toBe('10:30');
   });
 
   it('clears selection when second click has different date', () => {


### PR DESCRIPTION
## Summary
- compute slot duration dynamically and use second click to set end = slot start + duration
- normalize reversed selections to ensure correct start/end order
- extend schedule selection tests for new behaviour

## Testing
- `npm test`
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68987048e16c832aafeba023e9ffbbf4