### PR TITLE
Fix double border in admin schedule grid

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -24,5 +24,13 @@
     pointer-events: none;
     position: absolute;
     inset: 0;
-    background: repeating-linear-gradient(to bottom, #e5e7eb 0, #e5e7eb 1px, transparent 1px, transparent 60px);
+    background: linear-gradient(
+        to bottom,
+        transparent 0,
+        transparent 50%,
+        #e5e7eb 50%,
+        #e5e7eb 51%,
+        transparent 51%,
+        transparent 100%
+    );
 }


### PR DESCRIPTION
## Summary
- prevent duplicated borders in schedule by redrawing minute grid with a single divider

## Testing
- `npm test`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php' - curl error 56 while downloading https://repo.packagist.org/packages.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a4adc7284832aaf364269f736d276