### PR TITLE
Use suggested times when schedule freed

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1530,11 +1530,18 @@ document.addEventListener('horario:liberado', async e => {
     if (!waitlistData.waitlist.length) return;
     const match = waitlistData.waitlist.find(w => !profissional_id || String(w.profissional_id) === String(profissional_id));
     if (!match) return;
-    const msg = `Horário às ${hora} liberado. Encaixar ${match.paciente} (${match.contato})?`;
+    const { sugestao } = match;
+    const sugestaoInicio = sugestao?.inicio;
+    const sugestaoFim = sugestao?.fim;
+    const sugText = sugestaoInicio && sugestaoFim ? `${sugestaoInicio}–${sugestaoFim}` : sugestaoInicio || '';
+    let msg = `Horário às ${hora} liberado. Encaixar ${match.paciente} (${match.contato})?`;
+    if (sugText && sugestaoInicio !== hora) {
+        msg = `Horário às ${hora} liberado (sugestão: ${sugText}). Encaixar ${match.paciente} (${match.contato})?`;
+    }
     if (!window.confirm(msg)) return;
     selection.date = data;
     selection.professional = profissional_id;
-    selection.start = hora;
-    selection.end = null;
+    selection.start = sugestaoInicio || hora;
+    selection.end = sugestaoFim || null;
     abrirModalAgendamento({ ...match, status: 'confirmado' });
 });

--- a/resources/js/horario-liberado.test.js
+++ b/resources/js/horario-liberado.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.MutationObserver = dom.window.MutationObserver;
+global.CustomEvent = dom.window.CustomEvent;
+global.Event = dom.window.Event;
+
+let loaded = false;
+beforeAll(async () => {
+  if (!loaded) {
+    await import('./app.js');
+    loaded = true;
+  }
+});
+
+describe('horario:liberado listener', () => {
+  let fetchMock;
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="schedule-modal" class="hidden">
+        <input id="schedule-start" />
+        <input id="schedule-end" />
+        <input id="schedule-paciente" />
+        <input id="agendamento-id" />
+        <input id="schedule-professional" />
+        <input id="schedule-date" />
+        <div id="schedule-summary"></div>
+        <input id="hora_inicio" />
+        <input id="hora_fim" />
+        <div id="step-1"></div>
+        <div id="step-2" class="hidden"></div>
+        <input id="patient-search" />
+        <ul id="patient-results"></ul>
+        <div id="patient-notfound"></div>
+        <span id="selected-patient-name"></span>
+        <button id="patient-search-btn"></button>
+        <select id="schedule-status"></select>
+        <div id="schedule-time"></div>
+        <button id="schedule-save" data-store-url="#" data-update-url="#"></button>
+      </div>
+      <table id="schedule-table"><thead></thead><tbody></tbody></table>
+    `;
+    window.attachCellHandlers();
+    fetchMock = vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            waitlist: [
+              {
+                id: 1,
+                paciente: 'Fulano',
+                contato: '123',
+                observacao: '',
+                profissional_id: 1,
+                sugestao: { inicio: '09:00', fim: '09:30' },
+              },
+            ],
+          }),
+      })
+    );
+    global.fetch = fetchMock;
+    window.confirm = vi.fn(() => true);
+  });
+
+  it('prefills modal with suggested times and shows both options in message', async () => {
+    document.dispatchEvent(
+      new CustomEvent('horario:liberado', {
+        detail: { data: '2025-08-07', hora: '10:00', profissional_id: 1 },
+      })
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(fetchMock).toHaveBeenCalledWith('/admin/agendamentos/waitlist?date=2025-08-07&range=3');
+    const msg = window.confirm.mock.calls[0][0];
+    expect(msg).toContain('10:00');
+    expect(msg).toContain('09:00–09:30');
+    expect(document.getElementById('schedule-start').value).toBe('09:00');
+    expect(document.getElementById('schedule-end').value).toBe('09:30');
+  });
+});


### PR DESCRIPTION
## Summary
- Use waitlist suggestion as default time when a schedule slot is freed and notify if it differs from liberated hour
- Add tests covering horario:liberado listener default suggestion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f9a73334832ab0f55f63551ce70e