### PR TITLE
Guard profile and account links against missing routes

### DIFF
--- a/resources/views/partials/topbar.blade.php
+++ b/resources/views/partials/topbar.blade.php
@@ -75,8 +75,12 @@
                     <p class="text-xs text-gray-500">{{ $user->email }}</p>
                 @endif
             </div>
-            <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Editar Perfil</a>
-            <a href="{{ route('account.settings') }}" class="block px-4 py-2 hover:bg-gray-100">Configurações da Conta</a>
+            @if (\Illuminate\Support\Facades\Route::has('profile.edit'))
+                <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Editar Perfil</a>
+            @endif
+            @if (\Illuminate\Support\Facades\Route::has('account.settings'))
+                <a href="{{ route('account.settings') }}" class="block px-4 py-2 hover:bg-gray-100">Configurações da Conta</a>
+            @endif
             <form method="POST" action="{{ route('logout') }}">
                 @csrf
                 <button type="submit" class="w-full text-left px-4 py-2 hover:bg-gray-100">Sair</button>


### PR DESCRIPTION
## Summary
- Guard profile and account setting links behind route existence checks to prevent crashes when routes are undefined

## Testing
- ⚠️ `composer install` *(failed: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- ⚠️ `vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab58d0b6dc832aba1565031f5045c3