### PR TITLE
Open recurring schedule tab when editing escala cards

### DIFF
--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -323,9 +323,15 @@
             monthInput.value = date.slice(0,7);
             escalaForm.querySelector('[name="year"]').value = date.slice(0,4);
             escalaForm.querySelector('[name="month"]').value = parseInt(date.slice(5,7),10);
-            activateTab('daily');
+            activateTab('recurring');
+            escalaForm.querySelector('[name="semana"]').value = date;
+            const dayName = new Date(date).toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
+            const diasSelect = escalaForm.querySelector('[name="dias[]"]');
+            [...diasSelect.options].forEach(opt => {
+                opt.selected = opt.value.toLowerCase() === dayName;
+            });
+            escalaForm.querySelector('[name="repeat_until"]').value = '';
             escalaModal.classList.remove('hidden');
-            initCalendar([date], true);
         });
     });
 


### PR DESCRIPTION
## Summary
- Open recurring tab on escala card double-click
- Prefill week and weekday fields for recurring schedules and clear repeat-until
- Remove calendar initialization for recurring editing

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53194290832a839f71d44cb84a99