### PR TITLE
Add success alert after scheduling

### DIFF
--- a/resources/js/__tests__/schedule.test.js
+++ b/resources/js/__tests__/schedule.test.js
@@ -21,6 +21,7 @@ vi.mock('tom-select', () => ({
 const buildDom = () => {
   document.head.innerHTML = '<meta name="csrf-token" content="token">';
   document.body.innerHTML = `
+    <div id="schedule-success" class="hidden"></div>
     <div id="schedule-modal" class="hidden" data-hora="" data-date="">
       <input id="schedule-start" />
       <input id="schedule-end" />
@@ -148,6 +149,21 @@ describe('schedule selection', () => {
     expect(fetch).toHaveBeenCalled();
     const body = JSON.parse(fetch.mock.calls[0][1].body);
     expect(body.paciente_id).toBe('1');
+  });
+
+  it('shows success alert after saving', async () => {
+    const cell = document.querySelector('#schedule-table td[data-professional-id="1"][data-hora="09:00"]');
+    cell.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    const select = document.getElementById('schedule-paciente');
+    select.value = '1';
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const save = document.getElementById('schedule-save');
+    save.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await new Promise(r => setTimeout(r, 0));
+    const success = document.getElementById('schedule-success');
+    expect(success.classList.contains('hidden')).toBe(false);
   });
 });
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -879,6 +879,12 @@ document.addEventListener('DOMContentLoaded', () => {
                             if (data.redirect) { window.location.href = data.redirect; }
                             return;
                         }
+                        const success = document.getElementById('schedule-success');
+                        if (success) {
+                            success.textContent = 'Agendamento salvo com sucesso';
+                            success.classList.remove('hidden');
+                            setTimeout(() => success.classList.add('hidden'), 3000);
+                        }
                         const comp = root?.__x?.$data;
                         if (comp) {
                             comp.fetchProfessionals(date).then(profs => {

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -10,6 +10,7 @@
     <h1 class="text-2xl font-bold">Agendamentos</h1>
     <p class="text-gray-600">Agenda semanal por profissional</p>
 </div>
+<div id="schedule-success" class="hidden mb-4 rounded bg-green-500 text-white px-4 py-2"></div>
 @php
     // Dados de agenda são fornecidos pelo controlador
 @endphp


### PR DESCRIPTION
## Summary
- show green success bar after saving an appointment
- display success alert via JavaScript when schedule is stored
- test success alert behaviour

## Testing
- `npm test`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6898c1c5f924832a8d95b259a1a3d87a