### PR TITLE
Add placeholder lucide icon component

### DIFF
--- a/resources/views/components/lucide-icon.blade.php
+++ b/resources/views/components/lucide-icon.blade.php
@@ -1,0 +1,5 @@
+@props(['name'])
+<svg {{ $attributes }} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Placeholder icon: {{ $name }} -->
+    <circle cx="12" cy="12" r="10" />
+</svg>

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -7,51 +7,51 @@
     <nav class="flex-1 overflow-y-auto py-4">
         @if($isSuperAdmin)
         <a href="{{ route('backend.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Backend' : ''">
-            <x-lucide-database class="w-6 h-6" />
+            <x-lucide-icon name="database" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Backend</span>
         </a>
         <a href="{{ route('usuarios-admin.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Usuários Admin' : ''">
-            <x-lucide-user-cog class="w-6 h-6" />
+            <x-lucide-icon name="user-cog" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Usuários Admin</span>
         </a>
         @else
         <a href="{{ route('admin.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Dashboard' : ''">
-            <x-lucide-home class="w-6 h-6" />
+            <x-lucide-icon name="home" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Dashboard</span>
         </a>
         <a href="{{ route('pacientes.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Pacientes' : ''">
-            <x-lucide-users class="w-6 h-6" />
+            <x-lucide-icon name="users" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Pacientes</span>
         </a>
         <a href="{{ route('agenda.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Agenda' : ''">
-            <x-lucide-calendar class="w-6 h-6" />
+            <x-lucide-icon name="calendar" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Agenda</span>
         </a>
         <a href="#" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Prontuários' : ''">
-            <x-lucide-file-text class="w-6 h-6" />
+            <x-lucide-icon name="file-text" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Prontuários</span>
         </a>
         <a href="{{ route('profissionais.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Profissionais' : ''">
-            <x-lucide-stethoscope class="w-6 h-6" />
+            <x-lucide-icon name="stethoscope" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Profissionais</span>
         </a>
         <a href="{{ route('escalas.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Escalas de Trabalho' : ''">
-            <x-lucide-clipboard-list class="w-6 h-6" />
+            <x-lucide-icon name="clipboard-list" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Escalas de Trabalho</span>
         </a>
         <a href="{{ route('estoque.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Estoque' : ''">
-            <x-lucide-package class="w-6 h-6" />
+            <x-lucide-icon name="package" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Estoque</span>
         </a>
         <a href="{{ route('financeiro.index') }}" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Financeiro' : ''">
-            <x-lucide-wallet class="w-6 h-6" />
+            <x-lucide-icon name="wallet" class="w-6 h-6" />
             <span class="ml-3" x-show="!sidebarCollapsed">Financeiro</span>
         </a>
         <div class="mt-2" x-data="{ open: false }">
             <button @click="open = !open" class="flex items-center w-full px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Administração' : ''">
-                <x-lucide-settings class="w-6 h-6" />
+                <x-lucide-icon name="settings" class="w-6 h-6" />
                 <span class="ml-3" x-show="!sidebarCollapsed">Administração</span>
-                <x-lucide-chevron-right x-show="!sidebarCollapsed" :class="{'rotate-90': open}" class="w-4 h-4 ml-auto transform transition-transform" />
+                <x-lucide-icon name="chevron-right" x-show="!sidebarCollapsed" :class="{'rotate-90': open}" class="w-4 h-4 ml-auto transform transition-transform" />
             </button>
             <div x-show="open && !sidebarCollapsed" x-collapse class="mt-1 space-y-1 pl-12" x-cloak>
                 <a href="{{ route('clinicas.index') }}" class="block py-1 hover:underline">Clínicas</a>
@@ -61,9 +61,9 @@
         </div>
         <div class="mt-2" x-data="{ openAccess: false }">
             <button @click="openAccess = !openAccess" class="flex items-center w-full px-4 py-2 text-gray-700 hover:bg-gray-100" :title="sidebarCollapsed ? 'Gestão de Acessos' : ''">
-            <x-lucide-shield-check class="w-6 h-6" />
+            <x-lucide-icon name="shield-check" class="w-6 h-6" />
                 <span class="ml-3" x-show="!sidebarCollapsed">Gestão de Acessos</span>
-                <x-lucide-chevron-right x-show="!sidebarCollapsed" :class="{'rotate-90': openAccess}" class="w-4 h-4 ml-auto transform transition-transform" />
+                <x-lucide-icon name="chevron-right" x-show="!sidebarCollapsed" :class="{'rotate-90': openAccess}" class="w-4 h-4 ml-auto transform transition-transform" />
             </button>
             <div x-show="openAccess && !sidebarCollapsed" x-collapse class="mt-1 space-y-1 pl-12" x-cloak>
                 <a href="{{ route('usuarios.index') }}" class="block py-1 hover:underline">Usuários</a>


### PR DESCRIPTION
## Summary
- replace lucide icon usage with a generic `lucide-icon` component
- add minimal Blade component to render placeholder SVG icons

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68ab57c69400832aa5741d50ee0a9db2