### PR TITLE
Hide schedule success alert by default

### DIFF
--- a/resources/views/agendamentos/index.blade.php
+++ b/resources/views/agendamentos/index.blade.php
@@ -10,7 +10,7 @@
     <h1 class="text-2xl font-bold">Agendamentos</h1>
     <p class="text-gray-600">Agenda semanal por profissional</p>
 </div>
-<x-alert-success id="schedule-success" class="hidden">Agendamento salvo com sucesso</x-alert-success>
+<x-alert-success id="schedule-success" :show="false">Agendamento salvo com sucesso</x-alert-success>
 @php
     // Dados de agenda são fornecidos pelo controlador
 @endphp

--- a/resources/views/components/alert-success.blade.php
+++ b/resources/views/components/alert-success.blade.php
@@ -1,4 +1,11 @@
-<div x-data="{ show: true }" x-show="show" x-transition class="mb-4 flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-700">
+@php
+    $attributes = $attributes ?? new \Illuminate\View\ComponentAttributeBag;
+    $show = $attributes->has('show')
+        ? filter_var($attributes->get('show'), FILTER_VALIDATE_BOOLEAN)
+        : ($show ?? true);
+    $attributes = $attributes->except('show');
+@endphp
+<div x-data="{ show: {{ $show ? 'true' : 'false' }} }" x-show="show" x-transition {{ $attributes->merge(['class' => 'mb-4 flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-700']) }}>
     <div class="flex items-center">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />


### PR DESCRIPTION
## Summary
- allow alert-success component to accept attributes and initial visibility
- keep schedule success message hidden until explicitly shown

## Testing
- `npm test`
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a441cc14f8832a872dde8e736f11ef