### PR TITLE
Add financial management layout and navigation entry

### DIFF
--- a/resources/views/components/dashboard/chart.blade.php
+++ b/resources/views/components/dashboard/chart.blade.php
@@ -1,4 +1,4 @@
-@props(['title', 'chartId' => null])
+@props(['title', 'chartId' => null, 'height' => 'h-64'])
 
 @php
     $id = $chartId ?: \Illuminate\Support\Str::slug($title);
@@ -9,7 +9,7 @@
         <h3 class="text-lg font-semibold text-gray-700">{{ $title }}</h3>
         {{ $header ?? '' }}
     </div>
-    <div class="h-64">
+    <div class="{{ $height }}">
         <canvas id="{{ $id }}" class="w-full h-full"></canvas>
     </div>
     {{ $slot ?? '' }}

--- a/resources/views/components/dashboard/select-unidade.blade.php
+++ b/resources/views/components/dashboard/select-unidade.blade.php
@@ -1,7 +1,7 @@
-@props(['options' => []])
+@props(['options' => [], 'label' => 'Todas as Unidades'])
 <div class="relative" x-data="{ open: false }">
     <button @click="open = !open" type="button" class="flex items-center px-4 py-2 bg-white border rounded shadow-sm text-sm hover:bg-gray-50">
-        <span class="mr-2">Todas as Unidades</span>
+        <span class="mr-2">{{ $label }}</span>
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
         </svg>

--- a/resources/views/components/dashboard/stats-card.blade.php
+++ b/resources/views/components/dashboard/stats-card.blade.php
@@ -1,9 +1,9 @@
-@props(['title', 'value', 'icon' => null, 'comparison' => null])
+@props(['title', 'value', 'icon' => null, 'comparison' => null, 'valueClass' => 'text-black'])
 <div class="rounded-sm border border-stroke bg-white p-5 shadow">
     <div class="flex items-center justify-between">
         <div>
             <p class="text-sm text-gray-500">{{ $title }}</p>
-            <p class="mt-1 text-xl font-bold text-black">{{ $value }}</p>
+            <p class="mt-1 text-xl font-bold {{ $valueClass }}">{{ $value }}</p>
         </div>
         @if ($icon)
             <div class="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">

