### PR TITLE
Fix duplicated charts in finance dashboard

### DIFF
--- a/resources/views/financeiro/index.blade.php
+++ b/resources/views/financeiro/index.blade.php
@@ -96,10 +96,10 @@
             const el = document.getElementById(id);
             if (!el || !window.Chart) return;
 
-            const existing = Chart.getChart ? Chart.getChart(el) : null;
-            if (existing) existing.destroy();
-
-            new Chart(el, config);
+            if (el._chart) {
+                el._chart.destroy();
+            }
+            el._chart = new Chart(el, config);
         };
 
         createChart('formas-chart', {


### PR DESCRIPTION
## Summary
- prevent Chart.js graphs from overlaying by storing chart instance on canvas and destroying previous

## Testing
- `npm test`
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a442f39b84832a90a81e76d6d10eea