### PR TITLE
Add profile and account settings pages

### DIFF
--- a/app/Http/Controllers/AccountSettingsController.php
+++ b/app/Http/Controllers/AccountSettingsController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+
+class AccountSettingsController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+        return view('account.settings', compact('user'));
+    }
+}

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+
+class ProfileController extends Controller
+{
+    public function edit()
+    {
+        $user = Auth::user();
+        return view('profile.edit', compact('user'));
+    }
+}

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-2xl mx-auto bg-white p-6 rounded shadow">
+    <h1 class="text-2xl font-bold mb-4">Configurações da Conta</h1>
+    <p>Gerencie as configurações da sua conta.</p>
+</div>
+@endsection

--- a/resources/views/partials/topbar.blade.php
+++ b/resources/views/partials/topbar.blade.php
@@ -75,6 +75,8 @@
                     <p class="text-xs text-gray-500">{{ $user->email }}</p>
                 @endif
             </div>
+            <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Editar Perfil</a>
+            <a href="{{ route('account.settings') }}" class="block px-4 py-2 hover:bg-gray-100">Configurações da Conta</a>
             <form method="POST" action="{{ route('logout') }}">
                 @csrf
                 <button type="submit" class="w-full text-left px-4 py-2 hover:bg-gray-100">Sair</button>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-2xl mx-auto bg-white p-6 rounded shadow">
+    <h1 class="text-2xl font-bold mb-4">Editar Perfil</h1>
+    <p>Atualize suas informações de usuário aqui.</p>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,9 @@ Route::view('orcamentos/assinar', 'orcamentos.assinar')->name('orcamentos.assina
 Route::middleware(['web', 'auth', 'forcepasswordchange'])->group(function () {
     Route::get('/password/change', [\App\Http\Controllers\Auth\PasswordController::class, 'edit'])->name('password.change');
     Route::post('/password/change', [\App\Http\Controllers\Auth\PasswordController::class, 'update'])->name('password.update');
+
+    Route::get('/profile/edit', [\App\Http\Controllers\ProfileController::class, 'edit'])->name('profile.edit');
+    Route::get('/account/settings', [\App\Http\Controllers\AccountSettingsController::class, 'index'])->name('account.settings');
 });
 
 Route::middleware(['web', 'auth', 'forcepasswordchange', 'paciente'])


### PR DESCRIPTION
## Summary
- Add profile editing and account settings links to user menu
- Create ProfileController and AccountSettingsController with corresponding views
- Register authenticated routes for profile editing and account settings

## Testing
- `npm test`
- `php artisan test` *(fails: Failed opening required '/workspace/dentix/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ab554cf87c832aaa44eef53a1b00e6