### PR TITLE
style: apply TailAdmin input classes

### DIFF
--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -30,7 +30,14 @@
     </div>
     <div>
         <label class="block text-sm font-medium mb-1">Ano</label>
-        <input type="number" name="year" id="anoSelecionado" class="border rounded px-2 py-1" value="{{ $month->year }}" onchange="this.form.submit()">
+        <input
+            type="number"
+            name="year"
+            id="anoSelecionado"
+            class="appearance-none w-24 rounded border border-stroke bg-transparent py-2 px-3 focus:border-primary focus:ring-primary"
+            value="{{ $month->year }}"
+            onchange="this.form.submit()"
+        >
     </div>
     <div>
         <label class="block text-sm font-medium mb-1">Mês</label>


### PR DESCRIPTION
## Summary
- restyle year selector with TailAdmin Tailwind classes for consistency

## Testing
- `npm test`
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab43a41a98832a8c551aed6fec2a4f