### PR TITLE
Add appointment status selection

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -170,13 +170,13 @@ class AgendamentoController extends Controller
             'tipo' => 'nullable|string',
             'contato' => 'nullable|string',
             'observacao' => 'nullable|string',
+            'status' => 'required|in:confirmado,pendente,cancelado',
         ]);
 
         $data['hora_inicio'] = Carbon::parse($data['hora_inicio'])->format('H:i:s');
         $data['hora_fim'] = Carbon::parse($data['hora_fim'])->format('H:i:s');
 
         $data['clinica_id'] = $clinicId;
-        $data['status'] = 'confirmado';
         $data['tipo'] = $data['tipo'] ?? 'Consulta';
         $data['contato'] = $data['contato'] ?? '';
 
@@ -196,6 +196,7 @@ class AgendamentoController extends Controller
             'hora_inicio' => 'required',
             'hora_fim' => 'required',
             'observacao' => 'nullable|string',
+            'status' => 'required|in:confirmado,pendente,cancelado',
         ]);
 
         $data['hora_inicio'] = Carbon::parse($data['hora_inicio'])->format('H:i:s');

--- a/database/migrations/2024_01_01_000700_create_agendamentos_table.php
+++ b/database/migrations/2024_01_01_000700_create_agendamentos_table.php
@@ -14,7 +14,7 @@ return new class extends Migration {
             $table->foreignId('paciente_id')->nullable()->constrained('pacientes');
             $table->string('tipo');
             $table->string('contato')->nullable();
-            $table->string('status')->default('agendado');
+            $table->string('status')->default('pendente');
             $table->date('data');
             $table->time('hora_inicio');
             $table->time('hora_fim');

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -86,6 +86,7 @@
                                     data-inicio="{{ $item['hora_inicio'] }}"
                                     data-fim="{{ $item['hora_fim'] }}"
                                     data-observacao="{{ $item['observacao'] }}"
+                                    data-status="{{ $item['status'] }}"
                                     data-date="{{ $date }}"
                                     data-profissional-id="{{ $prof['id'] }}"
                                 />
@@ -131,6 +132,14 @@
             <label class="block mb-4">
                 <span class="text-sm">Observação</span>
                 <textarea id="schedule-observacao" class="mt-1 w-full border rounded p-1" placeholder="Digite aqui"></textarea>
+            </label>
+            <label class="block mb-4">
+                <span class="text-sm">Status</span>
+                <select id="schedule-status" class="mt-1 w-full border rounded p-1">
+                    <option value="confirmado">Confirmado</option>
+                    <option value="pendente">Pendente</option>
+                    <option value="cancelado">Cancelado</option>
+                </select>
             </label>
             <div class="flex justify-end gap-2">
                 <button id="schedule-cancel" class="px-3 py-1 border rounded">Cancelar</button>

--- a/resources/views/components/agenda/agendamento.blade.php
+++ b/resources/views/components/agenda/agendamento.blade.php
@@ -6,15 +6,21 @@
     'status' => 'pendente'
 ])
 @php
-    $statusLabel = $status === 'confirmado'
-        ? 'Confirmado'
-        : ($status === 'cancelado' ? 'Cancelado' : 'Sem confirmação');
-    $color = $status === 'confirmado'
-        ? 'bg-green-100 text-green-700'
-        : 'bg-gray-100 text-gray-700';
+    $statusLabel = match ($status) {
+        'confirmado' => 'Confirmado',
+        'pendente' => 'Pendente',
+        'cancelado' => 'Cancelado',
+        default => 'Sem confirmação',
+    };
+    $color = match ($status) {
+        'confirmado' => 'bg-green-100 text-green-700 border-green-800',
+        'pendente' => 'bg-yellow-100 text-yellow-700 border-yellow-800',
+        'cancelado' => 'bg-red-100 text-red-700 border-red-800',
+        default => 'bg-gray-100 text-gray-700 border-gray-800',
+    };
 @endphp
 {{-- Additional data-* attributes are forwarded to the root div --}}
-<div {{ $attributes->merge(['class' => "rounded p-2 text-xs border border-green-800 $color"]) }}>
+<div {{ $attributes->merge(['class' => "rounded p-2 text-xs border $color"]) }}>
     <div class="font-bold text-sm">{{ $paciente }}</div>
     @if($inicio && $fim)
         <div>{{ $inicio }} - {{ $fim }}</div>


### PR DESCRIPTION
## Summary
- allow choosing appointment status when creating or editing a schedule
- color code appointments for pending and cancelled states
- persist and validate status in controller and database

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899d8c589a4832a987f527f853ec0f8