--- a/resources/views/financeiro/index.blade.php
+++ b/resources/views/financeiro/index.blade.php
@@ -1,0 +1,130 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Financeiro']
+]])
+
+<div class="flex items-start justify-between mb-6">
+    <div>
+        <h1 class="text-2xl font-bold">Gestão Financeira</h1>
+        <p class="text-gray-600">Controle financeiro completo do consultório</p>
+    </div>
+    <div class="flex items-center gap-2">
+        <x-dashboard.select-unidade label="Todas as Clínicas" :options="$clinics" />
+        <a href="#" class="py-2 px-4 bg-emerald-600 text-white rounded hover:bg-emerald-700 text-sm">+ Novo Recebimento</a>
+        <a href="#" class="py-2 px-4 bg-red-600 text-white rounded hover:bg-red-700 text-sm">+ Novo Pagamento</a>
+        <a href="#" class="p-2 border rounded text-sm" title="Relatórios">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V9m4 10V5m4 14v-7M5 19V5" /></svg>
+        </a>
+    </div>
+</div>
+
+<div class="mb-6 border-b">
+    <nav class="flex space-x-4">
+        <button class="pb-2 text-sm font-medium border-b-2 border-emerald-600 text-emerald-600">Diário</button>
+        <button class="pb-2 text-sm font-medium text-gray-600 hover:text-emerald-600">Semanal</button>
+        <button class="pb-2 text-sm font-medium text-gray-600 hover:text-emerald-600">Mensal</button>
+        <button class="pb-2 text-sm font-medium text-gray-600 hover:text-emerald-600">Anual</button>
+        <button class="pb-2 text-sm font-medium text-gray-600 hover:text-emerald-600">Personalizado</button>
+    </nav>
+</div>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-6">
+    <x-dashboard.stats-card title="Saldo Atual" value="R$ 12.345,67" valueClass="text-emerald-600" />
+    <x-dashboard.stats-card title="Receitas (Mês)" value="R$ 25.000,00" valueClass="text-emerald-600" comparison="↑ 5% vs mês anterior" />
+    <x-dashboard.stats-card title="Despesas (Mês)" value="R$ 18.000,00" valueClass="text-red-600" comparison="↓ 3% vs mês anterior" />
+    <x-dashboard.stats-card title="A Receber" value="R$ 4.500,00" valueClass="text-orange-500" comparison="3 pendências" />
+</div>
+
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+    <x-dashboard.chart title="Comparativo entre Clínicas" chartId="comparativoClinicas" height="h-80" />
+    <x-dashboard.chart title="Fluxo de Caixa (6 meses)" chartId="fluxoCaixa" height="h-80" />
+    <div class="lg:col-span-2">
+        <x-dashboard.chart title="Formas de Pagamento" chartId="formasPagamento" height="h-80" />
+    </div>
+</div>
+
+<div class="mt-6">
+    <div class="flex space-x-4 border-b">
+        <button class="pb-2 text-sm font-medium border-b-2 border-emerald-600 text-emerald-600">Fluxo de Caixa</button>
+        <button class="pb-2 text-sm font-medium text-gray-600 hover:text-emerald-600">Receitas</button>
+        <button class="pb-2 text-sm font-medium text-gray-600 hover:text-emerald-600">Despesas</button>
+        <button class="pb-2 text-sm font-medium text-gray-600 hover:text-emerald-600">Relatórios</button>
+    </div>
+    <div class="p-6 bg-white rounded-b-lg">
+        <p class="text-sm text-gray-600">Conteúdo de exemplo para Fluxo de Caixa.</p>
+    </div>
+</div>
+
+@endsection
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const ctxClinicas = document.getElementById('comparativoClinicas').getContext('2d');
+    let chartClinicas;
+    function renderClinicas() {
+        if (chartClinicas) chartClinicas.destroy();
+        chartClinicas = new Chart(ctxClinicas, {
+            type: 'bar',
+            data: {
+                labels: ['Centro', 'Norte', 'Sul'],
+                datasets: [
+                    { label: 'Receitas', data: [12, 19, 3], backgroundColor: 'rgba(16,185,129,0.5)' },
+                    { label: 'Despesas', data: [8, 11, 5], backgroundColor: 'rgba(239,68,68,0.5)' }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false
+            }
+        });
+    }
+    renderClinicas();
+
+    const ctxFluxo = document.getElementById('fluxoCaixa').getContext('2d');
+    let chartFluxo;
+    function renderFluxo() {
+        if (chartFluxo) chartFluxo.destroy();
+        chartFluxo = new Chart(ctxFluxo, {
+            type: 'bar',
+            data: {
+                labels: ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun'],
+                datasets: [
+                    { label: 'Saldo', data: [5, 10, 8, 12, 7, 9], backgroundColor: 'rgba(59,130,246,0.5)' }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false
+            }
+        });
+    }
+    renderFluxo();
+
+    const ctxPag = document.getElementById('formasPagamento').getContext('2d');
+    let chartPag;
+    function renderPag() {
+        if (chartPag) chartPag.destroy();
+        chartPag = new Chart(ctxPag, {
+            type: 'doughnut',
+            data: {
+                labels: ['Dinheiro', 'Cartão', 'Pix'],
+                datasets: [{
+                    data: [30, 50, 20],
+                    backgroundColor: ['#10B981', '#3B82F6', '#F59E0B']
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false
+            }
+        });
+    }
+    renderPag();
+});
+</script>
+@endpush
+

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -57,6 +57,10 @@
             <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V8a1 1 0 00-.553-.894l-7-3.5a1 1 0 00-.894 0l-7 3.5A1 1 0 004 8v5m16 0v5a1 1 0 01-.553.894l-7 3.5a1 1 0 01-.894 0l-7-3.5A1 1 0 014 18v-5m16 0L12 7.5M4 13l8-4.5" /></svg>
             <span class="ml-3" x-show="!sidebarCollapsed">Estoque</span>
         </a>
+        <a href="{{ route('financeiro.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Financeiro' : ''">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3 1.343 3 3-1.343 3-3 3m0-12V4m0 16v-4m0 4c1.657 0 3-1.343 3-3s-1.343-3-3-3-3-1.343-3-3 1.343-3 3-3" /></svg>
+            <span class="ml-3" x-show="!sidebarCollapsed">Financeiro</span>
+        </a>
         <div class="mt-2" x-data="{ open: false }">
             <button @click="open = !open" class="flex items-center w-full px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Administração' : ''">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V5a2 2 0 00-2-2H6a2 2 0 00-2 2v8m16 0v6a2 2 0 01-2 2H6a2 2 0 01-2-2v-6m16 0H4" /></svg>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -49,3 +49,5 @@ Route::resource('escalas', EscalaTrabalhoController::class)->only(['index','stor
 
 Route::get('estoque', [EstoqueController::class, 'index'])->name('estoque.index');
 
+Route::view('financeiro', 'financeiro.index', ['clinics' => ['Clínica Centro', 'Clínica Norte']])->name('financeiro.index');
+


### PR DESCRIPTION
## Summary
- add Financeiro menu entry and route
- create Gestão Financeira page layout with stats and charts
- extend dashboard components for colored stats, adjustable chart height and labeled clinic selector

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a77e9ae6bc832aae9d4e1d7f10b70e