### PR TITLE
Keep canceled appointments visible and improve overlap layout

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -47,7 +47,7 @@ class AgendamentoController extends Controller
                 $hora = $start->format('H:i');
                 $rowspan = max(1, intdiv($start->diffInMinutes($end), 30));
 
-                $agenda[$ag->profissional_id][$hora] = [
+                $agenda[$ag->profissional_id][$hora][] = [
                     'id' => $ag->id,
                     'hora_inicio' => $start->format('H:i'),
                     'hora_fim' => $end->format('H:i'),
@@ -127,7 +127,7 @@ class AgendamentoController extends Controller
                 $hora = $start->format('H:i');
                 $rowspan = max(1, intdiv($start->diffInMinutes($end), 30));
 
-                $agenda[$ag->profissional_id][$hora] = [
+                $agenda[$ag->profissional_id][$hora][] = [
                     'id' => $ag->id,
                     'hora_inicio' => $start->format('H:i'),
                     'hora_fim' => $end->format('H:i'),

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -226,21 +226,25 @@ window.renderSchedule = function (professionals, agenda, baseTimes, date) {
             baseTimes.forEach(hora => {
                 let row = `<tr class="border-t" data-row="${hora}"><td class="bg-gray-50 w-24 min-w-[6rem] h-16 align-middle" data-slot="${hora}" data-hora="${hora}"><div class="h-full flex items-center justify-end px-2 text-xs text-gray-500 whitespace-nowrap">${hora}</div></td>`;
                 professionals.forEach(p => {
-                    const item = agenda[p.id] && agenda[p.id][hora];
-                    if (item && item.skip) return;
+                    const slot = agenda[p.id] && agenda[p.id][hora];
+                    if (slot && slot.skip) return;
                     row += `<td class="h-16 cursor-pointer border-l" data-professional-id="${p.id}" data-hora="${hora}" data-date="${date}"`;
-                    if (item && item.rowspan) {
-                        row += ` rowspan="${item.rowspan}"`;
+                    if (Array.isArray(slot) && slot[0] && slot[0].rowspan) {
+                        row += ` rowspan="${slot[0].rowspan}"`;
                     }
                     row += '>';
-                    if (item) {
+                    if (Array.isArray(slot)) {
                         const statusClasses = {
                             confirmado: { color: 'bg-green-100 text-green-700 border-green-800', label: 'Confirmado' },
                             pendente: { color: 'bg-yellow-100 text-yellow-700 border-yellow-800', label: 'Pendente' },
                             cancelado: { color: 'bg-red-100 text-red-700 border-red-800', label: 'Cancelado' },
                         };
-                        const { color, label } = statusClasses[item.status] || { color: 'bg-gray-100 text-gray-700 border-gray-800', label: 'Sem confirmação' };
-                        row += `<div class="rounded p-2 text-xs border ${color}" data-id="${item.id}" data-inicio="${item.hora_inicio}" data-fim="${item.hora_fim}" data-observacao="${item.observacao || ''}" data-status="${item.status}" data-date="${date}" data-profissional-id="${p.id}"><div class="font-bold text-sm">${item.paciente}</div><div>${item.hora_inicio} - ${item.hora_fim}</div><div>${item.observacao || ''}</div><div>${label}</div></div>`;
+                        row += '<div class="h-full flex flex-col gap-1 lg:flex-row lg:gap-1">';
+                        slot.forEach(item => {
+                            const { color, label } = statusClasses[item.status] || { color: 'bg-gray-100 text-gray-700 border-gray-800', label: 'Sem confirmação' };
+                            row += `<div class="flex-1 rounded p-2 text-xs border ${color}" data-id="${item.id}" data-inicio="${item.hora_inicio}" data-fim="${item.hora_fim}" data-observacao="${item.observacao || ''}" data-status="${item.status}" data-date="${date}" data-profissional-id="${p.id}"><div class="font-bold text-sm">${item.paciente}</div><div>${item.hora_inicio} - ${item.hora_fim}</div><div>${item.observacao || ''}</div><div>${label}</div></div>`;
+                        });
+                        row += '</div>';
                     }
                     row += '</td>';
                 });

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -75,21 +75,25 @@
                 <tr class="border-t" data-row="{{ $hora }}">
                     <td class="bg-gray-50 w-24 min-w-[6rem] h-16 align-middle" data-slot="{{ $hora }}" data-hora="{{ $hora }}"><x-agenda.horario :time="$hora" /></td>
                     @foreach($professionals as $prof)
-                        @php $item = $agenda[$prof['id']][$hora] ?? null; @endphp
-                        @if($item && ($item['skip'] ?? false))
+                        @php $slot = $agenda[$prof['id']][$hora] ?? null; @endphp
+                        @if($slot && ($slot['skip'] ?? false))
                             @continue
                         @endif
-                        <td class="h-16 cursor-pointer border-l" data-professional-id="{{ $prof['id'] }}" data-hora="{{ $hora }}" data-date="{{ $date }}" @if($item && isset($item['rowspan'])) rowspan="{{ $item['rowspan'] }}" @endif>
-                            @if($item)
-                                <x-agenda.agendamento :paciente="$item['paciente']" :inicio="$item['hora_inicio']" :fim="$item['hora_fim']" :observacao="$item['observacao']" :status="$item['status']"
-                                    data-id="{{ $item['id'] }}"
-                                    data-inicio="{{ $item['hora_inicio'] }}"
-                                    data-fim="{{ $item['hora_fim'] }}"
-                                    data-observacao="{{ $item['observacao'] }}"
-                                    data-status="{{ $item['status'] }}"
-                                    data-date="{{ $date }}"
-                                    data-profissional-id="{{ $prof['id'] }}"
-                                />
+                        <td class="h-16 cursor-pointer border-l" data-professional-id="{{ $prof['id'] }}" data-hora="{{ $hora }}" data-date="{{ $date }}" @if($slot && isset($slot[0]['rowspan'])) rowspan="{{ $slot[0]['rowspan'] }}" @endif>
+                            @if($slot)
+                                <div class="h-full flex flex-col gap-1 lg:flex-row lg:gap-1">
+                                    @foreach($slot as $item)
+                                        <x-agenda.agendamento :paciente="$item['paciente']" :inicio="$item['hora_inicio']" :fim="$item['hora_fim']" :observacao="$item['observacao']" :status="$item['status']" class="flex-1"
+                                            data-id="{{ $item['id'] }}"
+                                            data-inicio="{{ $item['hora_inicio'] }}"
+                                            data-fim="{{ $item['hora_fim'] }}"
+                                            data-observacao="{{ $item['observacao'] }}"
+                                            data-status="{{ $item['status'] }}"
+                                            data-date="{{ $date }}"
+                                            data-profissional-id="{{ $prof['id'] }}"
+                                        />
+                                    @endforeach
+                                </div>
                             @endif
                         </td>
                     @endforeach


### PR DESCRIPTION
## Summary
- Allow multiple appointments per time slot so canceled ones remain visible
- Display overlapping appointments side-by-side on large screens and stacked on small screens
- Update JavaScript rendering to handle multiple appointments responsively

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef6e5e3c832a965e96dda2fbf743