### PR TITLE
Adjust time inputs to use full width in schedule form

### DIFF
--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -170,13 +170,13 @@
                 </div>
             </div>
             <div class="flex gap-2 items-end">
-                <div>
+                <div class="w-1/2">
                     <label class="block text-sm mb-1">Início</label>
-                    <input type="time" name="hora_inicio" class="border rounded px-2 py-1">
+                    <input type="time" name="hora_inicio" class="w-full border rounded px-2 py-1">
                 </div>
-                <div>
+                <div class="w-1/2">
                     <label class="block text-sm mb-1">Fim</label>
-                    <input type="time" name="hora_fim" class="border rounded px-2 py-1">
+                    <input type="time" name="hora_fim" class="w-full border rounded px-2 py-1">
                 </div>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- Make start/end time inputs span full width of their containers
- Split start/end sections evenly with `w-1/2`

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-ansi --no-interaction --no-progress --no-scripts` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4df083c8832abfb1571e37bcb1cb