### PR TITLE
Exclude waitlist appointments from admin agenda queries

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -36,6 +36,7 @@ class AgendamentoController extends Controller
                         ->where('clinica_id', $clinicId)
                         ->whereDate('data', $date)
                         ->whereIn('profissional_id', $profIds)
+                        ->where('status', '!=', 'lista_espera')
                         ->get();
                 }
             );
@@ -126,6 +127,7 @@ class AgendamentoController extends Controller
                         ->where('clinica_id', $clinicId)
                         ->whereDate('data', $date)
                         ->whereIn('profissional_id', $profIds)
+                        ->where('status', '!=', 'lista_espera')
                         ->get();
                 }
             );

--- a/tests/Feature/AgendamentoTest.php
+++ b/tests/Feature/AgendamentoTest.php
@@ -8,7 +8,7 @@ namespace App\Models {
             return new self;
         }
 
-        public function where($field, $value)
+        public function where($field, $operator = null, $value = null)
         {
             return $this;
         }


### PR DESCRIPTION
## Summary
- Ignore `lista_espera` appointments in admin agenda listings
- Adjust Agendamento test stub for 3-argument `where`

## Testing
- `php tests/Feature/AgendamentoTest.php`
- `php tests/Feature/EscalaTrabalhoTest.php`
- `php tests/Feature/PatientSearchTest.php`
- `php tests/Unit/AgendamentoControllerTest.php`
- `php tests/Unit/ProfessionalControllerTest.php`
- `php tests/Unit/EscalaTrabalhoControllerTest.php` *(fails: Class "PHPUnit\\Framework\\TestCase" not found)*
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a596f42210832a9d8bb8e9a01bd473