### PR TITLE
Add global waitlist loader and update agenda change handling

### DIFF
--- a/resources/js/waitlist.test.js
+++ b/resources/js/waitlist.test.js
@@ -67,4 +67,11 @@ describe('waitlist integration', () => {
     expect(fetchMock).toHaveBeenCalledWith('/admin/agendamentos/waitlist?date=2025-08-08');
     expect(document.getElementById('waitlist-container').textContent).toContain('Maria');
   });
+
+  it('calls loadWaitlist when agenda changes without component', () => {
+    const spy = vi.spyOn(window, 'loadWaitlist').mockResolvedValue();
+    vi.spyOn(window, 'getAgendaComponent').mockReturnValue(null);
+    document.dispatchEvent(new CustomEvent('agenda:changed', { detail: { date: '2025-09-01' } }));
+    expect(spy).toHaveBeenCalledWith('2025-09-01');
+  });
 });


### PR DESCRIPTION
## Summary
- Add global `loadWaitlist` helper and use it on initial page load, agenda-day clicks, and `agenda:changed` events without calendar component
- Include new Vitest coverage ensuring `loadWaitlist` is triggered when `agenda:changed` fires without an agenda component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ba1e7d08832abb332f9d93a12a1f