### PR TITLE
Replace Font Awesome calendar icon with inline SVG

### DIFF
--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -122,7 +122,9 @@
                 <h2 class="font-semibold">Lista de Espera</h2>
                 <div class="flex items-center gap-2">
                     <button id="btn-waitlist-month" class="p-1 text-blue-600 hover:text-blue-800">
-                        <i class="fa fa-calendar"></i>
+                        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
                     </button>
                     <button id="waitlist-add" class="p-1 text-blue-600 hover:text-blue-800">
                         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Summary
- replace Font Awesome calendar icon on waitlist button with inline SVG calendar matching project styles

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a60b5f0bb0832a9fbd1f6816f20fba