### PR TITLE
feat: add TailAdmin tabs with icons to agenda views

### DIFF
--- a/resources/views/admin/agenda/fluxo.blade.php
+++ b/resources/views/admin/agenda/fluxo.blade.php
@@ -21,8 +21,18 @@
 </div>
 <div class="border-b mb-6">
     <nav class="-mb-px flex gap-4">
-        <a href="{{ route('agenda.index') }}" class="px-1 pb-2 text-gray-500 hover:text-gray-700">Agenda</a>
-        <a href="#" class="px-1 pb-2 border-b-2 border-blue-600 text-blue-600">Fluxo</a>
+        <a href="{{ route('agenda.index') }}" class="flex items-center gap-2 px-1 pb-2 border-b-2 border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            Agenda
+        </a>
+        <a href="{{ route('agenda.fluxo') }}" class="flex items-center gap-2 px-1 pb-2 border-b-2 border-primary text-primary">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.5 10.5a7.5 7.5 0 0113.5-3m1.5-3v3m0-3h-3M19.5 13.5A7.5 7.5 0 016 16.5m-1.5 3v-3m0 3h3" />
+            </svg>
+            Fluxo
+        </a>
     </nav>
 </div>
 <div x-data="agendaFluxo()" x-init="setup()">

--- a/resources/views/agenda.blade.php
+++ b/resources/views/agenda.blade.php
@@ -23,8 +23,18 @@
 </div>
 <div class="border-b mb-6">
     <nav class="-mb-px flex gap-4">
-        <a href="{{ route('agenda.index') }}" class="px-1 pb-2 border-b-2 border-blue-600 text-blue-600">Agenda</a>
-        <a href="{{ route('agenda.fluxo') }}" class="px-1 pb-2 text-gray-500 hover:text-gray-700">Fluxo</a>
+        <a href="{{ route('agenda.index') }}" class="flex items-center gap-2 px-1 pb-2 border-b-2 border-primary text-primary">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            Agenda
+        </a>
+        <a href="{{ route('agenda.fluxo') }}" class="flex items-center gap-2 px-1 pb-2 border-b-2 border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.5 10.5a7.5 7.5 0 0113.5-3m1.5-3v3m0-3h-3M19.5 13.5A7.5 7.5 0 016 16.5m-1.5 3v-3m0 3h3" />
+            </svg>
+            Fluxo
+        </a>
     </nav>
 </div>
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">

--- a/resources/views/agenda/fluxo.blade.php
+++ b/resources/views/agenda/fluxo.blade.php
@@ -14,8 +14,18 @@
 </div>
 <div class="border-b mb-6">
     <nav class="-mb-px flex gap-4">
-        <a href="{{ route('agenda.index') }}" class="px-1 pb-2 text-gray-500 hover:text-gray-700">Agenda</a>
-        <a href="{{ url('/admin/agenda/fluxo') }}" class="px-1 pb-2 border-b-2 border-blue-600 text-blue-600">Fluxo</a>
+        <a href="{{ route('agenda.index') }}" class="flex items-center gap-2 px-1 pb-2 border-b-2 border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            Agenda
+        </a>
+        <a href="{{ route('agenda.fluxo') }}" class="flex items-center gap-2 px-1 pb-2 border-b-2 border-primary text-primary">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.5 10.5a7.5 7.5 0 0113.5-3m1.5-3v3m0-3h-3M19.5 13.5A7.5 7.5 0 016 16.5m-1.5 3v-3m0 3h3" />
+            </svg>
+            Fluxo
+        </a>
     </nav>
 </div>
 <p class="text-gray-600">Em construção.</p>


### PR DESCRIPTION
## Summary
- style agenda navigation using TailAdmin tabs with icons
- apply same tab layout to Fluxo views

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: curl error 56 CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5783ec94832ab269ff0334e4f3f4