### PR TITLE
Remove custom arrow spans from selects

### DIFF
--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -66,31 +66,21 @@
             <div>
                 <label class="block text-sm font-medium mb-1" for="professional">Profissional</label>
                 <div class="relative z-20 w-full">
-                    <select id="professional" class="relative z-20 w-full appearance-none rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
+                    <select id="professional" class="relative z-20 w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
                         <option>Todos</option>
                         <option>Dr. João</option>
                         <option>Dra. Ana</option>
                     </select>
-                    <span class="pointer-events-none absolute top-1/2 right-4 -translate-y-1/2">
-                        <svg class="h-5 w-5 fill-current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
-                        </svg>
-                    </span>
                 </div>
             </div>
             <div>
                 <label class="block text-sm font-medium mb-1" for="type">Tipo de Consulta</label>
                 <div class="relative z-20 w-full">
-                    <select id="type" class="relative z-20 w-full appearance-none rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
+                    <select id="type" class="relative z-20 w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
                         <option>Todos</option>
                         <option>Consulta</option>
                         <option>Retorno</option>
                     </select>
-                    <span class="pointer-events-none absolute top-1/2 right-4 -translate-y-1/2">
-                        <svg class="h-5 w-5 fill-current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
-                        </svg>
-                    </span>
                 </div>
             </div>
         </div>

--- a/resources/views/agendamentos/partials/modal.blade.php
+++ b/resources/views/agendamentos/partials/modal.blade.php
@@ -38,18 +38,13 @@
             <label class="block mb-4">
                 <span class="text-sm">Status</span>
                 <div class="relative z-20 mt-1 w-full">
-                    <select id="schedule-status" class="relative z-20 w-full appearance-none rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
+                    <select id="schedule-status" class="relative z-20 w-full rounded border-[1.5px] border-stroke bg-gray-2 py-3 px-5 text-sm text-black outline-none transition focus:border-primary">
                         <option value="confirmado">Confirmado</option>
                         <option value="pendente">Pendente</option>
                         <option value="cancelado">Cancelado</option>
                         <option value="faltou">Faltou</option>
                         <option value="lista_espera">Lista de espera</option>
                     </select>
-                    <span class="pointer-events-none absolute top-1/2 right-4 -translate-y-1/2">
-                        <svg class="h-5 w-5 fill-current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
-                        </svg>
-                    </span>
                 </div>
             </label>
             <div class="flex justify-end gap-2">

--- a/resources/views/partials/topbar.blade.php
+++ b/resources/views/partials/topbar.blade.php
@@ -23,16 +23,11 @@
                 <form method="POST" action="{{ route('clinicas.selecionar') }}">
                     @csrf
                     <div class="relative">
-                        <select name="clinic_id" onchange="this.form.submit()" class="appearance-none rounded border-[1.5px] border-stroke bg-gray-2 py-2 pl-3 pr-8 text-sm text-black focus:border-primary focus:outline-none">
+                        <select name="clinic_id" onchange="this.form.submit()" class="rounded border-[1.5px] border-stroke bg-gray-2 py-2 pl-3 pr-8 text-sm text-black focus:border-primary focus:outline-none">
                             @foreach ($clinics as $clinic)
                                 <option value="{{ $clinic->id }}" @selected($clinic->id == $currentClinic)>{{ $clinic->nome }}</option>
                             @endforeach
                         </select>
-                        <span class="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2">
-                            <svg class="h-4 w-4 fill-current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
-                            </svg>
-                        </span>
                     </div>
                 </form>
             @elseif ($clinics->count() === 1)


### PR DESCRIPTION
## Summary
- simplify agenda filters by removing custom dropdown arrows
- streamline schedule modal status select
- clean topbar clinic selector styling

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab337a0e00832a901a8d6d49a2113f