### PR TITLE
Guard patient digit searches when query lacks numbers

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -111,10 +111,13 @@ class PatientController extends Controller
         $patients = Patient::with('pessoa')
             ->whereHas('pessoa', function ($query) use ($normalized, $q, $digits) {
                 $query->where('normalized_name', 'like', "%$normalized%")
-                    ->orWhere('email', 'like', "%$q%")
-                    ->orWhere('digits_cpf', 'like', "%$digits%")
-                    ->orWhere('digits_phone', 'like', "%$digits%")
-                    ->orWhere('digits_whatsapp', 'like', "%$digits%");
+                    ->orWhere('email', 'like', "%$q%");
+
+                if ($digits !== '') {
+                    $query->orWhere('digits_cpf', 'like', "%$digits%")
+                        ->orWhere('digits_phone', 'like', "%$digits%")
+                        ->orWhere('digits_whatsapp', 'like', "%$digits%");
+                }
             })
             ->limit(10)
             ->get();

--- a/tests/Feature/PatientSearchTest.php
+++ b/tests/Feature/PatientSearchTest.php
@@ -15,21 +15,9 @@ namespace App\Models {
             $this->results = $patients;
         }
 
-        public function join($table, $first, $operator, $second): self
+        public function whereHas($relation, $callback): self
         {
-            return $this;
-        }
-
-        public function select($columns): self
-        {
-            return $this;
-        }
-
-        public function when($value, $callback): self
-        {
-            if ($value) {
-                $callback($this);
-            }
+            $callback($this);
             return $this;
         }
 
@@ -40,11 +28,11 @@ namespace App\Models {
                 return $this;
             }
 
