### PR TITLE
Normaliza horario no agendamento

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -42,7 +42,10 @@ class AgendamentoController extends Controller
 
             foreach ($agendamentos as $ag) {
                 $pessoa = optional($ag->paciente)->pessoa;
-                $agenda[$ag->profissional_id][$ag->hora_inicio] = [
+                // banco armazena hora com segundos; para correlacionar com as células da tabela
+                // que usam formato HH:MM, normalizamos o valor removendo os segundos
+                $hora = substr($ag->hora_inicio, 0, 5);
+                $agenda[$ag->profissional_id][$hora] = [
                     'paciente' => $pessoa ? trim(($pessoa->primeiro_nome ?? '') . ' ' . ($pessoa->ultimo_nome ?? '')) : '',
                     'tipo' => $ag->tipo ?? '',
                     'contato' => $ag->contato ?? '',
@@ -109,7 +112,9 @@ class AgendamentoController extends Controller
                 ->get();
             foreach ($agendamentos as $ag) {
                 $pessoa = optional($ag->paciente)->pessoa;
-                $agenda[$ag->profissional_id][$ag->hora_inicio] = [
+                // hora_inicio vem como HH:MM:SS; usamos apenas HH:MM para coincidir com a tabela
+                $hora = substr($ag->hora_inicio, 0, 5);
+                $agenda[$ag->profissional_id][$hora] = [
                     'paciente' => $pessoa ? trim(($pessoa->primeiro_nome ?? '') . ' ' . ($pessoa->ultimo_nome ?? '')) : '',
                     'tipo' => $ag->tipo ?? '',
                     'contato' => $ag->contato ?? '',


### PR DESCRIPTION
## Summary
- Remove segundos do campo `hora_inicio` ao montar agenda para alinhar com formato da tabela

## Testing
- `npm test`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6898c32ea4fc832aa3d7fa779d59cd1f