### PR TITLE
feat: add agenda day selection

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -373,6 +373,7 @@ function initPatientSearch() {
     };
 }
 let selection = { start: null, end: null, professional: null, date: null };
+window.selectedAgendaDate = null;
 
 let dragging = false;
 let suppressClick = false;
@@ -868,11 +869,23 @@ document.addEventListener('agenda:changed', e => {
 Alpine.start();
 
 document.addEventListener('DOMContentLoaded', () => {
+    const agendaDays = document.querySelectorAll('.agenda-day');
+    if (agendaDays.length) {
+        window.selectedAgendaDate = document.querySelector('.agenda-day.bg-blue-500')?.dataset.date || null;
+        agendaDays.forEach(day => {
+            day.addEventListener('click', () => {
+                window.selectedAgendaDate = day.dataset.date;
+                agendaDays.forEach(d => d.classList.remove('bg-blue-500', 'text-white'));
+                day.classList.add('bg-blue-500', 'text-white');
+            });
+        });
+    }
+
     const waitlistBtn = document.getElementById('waitlist-add');
     if (waitlistBtn) {
         waitlistBtn.addEventListener('click', () => {
             const comp = window.getAgendaComponent();
-            const date = comp?.selectedDate;
+            const date = window.selectedAgendaDate || comp?.selectedDate;
             if (!date) return;
             selection.date = date;
             selection.start = null;

--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -49,7 +49,10 @@
                     @php
                         $isToday = $today->year == $currentDate->year && $today->month == $currentDate->month && $today->day == $day;
                     @endphp
-                    <span class="p-1 rounded {{ $isToday ? 'bg-blue-500 text-white' : '' }}">{{ $day }}</span>
+                    <span
+                        class="agenda-day p-1 rounded {{ $isToday ? 'bg-blue-500 text-white' : '' }}"
+                        data-date="{{ $currentDate->copy()->day($day)->format('Y-m-d') }}"
+                    >{{ $day }}</span>
                 @endfor
             </div>
         </div>


### PR DESCRIPTION
## Summary
- mark calendar days with data-date and agenda-day class
- track clicked agenda day and highlight active date
- use selected agenda date when adding from waitlist

## Testing
- `npm test`
- `php artisan test` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b07bc4c832ab4adf43c996b7a55