### PR TITLE
Remover observação do cartão de agendamento

### DIFF
--- a/resources/views/components/agenda/agendamento.blade.php
+++ b/resources/views/components/agenda/agendamento.blade.php
@@ -40,6 +40,5 @@
     @if($inicio && $fim)
         <div>{{ $inicio }} - {{ $fim }}</div>
     @endif
-    <div>{{ $observacao }}</div>
     <div>{{ $statusLabel }}</div>
 </div>


### PR DESCRIPTION
## Summary
- Remove exibição da observação no corpo do agendamento
- Manter observação apenas no atributo de título do cartão

## Testing
- `npm test`
- `composer install` (falhou: curl error 56 while downloading https://repo.packagist.org/packages.json)


------
https://chatgpt.com/codex/tasks/task_e_689b9a6baf2c832a9a39b9bc7c6c4c6d