### PR TITLE
Position agenda appointments using time-based layout

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -242,7 +242,7 @@ window.renderSchedule = function (professionals, agenda, baseTimes, date) {
                             cancelado: { color: 'bg-red-100 text-red-700 border-red-800', label: 'Cancelado' },
                         };
                         const { color, label } = statusClasses[item.status] || { color: 'bg-gray-100 text-gray-700 border-gray-800', label: 'Sem confirmação' };
-                        row += `<div class="rounded p-2 text-xs border ${color} flex-1 h-full" data-id="${item.id}" data-inicio="${item.hora_inicio}" data-fim="${item.hora_fim}" data-observacao="${item.observacao || ''}" data-status="${item.status}" data-date="${date}" data-profissional-id="${p.id}"><div class="font-bold text-sm">${item.paciente}</div><div>${item.hora_inicio} - ${item.hora_fim}</div><div>${item.observacao || ''}</div><div>${label}</div></div>`;
+                        row += `<div class="relative lg:flex-1"><div class="rounded p-2 text-xs border ${color} absolute w-full" data-id="${item.id}" data-inicio="${item.hora_inicio}" data-fim="${item.hora_fim}" data-observacao="${item.observacao || ''}" data-status="${item.status}" data-date="${date}" data-profissional-id="${p.id}"><div class="font-bold text-sm">${item.paciente}</div><div>${item.hora_inicio} - ${item.hora_fim}</div><div>${item.observacao || ''}</div><div>${label}</div></div></div>`;
                     });
                     row += '</div></td>';
                 });
@@ -379,6 +379,25 @@ const existeConflitoNaoCancelado = (prof, start, end) => {
     return false;
 };
 window.existeConflitoNaoCancelado = existeConflitoNaoCancelado;
+
+const positionAppointments = () => {
+    updateSlotMinutes();
+    const firstRow = document.querySelector('#schedule-table tbody tr');
+    if (!firstRow) return;
+    const cellHeight = firstRow.offsetHeight;
+    const pxPerMinute = cellHeight / slotMinutes;
+    document.querySelectorAll('#schedule-table td[data-hora]').forEach(cell => {
+        const cellStart = toMinutes(cell.dataset.hora);
+        cell.querySelectorAll('div[data-id]').forEach(appt => {
+            const start = toMinutes(appt.dataset.inicio);
+            const end = toMinutes(appt.dataset.fim);
+            const topPx = (start - cellStart) * pxPerMinute;
+            const heightPx = (end - start) * pxPerMinute;
+            appt.style.top = `${topPx}px`;
+            appt.style.height = `${heightPx}px`;
+        });
+    });
+};
 
 const clearSelection = (preserveProfessional = false) => {
     document.querySelectorAll('#schedule-table td[data-professional-id].selected')
@@ -707,6 +726,8 @@ function attachCellHandlers() {
 window.attachCellHandlers = attachCellHandlers;
 document.addEventListener('DOMContentLoaded', attachCellHandlers);
 document.addEventListener('schedule:rendered', attachCellHandlers);
+document.addEventListener('DOMContentLoaded', positionAppointments);
+document.addEventListener('schedule:rendered', positionAppointments);
 
 Alpine.start();
 

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -86,16 +86,18 @@
                         <td class="h-16 cursor-pointer border-l" data-professional-id="{{ $prof['id'] }}" data-hora="{{ $hora }}" data-date="{{ $date }}" @if($rowspan > 1) rowspan="{{ $rowspan }}" @endif>
                             <div class="h-full flex flex-col lg:flex-row gap-0.5">
                                 @foreach($display as $item)
-                                    <x-agenda.agendamento :paciente="$item['paciente']" :inicio="$item['hora_inicio']" :fim="$item['hora_fim']" :observacao="$item['observacao']" :status="$item['status']"
-                                        class="flex-1 h-full m-0"
-                                        data-id="{{ $item['id'] }}"
-                                        data-inicio="{{ $item['hora_inicio'] }}"
-                                        data-fim="{{ $item['hora_fim'] }}"
-                                        data-observacao="{{ $item['observacao'] }}"
-                                        data-status="{{ $item['status'] }}"
-                                        data-date="{{ $date }}"
-                                        data-profissional-id="{{ $prof['id'] }}"
-                                    />
+                                    <div class="relative lg:flex-1">
+                                        <x-agenda.agendamento :paciente="$item['paciente']" :inicio="$item['hora_inicio']" :fim="$item['hora_fim']" :observacao="$item['observacao']" :status="$item['status']"
+                                            class="absolute w-full m-0"
+                                            data-id="{{ $item['id'] }}"
+                                            data-inicio="{{ $item['hora_inicio'] }}"
+                                            data-fim="{{ $item['hora_fim'] }}"
+                                            data-observacao="{{ $item['observacao'] }}"
+                                            data-status="{{ $item['status'] }}"
+                                            data-date="{{ $date }}"
+                                            data-profissional-id="{{ $prof['id'] }}"
+                                        />
+                                    </div>
                                 @endforeach
                             </div>
                         </td>


### PR DESCRIPTION
## Summary
- Wrap agenda cards in relative containers and render appointments as absolute elements to remove flex-based equal heights
- Compute pixel offsets from start/end times and apply them via new `positionAppointments` helper
- Re-run positioning on initial load and `schedule:rendered` events to handle server and AJAX renders

## Testing
- `npm test`
- `composer install` *(failed: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899fd1c3d04832a87bbb10b427ba335