### PR TITLE
Simplify agenda layout with CSS minute grid

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -19,3 +19,10 @@
 #schedule-table td > div::after {
     pointer-events: none;
 }
+
+.minute-grid {
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(to bottom, #e5e7eb 0, #e5e7eb 1px, transparent 1px, transparent 30px);
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -227,17 +227,9 @@ window.renderSchedule = function (professionals, agenda, baseTimes, date) {
                 let row = `<tr class="border-t" data-row="${hora}"><td class="bg-gray-50 w-24 min-w-[6rem] h-16 align-middle" data-slot="${hora}" data-hora="${hora}"><div class="h-full flex items-center justify-end px-2 text-xs text-gray-500 whitespace-nowrap">${hora}</div></td>`;
                 professionals.forEach(p => {
                     const cellItems = (agenda[p.id] && agenda[p.id][hora]) || [];
-                    const hasItems = cellItems.some(it => !it.skip);
-                    const isCovered = cellItems.some(it => it.skip);
-
-                    if (hasItems) {
-                        const items = cellItems.filter(it => !it.skip);
-                        const rowsp = Math.max(...items.map(it => it.rowspan || 1));
-                        row += `<td class="h-16 cursor-pointer border-l" data-professional-id="${p.id}" data-hora="${hora}" data-date="${date}"`;
-                        if (rowsp > 1) {
-                            row += ` rowspan="${rowsp}"`;
-                        }
-                        row += '><div class="h-full flex flex-col lg:flex-row gap-0.5">';
+                    const items = cellItems.filter(it => !it.skip);
+                    row += `<td class="relative h-16 cursor-pointer border-l" data-professional-id="${p.id}" data-hora="${hora}" data-date="${date}"><div class="minute-grid"></div><div class="h-full flex flex-col lg:flex-row gap-0.5">`;
+                    if (items.length) {
                         items.forEach(item => {
                             const statusClasses = {
                                 confirmado: { color: 'bg-green-100 text-green-700 border-green-800', label: 'Confirmado' },
@@ -245,12 +237,12 @@ window.renderSchedule = function (professionals, agenda, baseTimes, date) {
                                 cancelado: { color: 'bg-red-100 text-red-700 border-red-800', label: 'Cancelado' },
                             };
                             const { color, label } = statusClasses[item.status] || { color: 'bg-gray-100 text-gray-700 border-gray-800', label: 'Sem confirmação' };
-                            row += `<div class="relative lg:flex-1"><div class="rounded p-2 text-xs border ${color} absolute w-full" data-id="${item.id}" data-inicio="${item.hora_inicio}" data-fim="${item.hora_fim}" data-observacao="${item.observacao || ''}" data-status="${item.status}" data-date="${date}" data-profissional-id="${p.id}"><div class="font-bold text-sm">${item.paciente}</div><div>${item.hora_inicio} - ${item.hora_fim}</div><div>${item.observacao || ''}</div><div>${label}</div></div></div>`;
+                            row += `<div class="relative lg:flex-1"><div class="rounded p-2 text-xs border ${color} absolute w-full z-10" data-id="${item.id}" data-inicio="${item.hora_inicio}" data-fim="${item.hora_fim}" data-observacao="${item.observacao || ''}" data-status="${item.status}" data-date="${date}" data-profissional-id="${p.id}"><div class="font-bold text-sm">${item.paciente}</div><div>${item.hora_inicio} - ${item.hora_fim}</div><div>${item.observacao || ''}</div><div>${label}</div></div></div>`;
                         });
-                        row += '</div></td>';
-                    } else if (!isCovered) {
-                        row += `<td class="h-16 cursor-pointer border-l" data-professional-id="${p.id}" data-hora="${hora}" data-date="${date}"><div class="relative lg:flex-1"></div></td>`;
+                    } else {
+                        row += '<div class="relative lg:flex-1"></div>';
                     }
+                    row += '</div></td>';
                 });
                 row += '</tr>';
                 tbody.insertAdjacentHTML('beforeend', row);

--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -79,13 +79,13 @@
                             $items = $agenda[$prof['id']][$hora] ?? [];
                             $display = collect($items)->reject(fn($i) => $i['skip'] ?? false);
                         @endphp
-                        @php $rowspan = $display->max('rowspan'); @endphp
-                        <td class="h-16 cursor-pointer border-l" data-professional-id="{{ $prof['id'] }}" data-hora="{{ $hora }}" data-date="{{ $date }}" @if($rowspan > 1) rowspan="{{ $rowspan }}" @endif>
+                        <td class="relative h-16 cursor-pointer border-l" data-professional-id="{{ $prof['id'] }}" data-hora="{{ $hora }}" data-date="{{ $date }}">
+                            <div class="minute-grid"></div>
                             <div class="h-full flex flex-col lg:flex-row gap-0.5">
                                 @forelse($display as $item)
                                     <div class="relative lg:flex-1">
                                         <x-agenda.agendamento :paciente="$item['paciente']" :inicio="$item['hora_inicio']" :fim="$item['hora_fim']" :observacao="$item['observacao']" :status="$item['status']"
-                                            class="absolute w-full m-0"
+                                            class="absolute w-full m-0 z-10"
                                             data-id="{{ $item['id'] }}"
                                             data-inicio="{{ $item['hora_inicio'] }}"
                                             data-fim="{{ $item['hora_fim'] }}"


### PR DESCRIPTION
## Summary
- Render schedule cells without rowspans and overlay minute guides
- Place appointment cards above the grid for reliable clicking
- Add minute-grid CSS utility

## Testing
- `npm test`
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689a3613bf78832aa8b502187bbd0544