### PR TITLE
feat: add waitlist month button

### DIFF
--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -120,11 +120,16 @@
         <div class="bg-white rounded-lg shadow p-4">
             <div class="flex justify-between items-center mb-2">
                 <h2 class="font-semibold">Lista de Espera</h2>
-                <button id="waitlist-add" class="p-1 text-blue-600 hover:text-blue-800">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-                    </svg>
-                </button>
+                <div class="flex items-center gap-2">
+                    <button id="btn-waitlist-month" class="p-1 text-blue-600 hover:text-blue-800">
+                        <i class="fa fa-calendar"></i>
+                    </button>
+                    <button id="waitlist-add" class="p-1 text-blue-600 hover:text-blue-800">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                        </svg>
+                    </button>
+                </div>
             </div>
             <div id="waitlist-container"></div>
         </div>


### PR DESCRIPTION
## Summary
- add calendar button to waitlist card for month view

## Testing
- `npm test`
- `php artisan test` (fails: Failed opening required 'vendor/autoload.php')
- `composer install` (fails: CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_68a5fdf5d15c832ab70f9c3e0770caa0