### PR TITLE
chore: pin Chart.js version

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,7 +14,7 @@
 
         });
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1"></script>
 </head>
 <body class="flex h-full bg-gray-100">
     @auth


### PR DESCRIPTION
## Summary
- pin Chart.js CDN reference to version 4.4.1 for consistent chart behavior

## Testing
- `npm run build`
- `npm install chart.js@4.4.1` *(fails: 403 Forbidden from npm registry)*
- `php artisan test` *(fails: vendor autoload not found; `composer install` blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4baf815d8832aafb56e56f80ce2ce