### PR TITLE
feat: apply TailAdmin select styling on agenda page

### DIFF
--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -65,19 +65,33 @@
         <div class="bg-white rounded-lg shadow p-4 space-y-4">
             <div>
                 <label class="block text-sm font-medium mb-1" for="professional">Profissional</label>
-                <select id="professional" class="w-full border-gray-300 rounded">
-                    <option>Todos</option>
-                    <option>Dr. João</option>
-                    <option>Dra. Ana</option>
-                </select>
+                <div class="relative z-20 w-full">
+                    <select id="professional" class="relative z-20 w-full appearance-none rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
+                        <option>Todos</option>
+                        <option>Dr. João</option>
+                        <option>Dra. Ana</option>
+                    </select>
+                    <span class="pointer-events-none absolute top-1/2 right-4 -translate-y-1/2">
+                        <svg class="h-5 w-5 fill-current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+                        </svg>
+                    </span>
+                </div>
             </div>
             <div>
                 <label class="block text-sm font-medium mb-1" for="type">Tipo de Consulta</label>
-                <select id="type" class="w-full border-gray-300 rounded">
-                    <option>Todos</option>
-                    <option>Consulta</option>
-                    <option>Retorno</option>
-                </select>
+                <div class="relative z-20 w-full">
+                    <select id="type" class="relative z-20 w-full appearance-none rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
+                        <option>Todos</option>
+                        <option>Consulta</option>
+                        <option>Retorno</option>
+                    </select>
+                    <span class="pointer-events-none absolute top-1/2 right-4 -translate-y-1/2">
+                        <svg class="h-5 w-5 fill-current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/agendamentos/partials/modal.blade.php
+++ b/resources/views/agendamentos/partials/modal.blade.php
@@ -37,13 +37,20 @@
             </label>
             <label class="block mb-4">
                 <span class="text-sm">Status</span>
-                <select id="schedule-status" class="mt-1 w-full border rounded p-1">
-                    <option value="confirmado">Confirmado</option>
-                    <option value="pendente">Pendente</option>
-                    <option value="cancelado">Cancelado</option>
-                    <option value="faltou">Faltou</option>
-                    <option value="lista_espera">Lista de espera</option>
-                </select>
+                <div class="relative z-20 mt-1 w-full">
+                    <select id="schedule-status" class="relative z-20 w-full appearance-none rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
+                        <option value="confirmado">Confirmado</option>
+                        <option value="pendente">Pendente</option>
+                        <option value="cancelado">Cancelado</option>
+                        <option value="faltou">Faltou</option>
+                        <option value="lista_espera">Lista de espera</option>
+                    </select>
+                    <span class="pointer-events-none absolute top-1/2 right-4 -translate-y-1/2">
+                        <svg class="h-5 w-5 fill-current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+                        </svg>
+                    </span>
+                </div>
             </label>
             <div class="flex justify-end gap-2">
                 <button id="schedule-cancel" class="px-3 py-1 border rounded">Cancelar</button>

--- a/resources/views/partials/topbar.blade.php
+++ b/resources/views/partials/topbar.blade.php
@@ -22,11 +22,18 @@
             @if ($clinics->count() > 1)
                 <form method="POST" action="{{ route('clinicas.selecionar') }}">
                     @csrf
-                    <select name="clinic_id" onchange="this.form.submit()" class="border-gray-300 rounded py-2 px-2 text-sm">
-                        @foreach ($clinics as $clinic)
-                            <option value="{{ $clinic->id }}" @selected($clinic->id == $currentClinic)>{{ $clinic->nome }}</option>
-                        @endforeach
-                    </select>
+                    <div class="relative">
+                        <select name="clinic_id" onchange="this.form.submit()" class="appearance-none rounded border-[1.5px] border-stroke bg-gray-2 py-2 pl-3 pr-8 text-sm text-black focus:border-primary focus:outline-none">
+                            @foreach ($clinics as $clinic)
+                                <option value="{{ $clinic->id }}" @selected($clinic->id == $currentClinic)>{{ $clinic->nome }}</option>
+                            @endforeach
+                        </select>
+                        <span class="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2">
+                            <svg class="h-4 w-4 fill-current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+                            </svg>
+                        </span>
+                    </div>
                 </form>
             @elseif ($clinics->count() === 1)
                 <span class="text-sm text-gray-600">{{ $clinics->first()->nome }}</span>


### PR DESCRIPTION
## Summary
- style agenda page selects using TailAdmin design
- restyle status select in schedule modal
- align topbar clinic selector with TailAdmin styling

## Testing
- `npm test`
- `php artisan test` *(fails: require(/workspace/dentix/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f581e90832aad1ee2f7b9b76c71