### PR TITLE
Ensure recurring schedule fields submitted and validate update interval

### DIFF
--- a/app/Http/Controllers/Admin/EscalaTrabalhoController.php
+++ b/app/Http/Controllers/Admin/EscalaTrabalhoController.php
@@ -251,7 +251,7 @@ class EscalaTrabalhoController extends Controller
                 'dias.*' => 'in:segunda,terca,quarta,quinta,sexta,sabado,domingo',
                 'hora_inicio' => 'required',
                 'hora_fim' => 'required',
-                'repeat_until' => 'nullable|date|after_or_equal:semana',
+                'repeat_until' => 'required_with:repeat_weeks|nullable|date|after_or_equal:semana',
                 'repeat_weeks' => 'nullable|integer|min:1',
                 'overwrite' => 'sometimes|boolean',
             ], [

--- a/resources/views/escalas/index.blade.php
+++ b/resources/views/escalas/index.blade.php
@@ -293,6 +293,18 @@
         escalaModal.classList.add('hidden');
     });
 
+    escalaForm.addEventListener('submit', () => {
+        if (!tabRecurring.classList.contains('hidden')) {
+            recurringInputs.forEach(el => {
+                el.disabled = false;
+            });
+            ['hora_inicio','hora_fim'].forEach(name => {
+                const input = escalaForm.querySelector(`[name="${name}"]`);
+                if (input) input.disabled = false;
+            });
+        }
+    });
+
     if (applyYear) {
         escalaForm.addEventListener('submit', () => {
             if (!tabRecurring.classList.contains('hidden') && applyYear.checked) {


### PR DESCRIPTION
## Summary
- Enable recurring schedule fields and times before submitting the form
- Require end date when repeating weeks in `EscalaTrabalhoController@update`
- Preserve deletion of existing schedule and insertion of new interval during update

## Testing
- `php artisan test` *(fails: require(/workspace/dentix/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68ab550db4bc832a84eb1220f0e36c3f