### PR TITLE
Add margin bottom to waitlist cards

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -310,7 +310,7 @@ window.renderWaitlist = function (items) {
     items.forEach(item => {
         container.insertAdjacentHTML(
             'beforeend',
-            `<div class="border rounded p-3 flex flex-col gap-2"><div class="font-medium">${item.paciente || ''}</div><div class="text-sm text-gray-500">${item.contato || ''}</div><div class="flex justify-between items-center"><span class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full">Lista de espera</span><button class="text-sm text-blue-600 hover:underline" data-id="${item.id}">Encaixar</button></div></div>`
+            `<div class="border rounded p-3 flex flex-col gap-2 mb-2.5"><div class="font-medium">${item.paciente || ''}</div><div class="text-sm text-gray-500">${item.contato || ''}</div><div class="flex justify-between items-center"><span class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full">Lista de espera</span><button class="text-sm text-blue-600 hover:underline" data-id="${item.id}">Encaixar</button></div></div>`
         );
     });
 };


### PR DESCRIPTION
## Summary
- add margin-bottom spacing to waitlist cards

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bd7f068c832ab2396d524e69def6