### PR TITLE
test: add waitlist endpoint coverage

### DIFF
--- a/resources/js/waitlist.test.js
+++ b/resources/js/waitlist.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.MutationObserver = dom.window.MutationObserver;
+global.CustomEvent = dom.window.CustomEvent;
+global.Event = dom.window.Event;
+
+let loaded = false;
+beforeAll(async () => {
+  if (!loaded) {
+    await import('./app.js');
+    loaded = true;
+  }
+});
+
+describe('waitlist integration', () => {
+  let fetchMock;
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="root"></div>
+      <div id="waitlist-container"></div>
+    `;
+    window.renderSchedule = vi.fn();
+    window.updateScheduleTable = vi.fn();
+    fetchMock = vi.fn((url) => {
+      if (url.includes('waitlist')) {
+        const date = url.split('date=')[1];
+        const name = date === '2025-08-07' ? 'Joao' : 'Maria';
+        return Promise.resolve({
+          json: () => Promise.resolve({ waitlist: [{ id: 1, paciente: name, contato: '123' }] })
+        });
+      }
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    });
+    global.fetch = fetchMock;
+  });
+
+  it('calls waitlist endpoint and renders results', async () => {
+    const comp = window.agendaCalendar();
+    comp.professionalsUrl = null;
+    comp.horariosUrl = null;
+    comp.waitlistUrl = '/admin/agendamentos/waitlist';
+    comp.baseTimes = [];
+
+    await comp.loadData('2025-08-07');
+
+    expect(fetchMock).toHaveBeenCalledWith('/admin/agendamentos/waitlist?date=2025-08-07');
+    expect(document.getElementById('waitlist-container').textContent).toContain('Joao');
+  });
+
+  it('updates waitlist when date changes', async () => {
+    const comp = window.agendaCalendar();
+    comp.professionalsUrl = null;
+    comp.horariosUrl = null;
+    comp.waitlistUrl = '/admin/agendamentos/waitlist';
+    comp.baseTimes = [];
+
+    await comp.loadData('2025-08-07');
+    fetchMock.mockClear();
+    document.getElementById('waitlist-container').innerHTML = '';
+
+    await comp.loadData('2025-08-08');
+
+    expect(fetchMock).toHaveBeenCalledWith('/admin/agendamentos/waitlist?date=2025-08-08');
+    expect(document.getElementById('waitlist-container').textContent).toContain('Maria');
+  });
+});

--- a/tests/Feature/WaitlistTest.php
+++ b/tests/Feature/WaitlistTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Models {
+    class Agendamento
+    {
+        public static array $records = [];
+        public static array $patients = [];
+
+        public static function create(array $data)
+        {
+            $data['id'] = count(self::$records) + 1;
+            $data['paciente'] = self::$patients[$data['paciente_id']] ?? null;
+            self::$records[] = $data;
+        }
+
+        public static function with($relations)
+        {
+            return new self;
+        }
+
+        private array $filters = [];
+
+        public function where($field, $operator = null, $value = null)
+        {
+            if ($value === null) {
+                $value = $operator;
+            }
+            $this->filters[$field] = $value;
+            return $this;
+        }
+
+        public function whereDate($field, $value)
+        {
+            $this->filters[$field] = $value;
+            return $this;
+        }
+
+        public function get()
+        {
+            $results = array_filter(self::$records, function ($rec) {
+                foreach ($this->filters as $k => $v) {
+                    if (($rec[$k] ?? null) != $v) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+            return collect(array_map(fn($r) => (object) $r, $results));
+        }
+    }
+}
+
+namespace Illuminate\Http {
+    class Request
+    {
+        public function __construct(private array $data = []) {}
+        public function query($key, $default = null)
+        {
+            return $this->data[$key] ?? $default;
+        }
+        public function validate(array $rules, array $messages = [])
+        {
+            return $this->data;
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../Unit/stubs.php';
+    require_once __DIR__ . '/../../app/Http/Controllers/Admin/AgendamentoController.php';
+
+    use PHPUnit\Framework\TestCase;
+    use App\Http\Controllers\Admin\AgendamentoController;
+
+    if (!function_exists('app')) {
+        function app($key = null)
+        {
+            if ($key === null) {
+                return new class {
+                    public function bound($name)
+                    {
+                        return $name === 'clinic_id';
+                    }
+                };
+            }
+            return $key === 'clinic_id' ? 1 : null;
+        }
+    }
+
+    if (!function_exists('response')) {
+        function response()
+        {
+            return new class {
+                public function json($data)
+                {
+                    return $data;
+                }
+            };
+        }
+    }
+
+    if (!function_exists('optional')) {
+        function optional($value)
+        {
+            return $value ? $value : new class {
+                public function __get($name)
+                {
+                    return null;
+                }
+            };
+        }
+    }
+
+    class WaitlistTest extends TestCase
+    {
+        public function test_store_and_waitlist_flow()
+        {
+            \App\Models\Agendamento::$records = [];
+            \App\Models\Agendamento::$patients = [
+                10 => (object) ['pessoa' => (object) ['primeiro_nome' => 'Ana', 'ultimo_nome' => 'Silva']],
+            ];
+
+            $controller = new AgendamentoController();
+            $storeReq = new \Illuminate\Http\Request([
+                'paciente_id' => 10,
+                'data' => '2025-08-07',
+                'status' => 'lista_espera',
+                'contato' => '1199999999',
+            ]);
+            $res = $controller->store($storeReq);
+            $this->assertSame(['success' => true], $res);
+
+            $waitReq = new \Illuminate\Http\Request(['date' => '2025-08-07']);
+            $waitRes = $controller->waitlist($waitReq);
+            $items = $waitRes['waitlist']->toArray();
+            $this->assertSame(1, count($items));
+            $this->assertSame('Ana Silva', $items[0]['paciente']);
+            $this->assertSame('1199999999', $items[0]['contato']);
+        }
+    }
+
+    $test = new WaitlistTest();
+    $test->test_store_and_waitlist_flow();
+    echo "Tests passed\n";
+}


### PR DESCRIPTION
## Summary
- add PHP test ensuring waitlist appointments are stored and retrieved
- add Vitest tests checking waitlist endpoint rendering and date filtering

## Testing
- `for f in tests/Feature/*Test.php; do php "$f"; done`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a5a309e9bc832a820dd9e642cf4205