### PR TITLE
Update appointment professional handling

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -224,7 +224,7 @@ class AgendamentoController extends Controller
             'hora_fim' => 'required',
             'observacao' => 'nullable|string',
             'status' => 'required|in:confirmado,pendente,cancelado,faltou',
-            'profissional_id' => 'required|exists:users,id',
+            'profissional_id' => 'required|exists:profissionais,id',
         ]);
 
         $data['hora_inicio'] = Carbon::parse($data['hora_inicio'])->format('H:i:s');
@@ -248,7 +248,14 @@ class AgendamentoController extends Controller
         }
 
         $oldDate = $agendamento->data;
-        $agendamento->update($data);
+        $agendamento->update([
+            'data' => $data['data'],
+            'hora_inicio' => $data['hora_inicio'],
+            'hora_fim' => $data['hora_fim'],
+            'observacao' => $data['observacao'] ?? '',
+            'status' => $data['status'],
+            'profissional_id' => $data['profissional_id'],
+        ]);
 
         if ($clinicId) {
             $newDate = Carbon::parse($data['data'])->format('Y-m-d');

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -754,7 +754,7 @@ document.addEventListener('drop', e => {
     const start = cell.dataset.hora;
     const end = addMinutes(start, duration);
     const date = cell.dataset.date;
-    const profissionalId = cell.dataset.professionalId;
+    const profissionalId = parseInt(cell.dataset.professionalId, 10);
 
     fetch(`admin/agendamentos/${draggedCard.id}`, {
         method: 'PUT',


### PR DESCRIPTION
## Summary
- validate and update `profissional_id` when modifying appointments
- send `profissional_id` on drag-and-drop moves in the schedule

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c0b8771c832a96aa9389a47e36cf