### PR TITLE
feat: add migrations for formularios

### DIFF
--- a/database/migrations/2024_06_01_000006_create_formularios_table.php
+++ b/database/migrations/2024_06_01_000006_create_formularios_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('formularios', function (Blueprint $table) {
+            $table->id();
+            $table->string('nome');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('formularios');
+    }
+};

--- a/database/migrations/2024_06_01_000007_create_perguntas_table.php
+++ b/database/migrations/2024_06_01_000007_create_perguntas_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('perguntas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('formulario_id')->constrained('formularios')->cascadeOnDelete();
+            $table->string('enunciado');
+            $table->string('tipo');
+            $table->text('opcoes')->nullable();
+            $table->unsignedInteger('ordem');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('perguntas');
+    }
+};

--- a/database/migrations/2024_06_01_000008_create_respostas_table.php
+++ b/database/migrations/2024_06_01_000008_create_respostas_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('respostas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('formulario_id')->constrained('formularios')->cascadeOnDelete();
+            $table->foreignId('pergunta_id')->constrained('perguntas')->cascadeOnDelete();
+            $table->text('resposta');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('respostas');
+    }
+};


### PR DESCRIPTION
## Summary
- add migration for formularios table
- add migration for related perguntas and respostas tables

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689bafb00d30832aae2dc6c90c53eb9a