### PR TITLE
Make agendamentos fields nullable

### DIFF
--- a/database/migrations/2024_06_19_000009_update_agendamentos_nullable_fields.php
+++ b/database/migrations/2024_06_19_000009_update_agendamentos_nullable_fields.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('agendamentos', function (Blueprint $table) {
+            $table->foreignId('profissional_id')->nullable()->change();
+            $table->time('hora_inicio')->nullable()->change();
+            $table->time('hora_fim')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agendamentos', function (Blueprint $table) {
+            $table->foreignId('profissional_id')->nullable(false)->change();
+            $table->time('hora_inicio')->nullable(false)->change();
+            $table->time('hora_fim')->nullable(false)->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- allow profissional_id and time fields to be nullable in agendamentos

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `php artisan migrate` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a59a6aeec8832ab0f9daa2023f60d4