### PR TITLE
feat: add waiting list status

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -181,7 +181,7 @@ class AgendamentoController extends Controller
             'tipo' => 'nullable|string',
             'contato' => 'nullable|string',
             'observacao' => 'nullable|string',
-            'status' => 'required|in:confirmado,pendente,cancelado,faltou',
+            'status' => 'required|in:confirmado,pendente,cancelado,faltou,lista_espera',
         ]);
 
         $data['hora_inicio'] = Carbon::parse($data['hora_inicio'])->format('H:i:s');
@@ -223,7 +223,7 @@ class AgendamentoController extends Controller
             'hora_inicio' => 'required',
             'hora_fim' => 'required',
             'observacao' => 'nullable|string',
-            'status' => 'required|in:confirmado,pendente,cancelado,faltou',
+            'status' => 'required|in:confirmado,pendente,cancelado,faltou,lista_espera',
             'profissional_id' => 'required|exists:profissionais,id',
         ]);
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -268,6 +268,7 @@ window.renderSchedule = function (professionals, agenda, baseTimes, date) {
                                     pendente: { color: 'bg-yellow-100 text-yellow-700 border-yellow-800', label: 'Pendente' },
                                     cancelado: { color: 'bg-red-100 text-red-700 border-red-800', label: 'Cancelado' },
                                     faltou: { color: 'bg-blue-100 text-blue-700 border-blue-800', label: 'Faltou' },
+                                    lista_espera: { color: 'bg-purple-100 text-purple-700 border-purple-800', label: 'Lista de espera' },
                                 };
                                   const { color, label } = statusClasses[item.status] || { color: 'bg-gray-100 text-gray-700 border-gray-800', label: 'Sem confirmação' };
                                   const title = [item.paciente, `${item.hora_inicio} - ${item.hora_fim}`, item.observacao, label].filter(Boolean).join('\n');

--- a/resources/views/agendamentos/partials/modal.blade.php
+++ b/resources/views/agendamentos/partials/modal.blade.php
@@ -40,6 +40,7 @@
                     <option value="pendente">Pendente</option>
                     <option value="cancelado">Cancelado</option>
                     <option value="faltou">Faltou</option>
+                    <option value="lista_espera">Lista de espera</option>
                 </select>
             </label>
             <div class="flex justify-end gap-2">

--- a/resources/views/components/agenda/agendamento.blade.php
+++ b/resources/views/components/agenda/agendamento.blade.php
@@ -11,6 +11,7 @@
         'pendente' => 'Pendente',
         'cancelado' => 'Cancelado',
         'faltou' => 'Faltou',
+        'lista_espera' => 'Lista de espera',
         default => 'Sem confirmação',
     };
     $borderColor = match ($status) {
@@ -18,6 +19,7 @@
         'pendente' => 'rgb(250 204 21 / var(--tw-bg-opacity, 1))',
         'cancelado' => 'rgb(248 113 113 / var(--tw-bg-opacity, 1))',
         'faltou' => 'rgb(30 64 175 / var(--tw-bg-opacity, 1))',
+        'lista_espera' => 'rgb(192 132 252 / var(--tw-bg-opacity, 1))',
         default => 'rgb(156 163 175 / var(--tw-bg-opacity, 1))',
     };
     $color = match ($status) {
@@ -25,6 +27,7 @@
         'pendente' => 'bg-yellow-100 text-yellow-700',
         'cancelado' => 'bg-red-100 text-red-700',
         'faltou' => 'bg-blue-100 text-blue-700',
+        'lista_espera' => 'bg-purple-100 text-purple-700',
         default => 'bg-gray-100 text-gray-700',
     };
     $titleParts = [$paciente];


### PR DESCRIPTION
## Summary
- allow `lista_espera` as a valid schedule status in controller validation
- expose new "Lista de espera" option in schedule status dropdown
- style appointments with waiting list status in JS and blade component

## Testing
- `npm test`
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a4f83d39dc832a97b550791b01b498