### PR TITLE
Expose budget signature route

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -41,8 +41,6 @@ Route::get('pacientes/search', [PatientController::class, 'search'])->name('paci
 Route::resource('pacientes', PatientController::class)
     ->parameters(['pacientes' => 'paciente']);
 
-Route::view('orcamentos/assinar', 'orcamentos.assinar')->name('orcamentos.assinar');
-
 Route::post('selecionar-clinica', [ClinicContextController::class, 'update'])->name('clinicas.selecionar');
 
 Route::resource('escalas', EscalaTrabalhoController::class)->only(['index','store','update','destroy']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,8 @@ Route::get('/', function () {
 
 require __DIR__.'/auth.php';
 
+Route::view('orcamentos/assinar', 'orcamentos.assinar')->name('orcamentos.assinar');
+
 Route::middleware(['web', 'auth', 'forcepasswordchange'])->group(function () {
     Route::get('/password/change', [\App\Http\Controllers\Auth\PasswordController::class, 'edit'])->name('password.change');
     Route::post('/password/change', [\App\Http\Controllers\Auth\PasswordController::class, 'update'])->name('password.update');


### PR DESCRIPTION
## Summary
- make budget signature page accessible outside admin prefix
- remove obsolete admin-only budget route

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `php -d detect_unicode=0 vendor/bin/phpunit` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68a79a9dfd90832a840c9ea9f2d349ef