### PR TITLE
fix: ensure consistent layout scroll

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -30,7 +30,7 @@
                 @include('partials.topbar')
             @endunless
         @endauth
-        <main class="flex-1 p-6 overflow-y-auto">
+        <main class="flex-1 p-6 overflow-y-scroll">
             @if ($errors->any() && !(isset($hideErrors) && $hideErrors))
                 @include('components.alert-error', ['slot' => $errors->first()])
             @endif


### PR DESCRIPTION
## Summary
- keep a persistent vertical scrollbar on the main layout by using `overflow-y-scroll`

## Testing
- `npm run build`
- `npm test`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5daca5554832ab07f54f0e1aadc12