-            if ($field === 'pessoas.normalized_name' && $operator === 'like') {
+            if ($field === 'normalized_name' && $operator === 'like') {
                 $term = trim($value, '%');
                 $matchStarts = !str_starts_with($value, '%');
                 $matches = array_filter($this->base, function ($p) use ($term, $matchStarts) {
-                    $name = $p->normalized_name;
+                    $name = $p->pessoa->normalized_name;
                     return $matchStarts ? str_starts_with($name, $term) : str_contains($name, $term);
                 });
                 $this->results = $matches;
@@ -56,61 +44,27 @@ namespace App\Models {
 
         public function orWhere($field, $operator = null, $value = null): self
         {
-            if ($field === 'pessoas.normalized_name' && $operator === 'like') {
+            if ($field === 'email' && $operator === 'like') {
                 $term = trim($value, '%');
-                $matchStarts = !str_starts_with($value, '%');
-                $matches = array_filter($this->base, function ($p) use ($term, $matchStarts) {
-                    $name = $p->normalized_name;
-                    return $matchStarts ? str_starts_with($name, $term) : str_contains($name, $term);
-                });
+                $matches = array_filter($this->base, fn($p) => str_contains($p->pessoa->email ?? '', $term));
                 $this->results = array_values(array_unique(array_merge($this->results, $matches), SORT_REGULAR));
-                $this->usedIndexes[] = 'pessoas_normalized_name_index';
-            } elseif ($field === 'pessoas.digits_phone' && $operator === 'like') {
+            } elseif ($field === 'digits_phone' && $operator === 'like') {
                 $term = trim($value, '%');
-                $matches = array_filter($this->base, function ($p) use ($term) {
-                    return str_contains($p->digits_phone, $term);
-                });
+                $matches = array_filter($this->base, fn($p) => str_contains($p->pessoa->digits_phone, $term));
                 $this->results = array_values(array_unique(array_merge($this->results, $matches), SORT_REGULAR));
                 $this->usedIndexes[] = 'pessoas_digits_phone_index';
-            } elseif ($field === 'pessoas.digits_whatsapp' && $operator === 'like') {
+            } elseif ($field === 'digits_whatsapp' && $operator === 'like') {
                 $term = trim($value, '%');
-                $matches = array_filter($this->base, function ($p) use ($term) {
-                    return str_contains($p->digits_whatsapp, $term);
-                });
+                $matches = array_filter($this->base, fn($p) => str_contains($p->pessoa->digits_whatsapp, $term));
                 $this->results = array_values(array_unique(array_merge($this->results, $matches), SORT_REGULAR));
                 $this->usedIndexes[] = 'pessoas_digits_whatsapp_index';
-            } elseif ($field === 'pessoas.digits_cpf' && $operator === 'like') {
+            } elseif ($field === 'digits_cpf' && $operator === 'like') {
                 $term = trim($value, '%');
-                $matches = array_filter($this->base, function ($p) use ($term) {
-                    return str_contains($p->digits_cpf, $term);
-                });
+                $matches = array_filter($this->base, fn($p) => str_contains($p->pessoa->digits_cpf, $term));
                 $this->results = array_values(array_unique(array_merge($this->results, $matches), SORT_REGULAR));
                 $this->usedIndexes[] = 'pessoas_digits_cpf_index';
-            } elseif ($field === 'pacientes.id') {
-                $matches = array_filter($this->base, fn($p) => $p->id == $operator);
-                $this->results = array_values(array_unique(array_merge($this->results, $matches), SORT_REGULAR));
             }
 
-            return $this;
-        }
-
-        public function orWhereRaw($sql, $bindings): self
-        {
-            $matches = [];
-            if (str_contains($sql, 'pessoas.email')) {
-                $pattern = $bindings[0];
-                $term = str_replace('%', '', $pattern);
-                $matches = array_filter($this->base, function ($p) use ($term) {
-                    $email = self::normalizeValue($p->email ?? '');
-                    return str_contains($email, $term);
-                });
-            }
-            $this->results = array_values(array_unique(array_merge($this->results, $matches), SORT_REGULAR));
-            return $this;
-        }
-
-        public function orderByRaw($sql, $bindings): self
-        {
             return $this;
         }
 
@@ -122,13 +76,6 @@ namespace App\Models {
         public function get($columns = ['*'])
         {
             return collect($this->results);
-        }
-
-        private static function normalizeValue(string $value): string
-        {
-            $normalized = Normalizer::normalize($value, Normalizer::FORM_D);
-            $withoutAccents = preg_replace('/\pM/u', '', $normalized);
-            return mb_strtolower($withoutAccents);
         }
     }
 
@@ -142,7 +89,7 @@ namespace App\Models {
             self::$collection = $patients;
         }
 
-        public static function query(): PatientQuery
+        public static function with($relation): PatientQuery
         {
             self::$lastQuery = new PatientQuery(self::$collection);
             return self::$lastQuery;
@@ -160,7 +107,7 @@ namespace Illuminate\Http {
             $this->query = $query;
         }
 
-        public function get($key, $default = null)
+        public function query($key = null, $default = null)
         {
             return $this->query[$key] ?? $default;
         }
@@ -182,12 +129,46 @@ namespace Illuminate\Support\Facades {
     }
 }
 
+namespace Illuminate\Support {
+    class Str
+    {
+        public static function of($value)
+        {
+            return new class($value) {
+                private string $value;
+                public function __construct($value)
+                {
+                    $this->value = $value;
+                }
+
+                public function ascii()
+                {
+                    $this->value = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $this->value);
+                    return $this;
+                }
+
+                public function lower()
+                {
+                    $this->value = mb_strtolower($this->value);
+                    return $this;
+                }
+
+                public function __toString()
+                {
+                    return $this->value;
+                }
+            };
+        }
+    }
+}
+
 namespace {
     require_once __DIR__.'/../Unit/stubs.php';
     require_once __DIR__.'/../../app/Http/Controllers/Admin/PatientController.php';
 
     use PHPUnit\Framework\TestCase;
     use App\Http\Controllers\Admin\PatientController;
+    use App\Models\Patient;
 
     if (! function_exists('response')) {
         function response()
@@ -205,7 +186,7 @@ namespace {
     {
         private function makePatient(array $attributes)
         {
-            $base = [
+            $defaults = [
                 'id' => 1,
                 'primeiro_nome' => 'John',
                 'nome_meio' => null,
@@ -215,75 +196,115 @@ namespace {
                 'cpf' => '',
                 'email' => null,
             ];
-            $p = (object) array_merge($base, $attributes);
-            $name = trim($p->primeiro_nome . ' ' . ($p->nome_meio ? $p->nome_meio . ' ' : '') . $p->ultimo_nome);
-            $p->normalized_name = Normalizer::normalize($name, Normalizer::FORM_D);
-            $p->normalized_name = preg_replace('/\pM/u', '', $p->normalized_name);
-            $p->normalized_name = mb_strtolower($p->normalized_name);
-            $p->digits_phone = preg_replace('/\D/', '', $p->phone);
-            $p->digits_whatsapp = preg_replace('/\D/', '', $p->whatsapp);
-            $p->digits_cpf = preg_replace('/\D/', '', $p->cpf);
-            return $p;
+            $data = array_merge($defaults, $attributes);
+            $pessoa = (object) [
+                'primeiro_nome' => $data['primeiro_nome'],
+                'nome_meio' => $data['nome_meio'],
+                'ultimo_nome' => $data['ultimo_nome'],
+                'phone' => $data['phone'],
+                'whatsapp' => $data['whatsapp'],
+                'cpf' => $data['cpf'],
+                'email' => $data['email'],
+            ];
+            $name = trim($pessoa->primeiro_nome . ' ' . ($pessoa->nome_meio ? $pessoa->nome_meio . ' ' : '') . $pessoa->ultimo_nome);
+            $pessoa->full_name = $name;
+            $normalized = Normalizer::normalize($name, Normalizer::FORM_D);
+            $normalized = preg_replace('/\pM/u', '', $normalized);
+            $pessoa->normalized_name = mb_strtolower($normalized);
+            $pessoa->digits_phone = preg_replace('/\D/', '', $pessoa->phone);
+            $pessoa->digits_whatsapp = preg_replace('/\D/', '', $pessoa->whatsapp);
+            $pessoa->digits_cpf = preg_replace('/\D/', '', $pessoa->cpf);
+            $patient = (object) ['id' => $data['id'], 'pessoa' => $pessoa];
+            return $patient;
         }
 
-        public function test_search_by_name_uses_index(): void
+        public function test_search_by_name_without_digits_does_not_use_digit_indexes(): void
         {
             $patients = [
                 $this->makePatient(['id' => 1, 'primeiro_nome' => 'Matéus', 'ultimo_nome' => 'Silva']),
             ];
-            \App\Models\Patient::setCollection($patients);
+            Patient::setCollection($patients);
 
             $controller = new PatientController();
-            $request = new \Illuminate\Http\Request(['q' => 'Mateus']);
+            $request = new \Illuminate\Http\Request(['query' => 'Mateus']);
             $result = $controller->search($request);
 
             $this->assertSame([
-                ['id' => 1, 'name' => 'Matéus Silva', 'phone' => '', 'cpf' => ''],
+                ['id' => 1, 'nome' => 'Matéus Silva', 'email' => null, 'telefone' => '', 'cpf' => ''],
             ], $result);
 
-            $this->assertSame(true, in_array('pessoas_normalized_name_index', \App\Models\Patient::$lastQuery->usedIndexes));
+            $used = Patient::$lastQuery->usedIndexes;
+            $this->assertSame(true, in_array('pessoas_normalized_name_index', $used));
+            $this->assertSame(false, in_array('pessoas_digits_phone_index', $used));
+            $this->assertSame(false, in_array('pessoas_digits_whatsapp_index', $used));
+            $this->assertSame(false, in_array('pessoas_digits_cpf_index', $used));
         }
 
-        public function test_search_by_phone_uses_index(): void
+        public function test_search_by_email_without_digits_does_not_use_digit_indexes(): void
+        {
+            $patients = [
+                $this->makePatient(['id' => 1, 'primeiro_nome' => 'Jane', 'ultimo_nome' => 'Doe', 'email' => 'jane@example.com']),
+            ];
+            Patient::setCollection($patients);
+
+            $controller = new PatientController();
+            $request = new \Illuminate\Http\Request(['query' => 'jane@example.com']);
+            $result = $controller->search($request);
+
+            $this->assertSame([
+                ['id' => 1, 'nome' => 'Jane Doe', 'email' => 'jane@example.com', 'telefone' => '', 'cpf' => ''],
+            ], $result);
+
+            $used = Patient::$lastQuery->usedIndexes;
+            $this->assertSame(true, in_array('pessoas_normalized_name_index', $used));
+            $this->assertSame(false, in_array('pessoas_digits_phone_index', $used));
+            $this->assertSame(false, in_array('pessoas_digits_whatsapp_index', $used));
+            $this->assertSame(false, in_array('pessoas_digits_cpf_index', $used));
+        }
+
+        public function test_search_by_phone_uses_phone_index(): void
         {
             $patients = [
                 $this->makePatient(['id' => 1, 'primeiro_nome' => 'Ana', 'ultimo_nome' => 'Silva', 'phone' => '(11) 91234-5678']),
             ];
-            \App\Models\Patient::setCollection($patients);
+            Patient::setCollection($patients);
 
             $controller = new PatientController();
-            $request = new \Illuminate\Http\Request(['q' => '11912345678']);
+            $request = new \Illuminate\Http\Request(['query' => '11912345678']);
             $result = $controller->search($request);
 
             $this->assertSame([
-                ['id' => 1, 'name' => 'Ana Silva', 'phone' => '(11) 91234-5678', 'cpf' => ''],
+                ['id' => 1, 'nome' => 'Ana Silva', 'email' => null, 'telefone' => '(11) 91234-5678', 'cpf' => ''],
             ], $result);
 
-            $this->assertSame(true, in_array('pessoas_digits_phone_index', \App\Models\Patient::$lastQuery->usedIndexes));
+            $used = Patient::$lastQuery->usedIndexes;
+            $this->assertSame(true, in_array('pessoas_digits_phone_index', $used));
         }
 
-        public function test_search_by_cpf_uses_index(): void
+        public function test_search_by_cpf_uses_cpf_index(): void
         {
             $patients = [
                 $this->makePatient(['id' => 1, 'primeiro_nome' => 'Carlos', 'ultimo_nome' => 'Ferreira', 'cpf' => '123.456.789-00']),
             ];
-            \App\Models\Patient::setCollection($patients);
+            Patient::setCollection($patients);
 
             $controller = new PatientController();
-            $request = new \Illuminate\Http\Request(['q' => '12345678900']);
+            $request = new \Illuminate\Http\Request(['query' => '12345678900']);
             $result = $controller->search($request);
 
             $this->assertSame([
-                ['id' => 1, 'name' => 'Carlos Ferreira', 'phone' => '', 'cpf' => '123.456.789-00'],
+                ['id' => 1, 'nome' => 'Carlos Ferreira', 'email' => null, 'telefone' => '', 'cpf' => '123.456.789-00'],
             ], $result);
 
-            $this->assertSame(true, in_array('pessoas_digits_cpf_index', \App\Models\Patient::$lastQuery->usedIndexes));
+            $used = Patient::$lastQuery->usedIndexes;
+            $this->assertSame(true, in_array('pessoas_digits_cpf_index', $used));
         }
     }
 
     $test = new PatientSearchTest();
-    $test->test_search_by_name_uses_index();
-    $test->test_search_by_phone_uses_index();
-    $test->test_search_by_cpf_uses_index();
+    $test->test_search_by_name_without_digits_does_not_use_digit_indexes();
+    $test->test_search_by_email_without_digits_does_not_use_digit_indexes();
+    $test->test_search_by_phone_uses_phone_index();
+    $test->test_search_by_cpf_uses_cpf_index();
     echo "Test passed\n";
 }


### PR DESCRIPTION
## Summary
- prevent patient search from matching by cpf/phone/whatsapp when query has no digits
- expand patient search tests for name, email, phone, and cpf queries

## Testing
- `php tests/Feature/PatientSearchTest.php`
- `php tests/Feature/AgendamentoTest.php` *(fails: in_array(): Argument #2 ($haystack) must be of type array, App\Models\EscalaTrabalho given)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7e890d0832a9b40be54305a0d86