### PR TITLE
Fix clinic relation foreign key in Organization model

### DIFF
--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -31,6 +31,6 @@ class Organization extends Model
 
     public function clinics()
     {
-        return $this->hasMany(Clinic::class);
+        return $this->hasMany(Clinic::class, 'organizacao_id');
     }
 }


### PR DESCRIPTION
## Summary
- fix Organization::clinics relation to use Portuguese foreign key `organizacao_id`

## Testing
- `php artisan test` *(fails: Failed to open required '/workspace/dentix/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689baf9c5080832a99f36c9ece13f410