### PR TITLE
feat: show pointer cursor on calendar days

### DIFF
--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -50,7 +50,7 @@
                         $isToday = $today->year == $currentDate->year && $today->month == $currentDate->month && $today->day == $day;
                     @endphp
                     <span
-                        class="agenda-day p-1 rounded {{ $isToday ? 'bg-blue-500 text-white' : '' }}"
+                        class="agenda-day p-1 rounded cursor-pointer {{ $isToday ? 'bg-blue-500 text-white' : '' }}"
                         data-date="{{ $currentDate->copy()->day($day)->format('Y-m-d') }}"
                     >{{ $day }}</span>
                 @endfor


### PR DESCRIPTION
## Summary
- enable pointer cursor on each agenda day

## Testing
- `npm test`
- `php artisan test` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a59ccb4864832a9d4415a4756b50dd