### PR TITLE
Add fluxo route and view for agenda

### DIFF
--- a/app/Http/Controllers/Admin/AgendaController.php
+++ b/app/Http/Controllers/Admin/AgendaController.php
@@ -38,6 +38,11 @@ class AgendaController extends Controller
         ));
     }
 
+    public function fluxo()
+    {
+        return view('agenda.fluxo');
+    }
+
     public function horarios(Request $request)
     {
         $clinicId = app()->bound('clinic_id') ? app('clinic_id') : null;

--- a/resources/views/agenda/fluxo.blade.php
+++ b/resources/views/agenda/fluxo.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('content')
+@include('partials.breadcrumbs', ['crumbs' => [
+    ['label' => 'Dashboard', 'url' => route('admin.index')],
+    ['label' => 'Agenda', 'url' => route('agenda.index')],
+    ['label' => 'Fluxo'],
+]])
+<div class="mb-6 flex items-start justify-between">
+    <div>
+        <h1 class="text-2xl font-bold">Fluxo de Pacientes</h1>
+        <p class="text-gray-600">Acompanhamento do fluxo de pacientes na clínica</p>
+    </div>
+</div>
+<div class="border-b mb-6">
+    <nav class="-mb-px flex gap-4">
+        <a href="{{ route('agenda.index') }}" class="px-1 pb-2 text-gray-500 hover:text-gray-700">Agenda</a>
+        <a href="{{ url('/admin/agenda/fluxo') }}" class="px-1 pb-2 border-b-2 border-blue-600 text-blue-600">Fluxo</a>
+    </nav>
+</div>
+<p class="text-gray-600">Em construção.</p>
+@endsection

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Admin\EstoqueController;
 Route::get('/', [DashboardController::class, 'index'])->name('admin.index');
 
 Route::get('agenda', [AgendaController::class, 'index'])->name('agenda.index');
+Route::get('agenda/fluxo', [AgendaController::class, 'fluxo'])->name('agenda.fluxo');
 Route::get('agenda/consultas', [AgendamentoController::class, 'consultasDia'])->name('agenda.consultas');
 Route::get('agendamentos', [AgendamentoController::class, 'index'])->name('agendamentos.index');
 Route::post('agendamentos', [AgendamentoController::class, 'store'])->name('agendamentos.store');


### PR DESCRIPTION
## Summary
- fix missing `/admin/agenda/fluxo` route by adding controller method
- add placeholder Fluxo page so navigation works

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: curl error 56: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab25413c20832a99f5a5a88a42ad4a