### PR TITLE
Normalize agendamento times

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -151,6 +151,9 @@ class AgendamentoController extends Controller
             'observacao' => 'nullable|string',
         ]);
 
+        $data['hora_inicio'] = Carbon::parse($data['hora_inicio'])->format('H:i:s');
+        $data['hora_fim'] = Carbon::parse($data['hora_fim'])->format('H:i:s');
+
         $data['clinica_id'] = $clinicId;
         $data['status'] = 'confirmado';
         $data['tipo'] = $data['tipo'] ?? 'Consulta';


### PR DESCRIPTION
## Summary
- Normalize `hora_inicio` and `hora_fim` in `AgendamentoController` to store times in `H:i:s` format

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898c7cebf9c832a89d8b2660aa8e8ac