### PR TITLE
feat: add waitlist modal handler

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -563,7 +563,7 @@ const selectRange = (date, prof, start, end) => {
     return true;
 };
 
-const abrirModalAgendamento = ag => {
+const abrirModalAgendamento = (ag, status = 'confirmado') => {
 
     const date = selection.date || '';
 
@@ -596,7 +596,7 @@ const abrirModalAgendamento = ag => {
             if (pacienteInput) pacienteInput.value = ag.paciente_id || '';
             if (selectedPatientName) selectedPatientName.textContent = ag.paciente || '';
             if (obs) obs.value = ag.observacao || '';
-            if (statusSel) statusSel.value = ag.status || 'confirmado';
+            if (statusSel) statusSel.value = ag.status || status;
             if (step1 && step2) {
                 step1.classList.add('hidden');
                 step2.classList.remove('hidden');
@@ -612,7 +612,7 @@ const abrirModalAgendamento = ag => {
             if (pacienteInput) pacienteInput.value = '';
             if (selectedPatientName) selectedPatientName.textContent = '';
             if (obs) obs.value = '';
-            if (statusSel) statusSel.value = 'confirmado';
+            if (statusSel) statusSel.value = status;
             if (step1 && step2) {
                 step1.classList.remove('hidden');
                 step2.classList.add('hidden');
@@ -868,6 +868,19 @@ document.addEventListener('agenda:changed', e => {
 Alpine.start();
 
 document.addEventListener('DOMContentLoaded', () => {
+    const waitlistBtn = document.getElementById('waitlist-add');
+    if (waitlistBtn) {
+        waitlistBtn.addEventListener('click', () => {
+            const comp = window.getAgendaComponent();
+            const date = comp?.selectedDate;
+            if (!date) return;
+            selection.date = date;
+            selection.start = null;
+            selection.end = null;
+            abrirModalAgendamento(null, 'lista_espera');
+            if (saveBtn) saveBtn.disabled = true;
+        });
+    }
     if (window.flatpickr) {
         flatpickr('.datepicker', {
             altInput: true,

--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -156,7 +156,7 @@
         <div class="bg-white rounded-lg shadow p-4">
             <div class="flex justify-between items-center mb-2">
                 <h2 class="font-semibold">Lista de Espera</h2>
-                <button class="p-1 text-blue-600 hover:text-blue-800">
+                <button id="waitlist-add" class="p-1 text-blue-600 hover:text-blue-800">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
                     </svg>


### PR DESCRIPTION
## Summary
- add unique id to agenda waitlist button
- enable waitlist add handler and open modal with preset status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a587c0492c832a87c805d372ff85f9