### PR TITLE
style: apply TailAdmin select styling

### DIFF
--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -19,11 +19,18 @@
 <form method="GET" class="flex flex-wrap gap-4 mb-4">
     <div>
         <label class="block text-sm font-medium mb-1">Clínica</label>
-        <select name="clinic_id" class="border rounded px-2 py-1" onchange="this.form.submit()">
-            @foreach($clinics as $c)
-                <option value="{{ $c->id }}" @selected($clinicId==$c->id)>{{ $c->nome }}</option>
-            @endforeach
-        </select>
+        <div class="relative">
+            <select name="clinic_id" class="appearance-none w-full rounded border border-stroke bg-transparent py-2 pl-3 pr-10 focus:border-primary" onchange="this.form.submit()">
+                @foreach($clinics as $c)
+                    <option value="{{ $c->id }}" @selected($clinicId==$c->id)>{{ $c->nome }}</option>
+                @endforeach
+            </select>
+            <span class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                <svg class="fill-current" width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M6.00016 7.33325L0.666992 1.99992L1.84016 0.826752L6.00016 4.98675L10.1602 0.826752L11.3335 1.99992L6.00016 7.33325Z" fill="currentColor"/>
+                </svg>
+            </span>
+        </div>
     </div>
     <div>
         <label class="block text-sm font-medium mb-1">Ano</label>
@@ -31,11 +38,18 @@
     </div>
     <div>
         <label class="block text-sm font-medium mb-1">Mês</label>
-        <select name="month" id="mesSelecionado" class="border rounded px-2 py-1" onchange="this.form.submit()">
-            @foreach($mesesDisponiveis as $mes)
-                <option value="{{ $mes->month }}" @selected($mes->equalTo($month))>{{ $mes->translatedFormat('F') }}</option>
-            @endforeach
-        </select>
+        <div class="relative">
+            <select name="month" id="mesSelecionado" class="appearance-none w-full rounded border border-stroke bg-transparent py-2 pl-3 pr-10 focus:border-primary" onchange="this.form.submit()">
+                @foreach($mesesDisponiveis as $mes)
+                    <option value="{{ $mes->month }}" @selected($mes->equalTo($month))>{{ $mes->translatedFormat('F') }}</option>
+                @endforeach
+            </select>
+            <span class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                <svg class="fill-current" width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M6.00016 7.33325L0.666992 1.99992L1.84016 0.826752L6.00016 4.98675L10.1602 0.826752L11.3335 1.99992L6.00016 7.33325Z" fill="currentColor"/>
+                </svg>
+            </span>
+        </div>
     </div>
     <div class="flex items-end gap-2">
         <button type="button" id="prev-month-btn" class="px-2 py-1 border rounded">Anterior</button>
@@ -97,11 +111,18 @@
             <input type="hidden" id="calendar-month-input" value="{{ $month->format('Y-m') }}">
             <div>
                 <label class="block text-sm mb-1">Profissional</label>
-                <select name="profissional_id" class="w-full border rounded px-2 py-1">
-                    @foreach($dentistas as $d)
-                        <option value="{{ $d->id }}">{{ $d->pessoa->primeiro_nome }} {{ $d->pessoa->ultimo_nome }}</option>
-                    @endforeach
-                </select>
+                <div class="relative">
+                    <select name="profissional_id" class="appearance-none w-full rounded border border-stroke bg-transparent py-2 pl-3 pr-10 focus:border-primary">
+                        @foreach($dentistas as $d)
+                            <option value="{{ $d->id }}">{{ $d->pessoa->primeiro_nome }} {{ $d->pessoa->ultimo_nome }}</option>
+                        @endforeach
+                    </select>
+                    <span class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                        <svg class="fill-current" width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M6.00016 7.33325L0.666992 1.99992L1.84016 0.826752L6.00016 4.98675L10.1602 0.826752L11.3335 1.99992L6.00016 7.33325Z" fill="currentColor"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
             <div class="mb-2">
                 <nav class="flex border-b">
@@ -126,11 +147,18 @@
                     </div>
                     <div class="flex-1">
                         <label class="block text-sm mb-1">Dia da semana</label>
-                        <select name="dias[]" multiple class="border rounded px-2 py-1 w-full" disabled>
-                            @foreach($dias as $d)
-                                <option value="{{ $d->toName() }}">{{ ucfirst($d->toName()) }}</option>
-                            @endforeach
-                        </select>
+                        <div class="relative">
+                            <select name="dias[]" multiple class="appearance-none w-full rounded border border-stroke bg-transparent py-2 pl-3 pr-10 focus:border-primary" disabled>
+                                @foreach($dias as $d)
+                                    <option value="{{ $d->toName() }}">{{ ucfirst($d->toName()) }}</option>
+                                @endforeach
+                            </select>
+                            <span class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                                <svg class="fill-current" width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M6.00016 7.33325L0.666992 1.99992L1.84016 0.826752L6.00016 4.98675L10.1602 0.826752L11.3335 1.99992L6.00016 7.33325Z" fill="currentColor"/>
+                                </svg>
+                            </span>
+                        </div>
                     </div>
                 </div>
                 <div class="flex gap-2 mb-2">
@@ -162,11 +190,18 @@
             </div>
             <div>
                 <label class="block text-sm mb-1">Cadeira</label>
-                <select name="cadeira_id" class="w-full border rounded px-2 py-1">
-                    @foreach($cadeiras as $c)
-                        <option value="{{ $c->id }}">{{ $c->nome }}</option>
-                    @endforeach
-                </select>
+                <div class="relative">
+                    <select name="cadeira_id" class="appearance-none w-full rounded border border-stroke bg-transparent py-2 pl-3 pr-10 focus:border-primary">
+                        @foreach($cadeiras as $c)
+                            <option value="{{ $c->id }}">{{ $c->nome }}</option>
+                        @endforeach
+                    </select>
+                    <span class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                        <svg class="fill-current" width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M6.00016 7.33325L0.666992 1.99992L1.84016 0.826752L6.00016 4.98675L10.1602 0.826752L11.3335 1.99992L6.00016 7.33325Z" fill="currentColor"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
             <div class="text-right space-x-2">
                 <button type="button" id="escala-delete" class="px-3 py-1 border rounded text-red-600 hidden">Excluir</button>


### PR DESCRIPTION
## Summary
- restyle schedule select inputs using TailAdmin classes and dropdown indicator

## Testing
- `npm test`
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3d2a8f8c832a956bf07503c9c06f