### PR TITLE
Exibe observação na lista de espera

### DIFF
--- a/app/Http/Controllers/Admin/AgendamentoController.php
+++ b/app/Http/Controllers/Admin/AgendamentoController.php
@@ -212,6 +212,7 @@ class AgendamentoController extends Controller
                     'id' => $ag->id,
                     'paciente' => $pessoa ? trim(($pessoa->primeiro_nome ?? '') . ' ' . ($pessoa->ultimo_nome ?? '')) : '',
                     'contato' => $ag->contato ?? '',
+                    'observacao' => $ag->observacao ?? '',
                 ];
             })
             ->values();

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -310,7 +310,7 @@ window.renderWaitlist = function (items) {
     items.forEach(item => {
         container.insertAdjacentHTML(
             'beforeend',
-            `<div class="border rounded p-3 flex flex-col gap-2"><div class="font-medium">${item.paciente || ''}</div><div class="text-sm text-gray-500">${item.contato || ''}</div><div class="flex justify-between items-center"><span class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full">Lista de espera</span><button class="text-sm text-blue-600 hover:underline" data-id="${item.id}">Encaixar</button></div></div>`
+            `<div class="border rounded p-3 flex flex-col gap-2"><div class="font-medium">${item.paciente || ''}</div><div class="text-sm text-gray-500">${item.contato || ''}</div><div class="text-sm text-gray-500">${item.observacao || ''}</div><div class="flex justify-between items-center"><span class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full">Lista de espera</span><button class="text-sm text-blue-600 hover:underline" data-id="${item.id}">Encaixar</button></div></div>`
         );
     });
 };

--- a/resources/js/waitlist.test.js
+++ b/resources/js/waitlist.test.js
@@ -29,8 +29,9 @@ describe('waitlist integration', () => {
       if (url.includes('waitlist')) {
         const date = url.split('date=')[1];
         const name = date === '2025-08-07' ? 'Joao' : 'Maria';
+        const observacao = date === '2025-08-07' ? 'obs1' : 'obs2';
         return Promise.resolve({
-          json: () => Promise.resolve({ waitlist: [{ id: 1, paciente: name, contato: '123' }] })
+          json: () => Promise.resolve({ waitlist: [{ id: 1, paciente: name, contato: '123', observacao }] })
         });
       }
       return Promise.resolve({ json: () => Promise.resolve({}) });
@@ -48,7 +49,9 @@ describe('waitlist integration', () => {
     await comp.loadData('2025-08-07');
 
     expect(fetchMock).toHaveBeenCalledWith('/admin/agendamentos/waitlist?date=2025-08-07');
-    expect(document.getElementById('waitlist-container').textContent).toContain('Joao');
+    const content = document.getElementById('waitlist-container').textContent;
+    expect(content).toContain('Joao');
+    expect(content).toContain('obs1');
   });
 
   it('updates waitlist when date changes', async () => {
@@ -65,7 +68,9 @@ describe('waitlist integration', () => {
     await comp.loadData('2025-08-08');
 
     expect(fetchMock).toHaveBeenCalledWith('/admin/agendamentos/waitlist?date=2025-08-08');
-    expect(document.getElementById('waitlist-container').textContent).toContain('Maria');
+    const content = document.getElementById('waitlist-container').textContent;
+    expect(content).toContain('Maria');
+    expect(content).toContain('obs2');
   });
 
   it('calls loadWaitlist when agenda changes without component', () => {

--- a/tests/Feature/WaitlistTest.php
+++ b/tests/Feature/WaitlistTest.php
@@ -126,6 +126,7 @@ namespace {
                 'data' => '2025-08-07',
                 'status' => 'lista_espera',
                 'contato' => '1199999999',
+                'observacao' => 'Checar radiografia',
             ]);
             $res = $controller->store($storeReq);
             $this->assertSame(['success' => true], $res);
@@ -136,6 +137,7 @@ namespace {
             $this->assertSame(1, count($items));
             $this->assertSame('Ana Silva', $items[0]['paciente']);
             $this->assertSame('1199999999', $items[0]['contato']);
+            $this->assertSame('Checar radiografia', $items[0]['observacao']);
         }
     }
 


### PR DESCRIPTION
## Resumo
- inclui observação no retorno da API de lista de espera
- mostra observação no card de cada paciente da lista de espera
- ajusta testes para cobrir exibição da observação

## Testes
- `npm test`
- `composer install` *(falha: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(falha: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bdd27cfc832a9e1ce1580a21e042